### PR TITLE
Classpath issue when building from Windows

### DIFF
--- a/project/build/Ensime.scala
+++ b/project/build/Ensime.scala
@@ -53,7 +53,7 @@ class EnsimeProject(info: ProjectInfo) extends DefaultProject(info){
 
     // Grab all jars..
     val cpLibs = ("dist" / "lib" ** "*.jar").get.map{ p => 
-      p.toString.replace("./dist/", "")
+			p.toString.replace("." + File.separator + "dist" + File.separator, "")
     }
 
     def writeScript(classpath:String, from:String, to:String){


### PR DESCRIPTION
I added a File.separator instead of "/" to correctly generate the server.sh and server.bat scripts on a Windows box. 
