### PR TITLE
Fix a “text is read-only” error when calling comint-previous-input in SBT buffer

### DIFF
--- a/src/main/elisp/ensime-sbt.el
+++ b/src/main/elisp/ensime-sbt.el
@@ -116,7 +116,9 @@
      (set (make-local-variable 'compilation-auto-jump-to-first-error) t)
      (set (make-local-variable 'comint-scroll-to-bottom-on-output) t)
      ;; `scala>' is for the repl launched from stb
-     (set (make-local-variable 'comint-prompt-regexp) "^\\(>\\|scala>\\) ")
+     (set (make-local-variable 'comint-prompt-regexp)
+          (let ((project-name (plist-get (ensime-config) :project-name)))
+            (concat "^\\(>\\|scala>\\|\\[" project-name "\\] \\$\\) ")))
      (set (make-local-variable 'comint-use-prompt-regexp) t)
      (set (make-local-variable 'comint-prompt-read-only) t)
      (set (make-local-variable 'comint-output-filter-functions)


### PR DESCRIPTION
This fixes an bug where the first time `comint-previous-input` is called at a SBT prompt, a “text is read-only” error message is displayed, the point moves to the beginning of the line, and the previous input is not entered. Caused by `comint-prompt-regexp` not matching the SBT project prompt.
