### PR TITLE
Avoid unnecessary proliferation of process hierarchies using POSIX exec

### DIFF
--- a/etc/scripts/cmd-at
+++ b/etc/scripts/cmd-at
@@ -1,3 +1,3 @@
 #!/bin/bash
 cd $1
-$2 $3
+exec $2 $3

--- a/etc/scripts/server
+++ b/etc/scripts/server
@@ -19,5 +19,5 @@ fi
 CLASSPATH=<RUNTIME_CLASSPATH>
 CMD="java -classpath ${CLASSPATH} ${ENSIME_JVM_ARGS} org.ensime.server.Server ${PORT_FILE}"
 echo $CMD
-$CMD
+exec $CMD
 


### PR DESCRIPTION
This is not only good process etiquette, it's absolutely essential for those of us unfortunate enough to be using `java.lang.Process` to invoke the ENSIME server (since `Process#destroy()` does not destroy grandchildren).

Note, I haven't fixed this for Windows, only *nix.  I'd like it to work on Windows as well, but I'm not aware of an `exec` equivalent for batch files.
