### PR TITLE
fixed numbering of steps in the getting started section of readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ Note: Currently, it may be necessary to first delete your project/target directo
 You should now have a .ensime file in the root of your project. There's no need to edit this file manually as you can now specify ENSIME settings directly from your sbt build file. Check the [manual](http://aemoncannon.github.com/ensime/index.html#tth_sEc3.1.1) for details.
 
 
-__5) Start ENSIME__
+__4) Start ENSIME__
 
 From inside Emacs, execute M-x ensime
 


### PR DESCRIPTION
There are only 4 steps in the getting started section, currently however step 4 is numbered step 5
