### PR TITLE
SBT Interaction Improvements

### DIFF
--- a/src/main/scala/org/ensime/config/Sbt.scala
+++ b/src/main/scala/org/ensime/config/Sbt.scala
@@ -134,7 +134,7 @@ object Sbt extends ExternalConfigurator {
     import scala.util.parsing.input._
     import scala.util.parsing.combinator._
     object ListParser extends RegexParsers {
-      def listOpen = regex("List\\(".r)
+      def listOpen = regex("(List|ArraySeq)\\(".r)
       def listClose = regex("\\)".r)
       def attrOpen = regex("Attributed\\(".r)
       def attrClose = regex("\\)".r)


### PR DESCRIPTION
A couple changes I needed to make for a real-world project.  These are actually generically useful, affecting both Emacs and jEdit.  Specifically, I would advocate that the Emacs ENSIME mode add support for passing SBT_OPTS to the child ENSIME process (similar to what the jEdit plugin now provides).
