### PR TITLE
Don't deactivate-mark when setting selection.

### DIFF
--- a/src/main/elisp/ensime.el
+++ b/src/main/elisp/ensime.el
@@ -2907,6 +2907,7 @@ any buffer visiting the given file."
   (goto-char start)
   (command-execute 'set-mark-command)
   (goto-char end)
+  (setq deactivate-mark nil)
   (ensime-set-selection-overlay start end))
 
 (defun ensime-expand-selection (start end)


### PR DESCRIPTION
... allows for delete-selection-mode for selections via `ensime-expand-selection-command`

Not sure where it's set to t, however.
