### PR TITLE
ensime-sym-at-point: Fetch info from the Server. Fixes #232

### DIFF
--- a/src/main/elisp/ensime.el
+++ b/src/main/elisp/ensime.el
@@ -2753,18 +2753,14 @@ any buffer visiting the given file."
  symbol, return nil."
   (save-excursion
     (goto-char (or point (point)))
-    (let ((start nil)
-	  (end nil))
-      (when (thing-at-point 'symbol)
-	(save-excursion
-	  (search-backward-regexp "\\W" nil t)
-	  (setq start (+ (point) 1)))
-	(save-excursion
-	  (search-forward-regexp "\\W" nil t)
-	  (setq end (- (point) 1)))
-	(list :start start
-	      :end end
-	      :name (buffer-substring-no-properties start end))))))
+    (let* ((info (ensime-rpc-symbol-at-point))
+           (start (ensime-pos-offset (ensime-symbol-decl-pos info)))
+           (name (ensime-symbol-name info)))
+      (when (and info start name)
+        (setq start (+ start ensime-ch-fix))
+        (list :start start
+              :end (+ start (string-width name))
+              :name name)))))
 
 
 (defun ensime-insert-import (qualified-name)


### PR DESCRIPTION
Do not rely on regex when parsing for a (possible) symbol at point,
but fetch this information from the server instead.
This should fix Issue #232 and rename every valid scala symbol correctly.
