### PR TITLE
Ensime should not override auto-complete settings.

### DIFF
--- a/src/main/elisp/ensime-auto-complete.el
+++ b/src/main/elisp/ensime-auto-complete.el
@@ -26,6 +26,11 @@
   :type 'boolean
   :group 'ensime-ui)
 
+(defcustom ensime-ac-override-settings t
+    "If non-nil, override auto-complete settings."
+    :type 'boolean
+    :group 'ensime-ui)
+
 (defcustom ensime-ac-case-sensitive nil
   "If non-nil, omit completions that don't match the case of prefix."
   :type 'boolean
@@ -285,44 +290,45 @@ be used later to give contextual help when entering arguments."
 
 
 (defun ensime-ac-enable ()
-  (make-local-variable 'ac-sources)
-  (setq ac-sources '(ac-source-ensime-completions))
+  (when ensime-ac-override-settings
+    (make-local-variable 'ac-sources)
+	(setq ac-sources '(ac-source-ensime-completions))
 
-  (make-local-variable 'ac-use-comphist)
-  (setq ac-use-comphist nil)
+	(make-local-variable 'ac-use-comphist)
+	(setq ac-use-comphist nil)
 
-  (make-local-variable 'ac-auto-show-menu)
-  (setq ac-auto-show-menu 0.5)
+	(make-local-variable 'ac-auto-show-menu)
+	(setq ac-auto-show-menu 0.5)
 
-  (make-local-variable 'ac-candidates-cache)
-  (setq ac-candidates-cache nil)
+	(make-local-variable 'ac-candidates-cache)
+	(setq ac-candidates-cache nil)
 
-  (make-local-variable 'ac-auto-start)
-  (setq ac-auto-start nil)
+	(make-local-variable 'ac-auto-start)
+	(setq ac-auto-start nil)
 
-  (make-local-variable 'ac-expand-on-auto-complete)
-  (setq ac-expand-on-auto-complete t)
+	(make-local-variable 'ac-expand-on-auto-complete)
+	(setq ac-expand-on-auto-complete t)
 
-  (make-local-variable 'ac-use-fuzzy)
-  (setq ac-use-fuzzy nil)
+	(make-local-variable 'ac-use-fuzzy)
+	(setq ac-use-fuzzy nil)
 
-  (make-local-variable 'ac-dwim)
-  (setq ac-dwim nil)
+	(make-local-variable 'ac-dwim)
+	(setq ac-dwim nil)
 
-  (make-local-variable 'ac-use-quick-help)
-  (setq ac-use-quick-help t)
+	(make-local-variable 'ac-use-quick-help)
+	(setq ac-use-quick-help t)
 
-  (make-local-variable 'ac-delete-dups)
-  (setq ac-delete-dups nil)
+	(make-local-variable 'ac-delete-dups)
+	(setq ac-delete-dups nil)
 
-  (make-local-variable 'ac-ignore-case)
-  (setq ac-ignore-case t)
+	(make-local-variable 'ac-ignore-case)
+	(setq ac-ignore-case t)
 
-  (make-local-variable 'ac-trigger-key)
-  (ac-set-trigger-key "TAB")
+	(make-local-variable 'ac-trigger-key)
+	(ac-set-trigger-key "TAB")
 
-  (auto-complete-mode 1)
-  )
+	(auto-complete-mode 1)
+  ))
 
 (defun ensime-ac-disable ()
   (auto-complete-mode 0)


### PR DESCRIPTION
Make auto-complete re-configuration optional (on by default).
