### PR TITLE
Added ability to specify the host IP address and port for server.

### DIFF
--- a/etc/scripts/server
+++ b/etc/scripts/server
@@ -3,6 +3,8 @@
 OS_NAME=`uname -s`
 JDK=
 PORT_FILE=
+SERVER_HOST=
+SERVER_PORT=
 
 usage()
 {
@@ -86,6 +88,9 @@ case $1 in
         PORT_FILE=$1 ;;
 esac
 
+SERVER_HOST=$2
+SERVER_PORT=$3
+
 determine_jdk
 
 if [ -z "$ENSIME_JVM_ARGS" ]; then
@@ -97,7 +102,7 @@ BOOTCLASSPATH=<RUNTIME_BOOTCLASSPATH>
 CLASSPATH=<RUNTIME_CLASSPATH>
 
 CMD="${JDK}/bin/java -Xbootclasspath/a:${BOOTCLASSPATH} -classpath ${CLASSPATH} \
-    ${ENSIME_JVM_ARGS} org.ensime.server.Server ${PORT_FILE}"
+    ${ENSIME_JVM_ARGS} org.ensime.server.Server ${PORT_FILE} ${SERVER_HOST} ${SERVER_PORT}"
 
 echo ""
 echo "${CMD}" | /usr/bin/fmt

--- a/etc/scripts/server.bat
+++ b/etc/scripts/server.bat
@@ -1,5 +1,7 @@
 set PORT_FILE=%1
+set SERVER_HOST=%2
+set SERVER_PORT=%3
 set BOOTCLASSPATH=<RUNTIME_BOOTCLASSPATH>
 set CLASSPATH=<RUNTIME_CLASSPATH>
 if not defined ENSIME_JVM_ARGS (set ENSIME_JVM_ARGS=-Xms256M -Xmx1512M -XX:PermSize=128m -Xss1M -Dfile.encoding=UTF-8)
-java -Xbootclasspath/a:%BOOTCLASSPATH% -classpath %CLASSPATH% %ENSIME_JVM_ARGS% org.ensime.server.Server %PORT_FILE%
+java -Xbootclasspath/a:%BOOTCLASSPATH% -classpath %CLASSPATH% %ENSIME_JVM_ARGS% org.ensime.server.Server %PORT_FILE% %SERVER_HOST% %SERVER_PORT%

--- a/src/main/elisp/ensime.el
+++ b/src/main/elisp/ensime.el
@@ -113,7 +113,7 @@
   :type 'string
   :group 'ensime-server)
 
-(defcustom ensime-default-port 9999
+(defcustom ensime-default-port 0
   "Port to use as the default for `ensime-connect'."
   :type 'integer
   :group 'ensime-server)
@@ -607,7 +607,9 @@ Do not show 'Writing..' message."
 	     (dir (or (plist-get config :server-root)
 		      ensime-default-server-root))
 	     (buffer ensime-server-buffer-name)
-	     (args (list (ensime-swank-port-file))))
+	     (server-host (or (plist-get config :server-host) ensime-default-server-host))
+	     (server-port (number-to-string (or (plist-get config :server-port) ensime-default-port)))
+	     (args (list (ensime-swank-port-file) server-host server-port)))
 
 	(ensime-delete-swank-port-file 'quiet)
 	(let ((server-proc (ensime-maybe-start-server cmd args env dir buffer)))

--- a/src/main/scala/org/ensime/server/Server.scala
+++ b/src/main/scala/org/ensime/server/Server.scala
@@ -28,7 +28,7 @@
 package org.ensime.server
 
 import java.io._
-import java.net.{ ServerSocket, Socket }
+import java.net.{ ServerSocket, Socket, InetAddress }
 import org.ensime.protocol._
 import org.ensime.util.WireFormat
 import org.ensime.config.Environment
@@ -42,9 +42,9 @@ object Server {
     System.setProperty("actors.maxPoolSize", "100")
 
     args match {
-      case Array(portfile) =>
+      case Array(portfile, serverHost, serverPort) =>
         {
-          println("Starting up Ensime...")
+          println("Starting up Ensime using host address " + serverHost + " and port " + serverPort + " ...")
           println(Environment.info)
 
           // TODO add an option to change the protocol
@@ -54,8 +54,14 @@ object Server {
 
           try {
             // 0 will cause socket to bind to first available port
-            val requestedPort = 0
-            val listener = new ServerSocket(requestedPort)
+            val requestedPort = serverPort.toInt
+            // the "requested maximum number of pending connections on the socket"
+            // with 0 being an implementation-specific default
+            val backlog = 0 
+            // The address to bind the server to. A value of null, "", or 127.0.0.1 represents
+            // the local loopback interface, thus only allowing local connections
+            val bindAddr = InetAddress.getByName(serverHost)
+            val listener = new ServerSocket(requestedPort, backlog, bindAddr)
             val actualPort = listener.getLocalPort
             println("Server listening on " + actualPort + "..")
             writePort(portfile, actualPort)
@@ -83,7 +89,7 @@ object Server {
           }
         }
       case _ => {
-        println("Usage: PROGRAM <portfile>")
+        println("Usage: PROGRAM <portfile> <server-host> <server-port>")
         System.exit(0)
 
       }


### PR DESCRIPTION
By default, server now binds to the loopback address, only allowing local connections to the server. Settings can be customized via the ensime-server config group in emacs.
