### PR TITLE
fixing sbt-11 guess

### DIFF
--- a/src/main/scala/org/ensime/config/Sbt.scala
+++ b/src/main/scala/org/ensime/config/Sbt.scala
@@ -339,7 +339,7 @@ object Sbt extends ExternalConfigurator {
       }
       case None => {
 	println("No project/build.properties found. Guessing sbt-11...")
-	(new Sbt10Style()).getConfig(baseDir, conf)
+	sbt11.getConfig(baseDir, conf)
       }
     }
   }


### PR DESCRIPTION
There is a little mistake. When we guess, that it is sbt11, we should use sbt 11:)
