### PR TITLE
Filtered Indexing

### DIFF
--- a/src/main/scala/org/ensime/util/SExp.scala
+++ b/src/main/scala/org/ensime/util/SExp.scala
@@ -89,7 +89,7 @@ object SExp extends RegexParsers {
 
   import scala.util.matching.Regex
 
-  lazy val string = regexGroups("""\"((?:[^\"\\]|\\.)*)\"""".r) ^^ { m => StringAtom(m.group(1)) }
+  lazy val string = regexGroups("""\"((?:[^\"\\]|\\.)*)\"""".r) ^^ { m => StringAtom(m.group(1).replace("\\\\", "\\")) }
   lazy val sym = regex("[a-zA-Z][a-zA-Z0-9-:]*".r) ^^ SymbolAtom
   lazy val keyword = regex(":[a-zA-Z][a-zA-Z0-9-:]*".r) ^^ KeywordAtom
   lazy val number = regex("[0-9]+".r) ^^ { cs => IntAtom(cs.toInt) }


### PR DESCRIPTION
Add a regex based configuration option to filter out classes for indexing.  With this patch, you can add 

:exclude-from-index ("com\\.sun\\..*" "com\\.apple\\..*")

to your .ensime file, and all classes below com.sun and com.apple in the package hierarchy will be skipped over when building the index.  This can dramatically decrease the amount of memory used by the index and prevent cluttering searches and suggestions with classes you know you don't want.
