### PR TITLE
Remove .sbt root project identification.

### DIFF
--- a/src/main/elisp/ensime-sbt.el
+++ b/src/main/elisp/ensime-sbt.el
@@ -226,7 +226,7 @@
 
 (defun ensime-sbt-project-dir-p (path)
   "Is path an sbt project?"
-  (or (not (null (directory-files path nil "\\.sbt$")))
+  (or 
       (file-exists-p (concat path "/project/Build.scala" ))
       (file-exists-p (concat path "/project/boot" ))
       (file-exists-p (concat path "/project/build.properties" ))))


### PR DESCRIPTION
In multi-project builds, .sbt files will live at the root of each
subproject, but sbt has to be run from the root to have access to root
project plugins and settings. Eliminating the not null check for .sbt
allows the sbt run to reach the root of the project without bailing out
too early, which would cause ensime-sbt to fail to load from the root of
a project.
