### PR TITLE
More robust matching of file names

### DIFF
--- a/src/main/elisp/ensime-sbt.el
+++ b/src/main/elisp/ensime-sbt.el
@@ -100,8 +100,8 @@
 
 
      (set (make-local-variable 'compilation-error-regexp-alist)
-	  '(("^\\[error\\] \\([_.a-zA-Z0-9/-]+[.]scala\\):\\([0-9]+\\):"
-	     1 2 nil 2 nil)))
+	  '(("^\\[error\\] \\(.+\\):\\([0-9]+\\): "
+	     1 2 nil 2 1)))
      (set (make-local-variable 'compilation-mode-font-lock-keywords)
 	  '(("^\\[error\\] Error running compile:"
 	     (0 compilation-error-face))


### PR DESCRIPTION
Adjusted error message matching regexp to allow matching a broader range of
file names.

In particular this fixes error message parsing in ensime-sbt console on Windows.
