### PR TITLE
quotes VM options

### DIFF
--- a/src/main/scala/org/ensime/server/DebugManager.scala
+++ b/src/main/scala/org/ensime/server/DebugManager.scala
@@ -558,7 +558,7 @@ class DebugManager(project: Project, protocol: ProtocolConversions,
           val arguments = connector.defaultArguments()
 
           val opts = arguments.get("options").value
-          val allVMOpts = (List(opts) ++ vmOptions).mkString(" ")
+          val allVMOpts = (List(opts) ++ vmOptions).map(opt => "\"" + opt + "\"").mkString(" ")
           arguments.get("options").setValue(allVMOpts)
           arguments.get("main").setValue(commandLine)
           arguments.get("suspend").setValue("false")


### PR DESCRIPTION
To correctly work with classpaths that contain whitespaces.

Otherwise for those lucky ones, who have their Sublime installations
in a directory named "Sublime Text 2", defaultConnector().launch() will hang
together with its enclosing debug manager actor upon debug-start.
