### PR TITLE
Do not display "ENSIME" in modeline when connected

### DIFF
--- a/src/main/elisp/ensime.el
+++ b/src/main/elisp/ensime.el
@@ -560,10 +560,9 @@ Do not show 'Writing..' message."
 		  (t " [ENSIME: No Connection]")))
 
 		((and ensime-mode (ensime-connected-p conn))
-		 (concat " "
-			 "[ENSIME: "
+		 (concat " ["
 			 (or (plist-get (ensime-config conn) :project-name)
-			     "Connected...")
+			     "ENSIME: Connected...")
 			 (let ((status (ensime-modeline-state-string conn))
 			       (unready (not (ensime-analyzer-ready conn))))
 			   (cond (status (concat " (" status ")"))


### PR DESCRIPTION
This commit changes `ensime-modeline-string` so that it will not display "ENSIME" in the Emacs mode line when we are connected to an ENSIME server. Currently, `ensime-modeline-string` always displays "ENSIME" in the mode line, although its documentation string says that "ENSIME" only appears if we are not connected. This often causes the more meaningful state information to be pushed off the screen.
