### PR TITLE
New feature : tab completion in ensime-sbt

### DIFF
--- a/src/main/elisp/ensime-comint-utils.el
+++ b/src/main/elisp/ensime-comint-utils.el
@@ -93,9 +93,9 @@ the output received after a call to `ensime-comint-complete'.")
   (if (member (buffer-name) ensime-comint-completion-buffers)
       (let* ((proc (get-buffer-process (current-buffer)))
              (input (buffer-substring (comint-line-beginning-position) (point))))
-        (process-put proc 'ensime-comint-completion t) ;; activate ensime-comint-cplt-output-filter
         (if (string-to-list input)
             (progn
+              (process-put proc 'ensime-comint-completion t) ;; activate ensime-comint-cplt-output-filter
               (comint-proc-query proc (concat input (kbd "TAB")))
               (comint-proc-query proc (kbd "C-a"))
               (comint-proc-query proc (kbd "C-k"))

--- a/src/main/elisp/ensime-sbt.el
+++ b/src/main/elisp/ensime-sbt.el
@@ -93,7 +93,7 @@
 	       '(lambda ()
 		  (remove-hook
 		   'ensime-source-buffer-saved-hook
-		   'ensime-sbt-maybe-auto-compile) nil t))
+		   'ensime-sbt-maybe-auto-compile)) nil t)
 
      (comint-mode)
 
@@ -115,7 +115,7 @@
      (set (make-local-variable 'comint-process-echoes) nil)
      (set (make-local-variable 'compilation-auto-jump-to-first-error) t)
      (set (make-local-variable 'comint-scroll-to-bottom-on-output) t)
-     (set (make-local-variable 'comint-prompt-regexp) "^\\(>\\|scala>\\) ")
+     (set (make-local-variable 'comint-prompt-regexp) "^> ")
      (set (make-local-variable 'comint-use-prompt-regexp) t)
      (set (make-local-variable 'comint-prompt-read-only) t)
      (set (make-local-variable 'comint-preoutput-filter-functions)


### PR DESCRIPTION
Hi,

Here is a modest contribution to ensime that brings tab completion in _ensime-sbt_ buffer.

The code is intended to be a bit generic, i.e it should also work in _ensime-inferior-scala_ but I switched it on in _ensime-sbt_ only because... well, because it actually doesn't work with the REPL and I don't really know why. Two remarks about that :
- output from the repl is cluttered with ANSI escape sequences
- entering ":keybindings" in _ensime-inferior-scala_ yields the answer "Key bindings unavailable."

I guess those issued need to be fixed in order to get tab completion to work with the repl, so if you have any hint about those, I'm all eyes !

Anyway, as suggested, the code is operational with sbt, so I hope you'll enjoy it.

Cheers,

G.N
