### PR TITLE
Fix reference sources in jars and zips

### DIFF
--- a/src/main/elisp/ensime.el
+++ b/src/main/elisp/ensime.el
@@ -2282,6 +2282,7 @@ any buffer visiting the given file."
 
     (when (ensime-file-in-directory-p effective-file (ensime-source-jars-dir))
       (with-current-buffer (get-file-buffer effective-file)
+	(auto-revert-mode t)
         (setq buffer-read-only t)))))
 
 ;; Compilation result interface

--- a/src/main/scala/org/ensime/config/ProjectConfig.scala
+++ b/src/main/scala/org/ensime/config/ProjectConfig.scala
@@ -877,7 +877,7 @@ class ProjectConfig(
   }
 
   def referenceSources: Set[CanonFile] = {
-    expandRecursively(root, referenceSourceRoots, isValidSourceOrJarFile _).toSet
+    expandRecursively(root, referenceSourceRoots, isValidSourceOrArchive _).toSet
   }
 
   def sourceFilenames: Set[String] = {

--- a/src/main/scala/org/ensime/indexer/ClassFileIndex.scala
+++ b/src/main/scala/org/ensime/indexer/ClassFileIndex.scala
@@ -169,12 +169,7 @@ class ClassFileIndex(config: ProjectConfig) {
     enclosingPackage: String,
     classNamePrefix: String): Set[AbstractFile] = {
     println("Looking for " + (enclosingPackage, classNamePrefix))
-    val subPath = enclosingPackage.replace(".", "/") + "/" + classNamePrefix
-    // TODO(aemoncannon): Build lookup structure to make this more efficient.
-    if (System.getProperty("ensime.log.symbol.lookup") != null) {
-      println("subPath is " + subPath)
-      println("sourceNamesForClassFile is " + sourceNamesForClassFile)
-    }
+    val subPath = enclosingPackage.replace(".", "/") + "/" + classNamePrefix.replaceAll("[$]$", "")
     val sourceNames: Set[String] = sourceNamesForClassFile.collect {
       case (loc, sourceNames) if (
         loc.file.contains(subPath) ||

--- a/src/main/scala/org/ensime/util/FileUtil.scala
+++ b/src/main/scala/org/ensime/util/FileUtil.scala
@@ -145,7 +145,7 @@ object FileUtils {
 
   def expandSourceJars(fileList: Iterable[CanonFile]): Iterable[AbstractFile] = {
     fileList.flatMap { f =>
-      if (isValidJar(f)) {
+      if (isValidArchive(f)) {
         ZipArchive.fromFile(f).deepIterator.filter(f => isValidSourceName(f.name))
       } else {
         Seq(AbstractFile.getFile(f))
@@ -172,6 +172,7 @@ object FileUtils {
   }
 
   def isValidJar(f: File): Boolean = f.exists && f.getName.endsWith(".jar")
+  def isValidArchive(f: File): Boolean = f.exists && (f.getName.endsWith(".jar") || f.getName.endsWith(".zip"))
   def isValidClassDir(f: File): Boolean = f.exists && f.isDirectory
   def isValidSourceName(filename: String) = {
     filename.endsWith(".scala") || filename.endsWith(".java")
@@ -179,8 +180,8 @@ object FileUtils {
   def isValidSourceFile(f: File): Boolean = {
     f.exists && !f.isHidden && isValidSourceName(f.getName)
   }
-  def isValidSourceOrJarFile(f: File): Boolean = {
-    isValidSourceFile(f) || isValidJar(f)
+  def isValidSourceOrArchive(f: File): Boolean = {
+    isValidSourceFile(f) || isValidArchive(f)
   }
   def isJavaSourceFile(f: File): Boolean = {
     f.exists && (f.getName.endsWith(".java"))


### PR DESCRIPTION
make the class/source lookup support companion objects (which is how imports come through), and allow `zip` files.
