### PR TITLE
Symlinks and index

### DIFF
--- a/src/main/elisp/ensime.el
+++ b/src/main/elisp/ensime.el
@@ -2544,7 +2544,8 @@ any buffer visiting the given file."
 
 (defun ensime-files-equal-p (f1 f2)
   "Return t if file-names refer to same file."
-  (equal (expand-file-name f1) (expand-file-name f2)))
+  (equal (file-truename (expand-file-name f1))
+         (file-truename (expand-file-name f2))))
 
 
 (defun ensime-window-showing-file (file)


### PR DESCRIPTION
Hi,

So, here's the situation: I'm working out of some obscure long path directory, which is symlinked into other more convenient for me location. I never use real path myself, yet ensime seems to expand symlinks when it builds the index. Then file name comparisons fail, and compilation error navigation no longer works.

This change did fix M-n/M-p for me, and didn't break anything else so far, which is nice. Yet the other problem is that when I start navigating across the files, those coming from index open under real long path. So I get a mix of buffers with two different path prefixes, buffer list becomes a real mess, mark by file name mask fails etc.

I feel like server probably shouldn't be normalizing paths in the first place. What is your opinion on that? Was it deliberate?
