### PR TITLE
auto detect java-home on  OS X

### DIFF
--- a/etc/scripts/server
+++ b/etc/scripts/server
@@ -1,6 +1,12 @@
 #!/bin/bash
 set -f
 
+if [ `uname -s` = 'Darwin' ]; then
+    if [ -z $JAVA_HOME ]; then
+	JAVA_HOME=`/usr/libexec/java_home`
+    fi
+fi
+
 case "$1" in
   -h|--help|"")
     echo "$0 should be run by emacs plugin. M-x ensime should start the server for you"


### PR DESCRIPTION
Hi,

This change allowed me to use the ensime debugger on OS X. I have a forthcoming change that does something similar on Linux.

Please, let me know if you see any issues with doing this.

Thanks,
Anatoly
