### PR TITLE
Add scalriform preference: placeScaladocAsterisksBeneathSecondAsterisk

### DIFF
--- a/src/main/scala/org/ensime/config/ProjectConfig.scala
+++ b/src/main/scala/org/ensime/config/ProjectConfig.scala
@@ -839,6 +839,8 @@ class ProjectConfig(
           fp.setPreference(IndentWithTabs, value)
         case ('multilineScaladocCommentsStartOnFirstLine, value: Boolean) =>
           fp.setPreference(MultilineScaladocCommentsStartOnFirstLine, value)
+        case ('placeScaladocAsterisksBeneathSecondAsterisk, value: Boolean) =>
+          fp.setPreference(PlaceScaladocAsterisksBeneathSecondAsterisk, value)
         case ('preserveDanglingCloseParenthesis, value: Boolean) =>
           fp.setPreference(PreserveDanglingCloseParenthesis, value)
         case ('preserveSpaceBeforeArguments, value: Boolean) =>


### PR DESCRIPTION
Noticed this one was missing. Allows you to prefer the following style:

``` scala
/** This is a first line of documentation
  * This is the second line, with asterisk aligned to second asterisk of first line
  */
```

In `~/.sbt/0.13/global.sbt`:

``` scala
ensimeConfig := sexp(                                                                                                                                                                   
  key(":compiler-args"), sexp("-Ywarn-dead-code", "-Ywarn-shadowing"),                                                                                                                  
  key(":formatting-prefs"),                                                                                                                                                             
  sexp(                                                                                                                                       
    key(":multilineScaladocCommentsStartOnFirstLine"), true,                                                                                                                            
    key(":placeScaladocAsterisksBeneathSecondAsterisk"), true)                                                                                                                          
)
```
