### PR TITLE
206 make it work with Windows again, npes from presentation

### DIFF
--- a/etc/scripts/server.bat
+++ b/etc/scripts/server.bat
@@ -1,4 +1,10 @@
 set PORT_FILE=%1
 set CLASSPATH=<RUNTIME_CLASSPATH>
 if "%ENSIME_JVM_ARGS%"=="" (set ENSIME_JVM_ARGS=-XX:+DoEscapeAnalysis -Xms256M -Xmx1512M -XX:PermSize=128m -Xss1M -Dfile.encoding=UTF-8)
+REM Change SBT_JAR to point to the launcher jar used by your starting sbt.bat
+REM set SBT_JAR="C:\Dev\bin\sbt-launch-0.11.jar"
+REM change JLINE_TERM to force changes in the SBT loading
+set JLINE_TERM=-Djline.terminal=jline.UnixTerminal
+REM change the line below to modify extra options to SBTs launcher
+REM set SBT_OPTS=-Dfile.encoding=utf8
 java -classpath %CLASSPATH% %ENSIME_JVM_ARGS% org.ensime.server.Server %PORT_FILE%

--- a/src/main/scala/org/ensime/config/Sbt.scala
+++ b/src/main/scala/org/ensime/config/Sbt.scala
@@ -72,12 +72,15 @@ object Sbt extends ExternalConfigurator {
       import scala.collection.JavaConversions._
       val expectinator = new ExpectJ()
       val pathToSbtJar = (new File(".", "bin/" + jarName)).getCanonicalPath()
+      val possiblyOverridden = Option(System getenv "SBT_JAR") getOrElse pathToSbtJar
+      // provided by default in the server.bat
+      val jLineTerm = Option(System getenv "JLINE_TERM") getOrElse ""    
       expectinator.spawn(new Executor(){
 	  def execute():Process = {
 	    val reqArgs = Vector(
-//	      "-Djline.terminal=scala.UnixTerminal",
+	      jLineTerm,
 	      "-Dsbt.log.noformat=true",
-	      "-jar", pathToSbtJar)
+	      "-jar", possiblyOverridden)
 	    val args = (Vector("java") ++ jvmArgs ++ reqArgs ++ appArgs) filter { _.trim().length > 0 }
 	    println("Starting sbt with command line: " + args.mkString(" "))
 	    val pb = new ProcessBuilder(args)
@@ -195,18 +198,19 @@ object Sbt extends ExternalConfigurator {
 
     def jarName:String = "sbt-launch-0.10.1.jar"
 
-    override def appArgs:List[String] = List("console-project")
+    override def appArgs:List[String] = List()//"console-project")
 
     def getConfig(baseDir: File, conf: FormatHandler): Either[Throwable, ExternalConfig] = {
       try{
 
 	implicit val shell = spawn(baseDir)
+	shell.send(ln("console-project"))
 
 	shell.expect(prompt)
 
 	conf.sbtActiveSubproject match {
 	  case Some(sub) => {
-	    evalUnit("val x = Extracted(structure, session, ProjectRef(new File(\"" + baseDir + "\"),\"" + sub.name + "\"))")
+	    evalUnit("val x = Extracted(structure, session, ProjectRef(new File(\"" + (baseDir.getCanonicalPath.replaceAll("\\\\","/")) + "\"),\"" + sub.name + "\"))")
 	  }
 	  case None =>
 	    evalUnit("val x = Project.extract(currentState)")
@@ -245,13 +249,14 @@ object Sbt extends ExternalConfigurator {
 	  taskResultAsList("exportedProducts in Runtime")
 	)
 
-	val sourceRoots =  (
+	val sourceRoots = (
 	  settingAsList("sourceDirectories in Compile") ++
 	  settingAsList("sourceDirectories in Test")
 	)
 	val target = CanonFile(getSetting("classDirectory").getOrElse("./classes"))
 
-	shell.send(":quit\n")
+	shell.send(":quit\n") // from console
+	shell.send("exit\n") // from sbt
 	shell.expectClose()
 	shell.stop()
 


### PR DESCRIPTION
Added optional SBT_JAR for override, had also hoped it would stop internalDependencyClasspath from forcing recompiles, but alas not.

Windows needs the terminal setting, but running with it set kills sbt when run with console-project.  As such its run from the prompt.

Paths need regex, but I think its got a bad smell, I'll look further at fixing that up.

The npes are on the jaxen-tests subproject of scales.  It could be related to there not being a target directory, its a test only project.
