### PR TITLE
Terminate port file with new line

### DIFF
--- a/src/main/scala/org/ensime/server/Server.scala
+++ b/src/main/scala/org/ensime/server/Server.scala
@@ -91,23 +91,26 @@ object Server {
   }
 
   private def writePort(filename: String, port: Int) {
-    val out = new PrintWriter(filename)
     try {
+      val out = new PrintWriter(filename)
       out.println(port)
       out.flush()
-      System.out.println("Wrote port " + port + " to " + filename + ".")
+      out.close()
+      if (!out.checkError()) {
+        System.out.println("Wrote port " + port + " to " + filename + ".")
+      } else {
+        throw new IOException
+      }
     } catch {
-      case e: IOException => {
-        System.err.println("Could not write port to " + filename + ". " + e)
+      case e:IOException => {
+        System.err.println("Could not write port to " + filename + ".")
         System.exit(-1)
       }
     } finally {
-      out.close()
       Runtime.getRuntime.addShutdownHook(
         new Thread { override def run { new java.io.File(filename).delete } })
     }
   }
-
 }
 
 class SocketHandler(socket: Socket, protocol: Protocol, project: Project) extends Actor {


### PR DESCRIPTION
Most programs assume text files (not binary files) are new line terminated.
While going through the installation process of https://github.com/megaannum/vimside
which uses Ensime, I stumbled on this problem with Vimscript's
`readfile` function.
