### PR TITLE
Update version of ensime-sbt-cmd plugin

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,4 +1,4 @@
-addSbtPlugin("org.ensime" % "ensime-sbt-cmd" % "0.1.2")
+addSbtPlugin("org.ensime" % "ensime-sbt-cmd" % "0.1.4")
 
 addSbtPlugin("com.timushev.sbt" % "sbt-updates" % "0.1.6")
 


### PR DESCRIPTION
This can't be backported to scala 2.9, unless we make the 0.1.4 version of the plugin work with that version.
