### PR TITLE
Akka Actors, protocol cleanup and logging - 2.9 port

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -19,6 +19,10 @@ libraryDependencies <<= scalaVersion { scalaVersion => Seq(
   "org.scalatest"              %% "scalatest"            % "1.9.2" % "test",
   "org.scalariform"            %% "scalariform"          % "0.1.4",
   "org.scala-lang"             %  "scala-compiler"       % scalaVersion,
+  "com.typesafe.akka" %% "akka-actor" % "2.0.5",
+  "com.typesafe.akka" %% "akka-slf4j" % "2.0.5",
+  "com.typesafe.akka" %% "akka-testkit" % "2.0.5" % "test",
+  "ch.qos.logback" % "logback-classic" % "1.0.13",
   "org.scala-refactoring"      %% "org.scala-refactoring.library" % "0.6.2"
 )}
 

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -5,3 +5,5 @@ addSbtPlugin("com.timushev.sbt" % "sbt-updates" % "0.1.6")
 addSbtPlugin("net.virtual-void" % "sbt-dependency-graph" % "0.7.4")
 
 addSbtPlugin("com.typesafe.sbt" % "sbt-scalariform" % "1.3.0")
+
+addSbtPlugin("com.github.mpeltonen" % "sbt-idea" % "1.6.0")

--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -1,0 +1,4 @@
+akka {
+  loggers = ["akka.event.slf4j.Slf4jLogger"]
+  loglevel = "INFO"
+}

--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -1,0 +1,14 @@
+<configuration>
+
+  <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+    <!-- encoders are assigned the type
+         ch.qos.logback.classic.encoder.PatternLayoutEncoder by default -->
+    <encoder>
+      <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+    </encoder>
+  </appender>
+
+  <root level="debug">
+    <appender-ref ref="STDOUT" />
+  </root>
+</configuration>

--- a/src/main/scala/org/ensime/config/ProjectConfig.scala
+++ b/src/main/scala/org/ensime/config/ProjectConfig.scala
@@ -733,7 +733,7 @@ object ProjectConfig {
   }
 }
 
-class ReplConfig(val classpath: String) {}
+class ReplConfig(val classpath: String)
 
 case class ProjectConfig(
     name: Option[String] = None,

--- a/src/main/scala/org/ensime/indexer/ClassFileIndex.scala
+++ b/src/main/scala/org/ensime/indexer/ClassFileIndex.scala
@@ -16,6 +16,7 @@ import scala.tools.nsc.io.AbstractFile
 case class Op(
   op: String,
   description: String)
+
 case class MethodBytecode(
   className: String,
   methodName: String,

--- a/src/main/scala/org/ensime/indexer/IndexWorkQueue.scala
+++ b/src/main/scala/org/ensime/indexer/IndexWorkQueue.scala
@@ -1,0 +1,37 @@
+package org.ensime.indexer
+
+import akka.actor.Actor
+import org.apache.lucene.index.IndexWriter
+import org.ensime.model.{ MethodSearchResult, TypeSearchResult }
+import org.objectweb.asm.Opcodes
+
+class IndexWorkQueue(writer: IndexWriter) extends Actor {
+  import LuceneIndex._
+  override def receive = {
+    case ClassEvent(name: String, location: String, flags: Int) =>
+      val i = name.lastIndexOf(".")
+      val localName = if (i > -1) name.substring(i + 1) else name
+      val value = TypeSearchResult(name,
+        localName,
+        declaredAs(name, flags),
+        Some((location, -1)))
+      val doc = buildDoc(value)
+      writer.addDocument(doc)
+    case MethodEvent(className: String, name: String,
+      location: String, flags: Int) =>
+      val isStatic = (flags & Opcodes.ACC_STATIC) != 0
+      val revisedClassName = if (isStatic) className + "$"
+      else className
+      val lookupKey = revisedClassName + "." + name
+      val value = MethodSearchResult(lookupKey,
+        name,
+        'method,
+        Some((location, -1)),
+        revisedClassName)
+      val doc = buildDoc(value)
+      writer.addDocument(doc)
+    case StopEvent =>
+      sender ! StopEvent
+      context.stop(self)
+  }
+}

--- a/src/main/scala/org/ensime/indexer/LuceneIndexer.scala
+++ b/src/main/scala/org/ensime/indexer/LuceneIndexer.scala
@@ -1,6 +1,8 @@
 package org.ensime.indexer
 
 import java.io.IOException
+import akka.actor.{ Props, ActorRef, ActorSystem }
+import akka.util.Timeout
 import org.apache.lucene.analysis.SimpleAnalyzer
 import org.apache.lucene.document.Document
 import org.apache.lucene.document.Field
@@ -23,16 +25,19 @@ import org.apache.lucene.store.FSDirectory
 import org.apache.lucene.util.Version
 import java.io.File
 import org.ensime.util._
-import scala.actors._
 import org.ensime.model.{ SymbolSearchResult, TypeSearchResult, MethodSearchResult }
+import org.slf4j.LoggerFactory
 import scala.collection.{ mutable, JavaConversions }
+import scala.concurrent.Await
 import scala.util.matching.Regex
 import scala.collection.mutable.ListBuffer
 import org.objectweb.asm.Opcodes
 import org.json.simple._
 import scala.util.Properties._
+import akka.pattern.ask
 
 object LuceneIndex extends StringSimilarity {
+  val log = LoggerFactory.getLogger("LuceneIndex")
   val KeyIndexVersion = "indexVersion"
   val KeyFileHashes = "fileHashes"
   val IndexVersion: Int = 5
@@ -100,11 +105,9 @@ object LuceneIndex extends StringSimilarity {
         (onDiskIndexVersion, indexedFiles)
       } else (0, Map())
     } catch {
-      case e: IOException =>
-        e.printStackTrace(); (0, Map())
-      case e: CorruptIndexException =>
-        e.printStackTrace(); (0, Map())
-      case e: Exception => e.printStackTrace(); (0, Map())
+      case e: Exception =>
+        log.error("Exception Seen in loadIndexUserData",e)
+        (0, Map())
     }
   }
 
@@ -145,45 +148,29 @@ object LuceneIndex extends StringSimilarity {
     tokens.toString()
   }
 
-  private def buildDoc(value: SymbolSearchResult): Document = {
+  def buildDoc(value: SymbolSearchResult): Document = {
     val doc = new Document()
 
-    doc.add(new Field("tags",
-      tokenize(value.name), Field.Store.NO, Field.Index.ANALYZED))
-    doc.add(new Field("localNameTags",
-      tokenize(value.localName), Field.Store.NO, Field.Index.ANALYZED))
+    doc.add(new Field("tags", tokenize(value.name), Field.Store.NO, Field.Index.ANALYZED))
+    doc.add(new Field("localNameTags", tokenize(value.localName), Field.Store.NO, Field.Index.ANALYZED))
 
-    doc.add(new Field("name",
-      value.name, Field.Store.YES, Field.Index.NOT_ANALYZED))
-    doc.add(new Field("localName",
-      value.localName, Field.Store.YES, Field.Index.NOT_ANALYZED))
-    doc.add(new Field("type",
-      value.declaredAs.toString(), Field.Store.YES,
-      Field.Index.NOT_ANALYZED))
+    doc.add(new Field("name", value.name, Field.Store.YES, Field.Index.NOT_ANALYZED))
+    doc.add(new Field("localName", value.localName, Field.Store.YES, Field.Index.NOT_ANALYZED))
+    doc.add(new Field("type", value.declaredAs.toString(), Field.Store.YES, Field.Index.NOT_ANALYZED))
     value.pos match {
       case Some((file, offset)) =>
-        doc.add(new Field("file", file, Field.Store.YES,
-          Field.Index.NOT_ANALYZED))
-        doc.add(new Field("offset", offset.toString, Field.Store.YES,
-          Field.Index.NOT_ANALYZED))
+        doc.add(new Field("file", file, Field.Store.YES, Field.Index.NOT_ANALYZED))
+        doc.add(new Field("offset", offset.toString, Field.Store.YES, Field.Index.NOT_ANALYZED))
       case None =>
-        doc.add(new Field("file", "", Field.Store.YES,
-          Field.Index.NOT_ANALYZED))
-        doc.add(new Field("offset", "", Field.Store.YES,
-          Field.Index.NOT_ANALYZED))
+        doc.add(new Field("file", "", Field.Store.YES, Field.Index.NOT_ANALYZED))
+        doc.add(new Field("offset", "", Field.Store.YES, Field.Index.NOT_ANALYZED))
     }
     value match {
       case value: TypeSearchResult =>
-        doc.add(new Field("docType",
-          "type", Field.Store.NO,
-          Field.Index.ANALYZED))
+        doc.add(new Field("docType", "type", Field.Store.NO, Field.Index.ANALYZED))
       case value: MethodSearchResult =>
-        doc.add(new Field("owner",
-          value.owner, Field.Store.YES,
-          Field.Index.NOT_ANALYZED))
-        doc.add(new Field("docType",
-          "method", Field.Store.NO,
-          Field.Index.ANALYZED))
+        doc.add(new Field("owner", value.owner, Field.Store.YES, Field.Index.NOT_ANALYZED))
+        doc.add(new Field("docType", "method", Field.Store.NO, Field.Index.ANALYZED))
     }
     doc
   }
@@ -208,7 +195,7 @@ object LuceneIndex extends StringSimilarity {
     }
   }
 
-  private def declaredAs(name: String, flags: Int) = {
+  def declaredAs(name: String, flags: Int): Symbol = {
     if (name.endsWith("$")) 'object
     else if ((flags & Opcodes.ACC_INTERFACE) != 0) 'trait
     else 'class
@@ -225,18 +212,12 @@ object LuceneIndex extends StringSimilarity {
   }
 
   def buildStaticIndex(
+    actorSystem: ActorSystem,
     writer: IndexWriter,
     files: Iterable[File],
     includes: Iterable[Regex],
     excludes: Iterable[Regex]) {
     val t = System.currentTimeMillis()
-
-    sealed trait IndexEvent
-    case class ClassEvent(name: String,
-      location: String, flags: Int) extends IndexEvent
-    case class MethodEvent(className: String, name: String,
-      location: String, flags: Int) extends IndexEvent
-    case object StopEvent extends IndexEvent
 
     /**
      * Implement a producer, consumer model for creation of the static index.
@@ -248,41 +229,7 @@ object LuceneIndex extends StringSimilarity {
      * full speed, spooling work to the mailbox, while the index writing
      * slowly catches up.
      */
-    class IndexWorkQueue extends Actor {
-      def act() {
-        loop {
-          receive {
-            case ClassEvent(name: String, location: String, flags: Int) =>
-              val i = name.lastIndexOf(".")
-              val localName = if (i > -1) name.substring(i + 1) else name
-              val value = TypeSearchResult(name,
-                localName,
-                declaredAs(name, flags),
-                Some((location, -1)))
-              val doc = buildDoc(value)
-              writer.addDocument(doc)
-            case MethodEvent(className: String, name: String,
-              location: String, flags: Int) =>
-              val isStatic = (flags & Opcodes.ACC_STATIC) != 0
-              val revisedClassName = if (isStatic) className + "$"
-              else className
-              val lookupKey = revisedClassName + "." + name
-              val value = MethodSearchResult(lookupKey,
-                name,
-                'method,
-                Some((location, -1)),
-                revisedClassName)
-              val doc = buildDoc(value)
-              writer.addDocument(doc)
-            case StopEvent =>
-              reply(StopEvent)
-              exit()
-          }
-        }
-      }
-    }
-    val indexWorkQ = new IndexWorkQueue
-    indexWorkQ.start
+    val indexWorkQ: ActorRef = actorSystem.actorOf(Props(new IndexWorkQueue(writer)))
 
     val handler = new ClassHandler {
       var classCount = 0
@@ -309,7 +256,10 @@ object LuceneIndex extends StringSimilarity {
 
     println("Updated: Indexing classpath...")
     ClassIterator.findPublicSymbols(files, handler)
-    indexWorkQ !? StopEvent
+
+    import scala.concurrent.duration._
+    // wait for the worker to complete
+    Await.result(ask(indexWorkQ, StopEvent)(Timeout(3.hours)), Duration.Inf)
     val elapsed = System.currentTimeMillis() - t
     println("Indexing completed in " + elapsed / 1000.0 + " seconds.")
     println("Indexed " + handler.classCount + " classes with " +
@@ -318,7 +268,7 @@ object LuceneIndex extends StringSimilarity {
 
 }
 
-trait LuceneIndex {
+class LuceneIndex {
 
   import LuceneIndex._
 
@@ -331,6 +281,7 @@ trait LuceneIndex {
   private var indexReader: Option[IndexReader] = None
 
   def initialize(
+    actorSystem: ActorSystem,
     root: File,
     files: Set[File],
     includes: Iterable[Regex],
@@ -364,7 +315,7 @@ trait LuceneIndex {
     for (writer <- indexWriter) {
       if (shouldReindex(version, indexedFiles.toSet, hashed)) {
         println("Re-indexing...")
-        buildStaticIndex(writer, files, includes, excludes)
+        buildStaticIndex(actorSystem, writer, files, includes, excludes)
         val json = JSONValue.toJSONString(
           JavaConversions.mapAsJavaMap(hashed.toMap))
         val userData = Map[String, String](
@@ -526,7 +477,8 @@ object IndexTest extends LuceneIndex {
   def main(args: Array[String]) {
     val classpath = "/Users/aemon/projects/ensime/target/scala-2.9.2/classes:/Users/aemon/projects/ensime/lib/org.scala-refactoring_2.9.2-SNAPSHOT-0.5.0-SNAPSHOT.jar"
     val files = classpath.split(":").map { new File(_) }.toSet
-    initialize(new File("."), files, List(), List())
+    val actorSystem = ActorSystem.create()
+    initialize(actorSystem, new File("."), files, List(), List())
 
     import java.util.Scanner
     val in = new Scanner(System.in)
@@ -540,5 +492,6 @@ object IndexTest extends LuceneIndex {
       }
       line = in.nextLine()
     }
+    actorSystem.shutdown()
   }
 }

--- a/src/main/scala/org/ensime/indexer/event.scala
+++ b/src/main/scala/org/ensime/indexer/event.scala
@@ -1,0 +1,7 @@
+package org.ensime.indexer
+
+sealed trait IndexEvent
+case class ClassEvent(name: String, location: String, flags: Int) extends IndexEvent
+case class MethodEvent(className: String, name: String, location: String, flags: Int) extends IndexEvent
+case object StopEvent extends IndexEvent
+

--- a/src/main/scala/org/ensime/model/Model.scala
+++ b/src/main/scala/org/ensime/model/Model.scala
@@ -1,18 +1,23 @@
 package org.ensime.model
 
 import java.io.File
+import akka.pattern.Patterns
+import akka.util.Timeout
+
 import scala.collection.mutable
+import scala.concurrent.Await
 import scala.tools.nsc.util.{ NoPosition, Position }
-import scala.tools.nsc.io.AbstractFile
 import org.ensime.util.CanonFile
 import org.ensime.server.RichPresentationCompiler
 import org.ensime.server.SourceFileCandidatesReq
+import org.ensime.server.AbstractFiles
+import scala.concurrent.duration._
 
 abstract class EntityInfo(val name: String, val members: Iterable[EntityInfo]) {}
 
 case class SourcePosition(file: CanonFile, line: Int)
 
-case class SourceFileInfo(file: File, contents: Option[String]) {}
+case class SourceFileInfo(file: File, contents: Option[String])
 object SourceFileInfo {
   def apply(file: String) = new SourceFileInfo(new File(file), None)
   def apply(file: File) = new SourceFileInfo(file, None)
@@ -21,7 +26,7 @@ object SourceFileInfo {
 class PackageInfo(
   override val name: String,
   val fullname: String,
-  override val members: Iterable[EntityInfo]) extends EntityInfo(name, members) {}
+  override val members: Iterable[EntityInfo]) extends EntityInfo(name, members)
 
 trait SymbolSearchResult {
   val name: String
@@ -61,11 +66,11 @@ class SymbolInfo(
   val declPos: Position,
   val tpe: TypeInfo,
   val isCallable: Boolean,
-  val ownerTypeId: Option[Int]) {}
+  val ownerTypeId: Option[Int])
 
 case class CompletionSignature(
   sections: List[List[(String, String)]],
-  result: String) {}
+  result: String)
 
 case class CompletionInfo(
   name: String,
@@ -73,11 +78,11 @@ case class CompletionInfo(
   tpeId: Int,
   isCallable: Boolean,
   relevance: Int,
-  toInsert: Option[String]) {}
+  toInsert: Option[String])
 
 case class CompletionInfoList(
   prefix: String,
-  completions: List[CompletionInfo]) {}
+  completions: List[CompletionInfo])
 
 trait PatchOp {
   val start: Int
@@ -101,7 +106,7 @@ case class BreakpointList(active: List[Breakpoint], pending: List[Breakpoint])
 
 case class OffsetRange(from: Int, to: Int)
 
-sealed trait DebugLocation {}
+sealed trait DebugLocation
 
 case class DebugObjectReference(
   objectId: Long) extends DebugLocation
@@ -170,11 +175,17 @@ case class DebugBacktrace(
   threadId: Long,
   threadName: String)
 
-class NamedTypeMemberInfo(override val name: String, val tpe: TypeInfo, val pos: Position, val declaredAs: scala.Symbol) extends EntityInfo(name, List()) {}
+class NamedTypeMemberInfo(override val name: String,
+  val tpe: TypeInfo,
+  val pos: Position,
+  val declaredAs: scala.Symbol) extends EntityInfo(name, List())
 
-class NamedTypeMemberInfoLight(override val name: String, val tpeSig: String, val tpeId: Int, val isCallable: Boolean) extends EntityInfo(name, List()) {}
+class NamedTypeMemberInfoLight(override val name: String,
+  val tpeSig: String,
+  val tpeId: Int,
+  val isCallable: Boolean) extends EntityInfo(name, List())
 
-class PackageMemberInfoLight(val name: String) {}
+class PackageMemberInfoLight(val name: String)
 
 class TypeInfo(
   name: String,
@@ -184,25 +195,25 @@ class TypeInfo(
   val args: Iterable[TypeInfo],
   members: Iterable[EntityInfo],
   val pos: Position,
-  val outerTypeId: Option[Int]) extends EntityInfo(name, members) {}
+  val outerTypeId: Option[Int]) extends EntityInfo(name, members)
 
 class ArrowTypeInfo(
   override val name: String,
   override val id: Int,
   val resultType: TypeInfo,
-  val paramSections: Iterable[ParamSectionInfo]) extends TypeInfo(name, id, 'nil, name, List(), List(), NoPosition, None) {}
+  val paramSections: Iterable[ParamSectionInfo]) extends TypeInfo(name, id, 'nil, name, List(), List(), NoPosition, None)
 
 class CallCompletionInfo(
   val resultType: TypeInfo,
-  val paramSections: Iterable[ParamSectionInfo]) {}
+  val paramSections: Iterable[ParamSectionInfo])
 
 class ParamSectionInfo(
   val params: Iterable[(String, TypeInfo)],
   val isImplicit: Boolean)
 
-class InterfaceInfo(val tpe: TypeInfo, val viaView: Option[String]) {}
+class InterfaceInfo(val tpe: TypeInfo, val viaView: Option[String])
 
-class TypeInspectInfo(val tpe: TypeInfo, val companionId: Option[Int], val supers: Iterable[InterfaceInfo]) {}
+class TypeInspectInfo(val tpe: TypeInfo, val companionId: Option[Int], val supers: Iterable[InterfaceInfo])
 
 trait ModelBuilders { self: RichPresentationCompiler =>
 
@@ -237,13 +248,20 @@ trait ModelBuilders { self: RichPresentationCompiler =>
       val top = sym.toplevelClass
       val name = if (sym.owner.isPackageObjectClass) "package$.class"
       else top.name + (if (top.isModuleClass) "$" else "")
-      indexer !? (1000, SourceFileCandidatesReq(pack, name)) match {
-        case Some(files: Set[AbstractFile]) =>
-          files.flatMap { f =>
+
+      import scala.concurrent.ExecutionContext.Implicits.global
+      val askRes = Patterns.ask(indexer, SourceFileCandidatesReq(pack, name), Timeout(1000.milliseconds))
+      val optFut = askRes map (Some(_)) recover { case _ => None }
+      val result = Await.result(askRes, Duration.Inf)
+      result match {
+        case Some(f: AbstractFiles) =>
+          f.files.flatMap { f =>
             println("Linking:" + (sym, f))
             askLinkPos(sym, f)
           }.find(_.isDefined).getOrElse(NoPosition)
-        case _ => NoPosition
+        case _ =>
+          println("WARNING - locateSymbolPos " + sym + " timed out")
+          NoPosition
       }
     }
   }

--- a/src/main/scala/org/ensime/protocol/ConnectionInfo.scala
+++ b/src/main/scala/org/ensime/protocol/ConnectionInfo.scala
@@ -1,0 +1,7 @@
+package org.ensime.protocol
+
+class ConnectionInfo {
+  val pid = None
+  val serverName: String = "ENSIME-ReferenceServer"
+  val protocolVersion: String = "0.8.9"
+}

--- a/src/main/scala/org/ensime/protocol/Protocol.scala
+++ b/src/main/scala/org/ensime/protocol/Protocol.scala
@@ -1,12 +1,9 @@
 package org.ensime.protocol
 
 import java.io._
-import org.ensime.config.{ ReplConfig, ProjectConfig }
-import org.ensime.indexer.MethodBytecode
-import org.ensime.model._
+import akka.actor.ActorRef
 import org.ensime.server._
 import org.ensime.util._
-import scala.actors._
 import scala.tools.nsc.util.{ Position, RangePosition }
 
 case class IncomingMessageEvent(obj: Any)
@@ -42,7 +39,13 @@ object ProtocolConst {
 
 }
 
-trait Protocol extends ProtocolConversions {
+trait Protocol {
+
+  /**
+   * Protocols must expose an appropriate class for converting messages to
+   * the underlying wire format
+   */
+  val conversions: ProtocolConversions
 
   /**
    * Read a message from the socket.
@@ -91,8 +94,8 @@ trait Protocol extends ProtocolConversions {
    * @param  peer  The Actor.
    * @return        Void
    */
-  def setOutputActor(peer: Actor)
-  protected def peer: Actor
+  def setOutputActor(peer: ActorRef)
+  protected def peer: ActorRef
 
   /**
    * Designate the target to which RPC handling
@@ -151,65 +154,4 @@ trait Protocol extends ProtocolConversions {
    */
   def sendProtocolError(code: Int, detail: Option[String])
 
-}
-
-trait ProtocolConversions {
-  def toWF(evt: SendBackgroundMessageEvent): WireFormat
-  def toWF(evt: AnalyzerReadyEvent): WireFormat
-  def toWF(evt: FullTypeCheckCompleteEvent): WireFormat
-  def toWF(evt: IndexerReadyEvent): WireFormat
-  def toWF(evt: NewNotesEvent): WireFormat
-  def toWF(evt: ClearAllNotesEvent): WireFormat
-  def toWF(evt: DebugEvent): WireFormat
-
-  def toWF(obj: DebugLocation): WireFormat
-  def toWF(obj: DebugValue): WireFormat
-  def toWF(evt: DebugNullValue): WireFormat
-  def toWF(evt: DebugPrimitiveValue): WireFormat
-  def toWF(evt: DebugClassField): WireFormat
-  def toWF(obj: DebugStringInstance): WireFormat
-  def toWF(evt: DebugObjectInstance): WireFormat
-  def toWF(evt: DebugArrayInstance): WireFormat
-  def toWF(evt: DebugStackLocal): WireFormat
-  def toWF(evt: DebugStackFrame): WireFormat
-  def toWF(evt: DebugBacktrace): WireFormat
-
-  def toWF(pos: SourcePosition): WireFormat
-  def toWF(config: BreakpointList): WireFormat
-  def toWF(config: ProjectConfig): WireFormat
-  def toWF(config: ReplConfig): WireFormat
-  def toWF(value: Boolean): WireFormat
-  def toWF(value: String): WireFormat
-  def toWF(value: Note): WireFormat
-  def toWF(notelist: NoteList): WireFormat
-
-  def toWF(values: Iterable[WireFormat]): WireFormat
-  def toWF(value: CompletionInfo): WireFormat
-  def toWF(value: CompletionInfoList): WireFormat
-  def toWF(value: PackageMemberInfoLight): WireFormat
-  def toWF(value: SymbolInfo): WireFormat
-  def toWF(value: NamedTypeMemberInfoLight): WireFormat
-  def toWF(value: NamedTypeMemberInfo): WireFormat
-  def toWF(value: EntityInfo): WireFormat
-  def toWF(value: TypeInfo): WireFormat
-  def toWF(value: PackageInfo): WireFormat
-  def toWF(value: CallCompletionInfo): WireFormat
-  def toWF(value: InterfaceInfo): WireFormat
-  def toWF(value: TypeInspectInfo): WireFormat
-  def toWF(value: SymbolSearchResults): WireFormat
-  def toWF(value: ImportSuggestions): WireFormat
-  def toWF(value: SymbolSearchResult): WireFormat
-  def toWF(value: Position): WireFormat
-  def toWF(value: RangePosition): WireFormat
-  def toWF(value: FileRange): WireFormat
-  def toWF(value: SymbolDesignations): WireFormat
-
-  def toWF(value: RefactorFailure): WireFormat
-  def toWF(value: RefactorEffect): WireFormat
-  def toWF(value: RefactorResult): WireFormat
-  def toWF(value: Undo): WireFormat
-  def toWF(value: UndoResult): WireFormat
-  def toWF(value: Null): WireFormat
-  def toWF(vmStatus: DebugVmStatus): WireFormat
-  def toWF(method: MethodBytecode): WireFormat
 }

--- a/src/main/scala/org/ensime/protocol/ProtocolConversions.scala
+++ b/src/main/scala/org/ensime/protocol/ProtocolConversions.scala
@@ -1,0 +1,72 @@
+package org.ensime.protocol
+
+import org.ensime.config.{ ReplConfig, ProjectConfig }
+import org.ensime.indexer.MethodBytecode
+import org.ensime.model._
+import org.ensime.server._
+import org.ensime.util.{ FileRange, NoteList, Note, WireFormat }
+
+import scala.reflect.internal.util.{ RangePosition, Position }
+
+trait ProtocolConversions {
+  def toWF(evt: ConnectionInfo): WireFormat
+  def toWF(evt: SendBackgroundMessageEvent): WireFormat
+  def toWF(evt: AnalyzerReadyEvent): WireFormat
+  def toWF(evt: FullTypeCheckCompleteEvent): WireFormat
+  def toWF(evt: IndexerReadyEvent): WireFormat
+  def toWF(evt: NewNotesEvent): WireFormat
+  def toWF(evt: ClearAllNotesEvent): WireFormat
+  def toWF(evt: DebugEvent): WireFormat
+
+  def toWF(obj: DebugLocation): WireFormat
+  def toWF(obj: DebugValue): WireFormat
+  def toWF(evt: DebugNullValue): WireFormat
+  def toWF(evt: DebugPrimitiveValue): WireFormat
+  def toWF(evt: DebugClassField): WireFormat
+  def toWF(obj: DebugStringInstance): WireFormat
+  def toWF(evt: DebugObjectInstance): WireFormat
+  def toWF(evt: DebugArrayInstance): WireFormat
+  def toWF(evt: DebugStackLocal): WireFormat
+  def toWF(evt: DebugStackFrame): WireFormat
+  def toWF(evt: DebugBacktrace): WireFormat
+
+  def toWF(pos: SourcePosition): WireFormat
+  def toWF(config: Breakpoint): WireFormat
+  def toWF(config: BreakpointList): WireFormat
+  def toWF(config: ProjectConfig): WireFormat
+  def toWF(config: ReplConfig): WireFormat
+  def toWF(value: Boolean): WireFormat
+  def toWF(value: String): WireFormat
+  def toWF(value: Note): WireFormat
+  def toWF(notelist: NoteList): WireFormat
+
+  def toWF(values: Iterable[WireFormat]): WireFormat
+  def toWF(value: CompletionInfo): WireFormat
+  def toWF(value: CompletionInfoList): WireFormat
+  def toWF(value: PackageMemberInfoLight): WireFormat
+  def toWF(value: SymbolInfo): WireFormat
+  def toWF(value: NamedTypeMemberInfoLight): WireFormat
+  def toWF(value: NamedTypeMemberInfo): WireFormat
+  def toWF(value: EntityInfo): WireFormat
+  def toWF(value: TypeInfo): WireFormat
+  def toWF(value: PackageInfo): WireFormat
+  def toWF(value: CallCompletionInfo): WireFormat
+  def toWF(value: InterfaceInfo): WireFormat
+  def toWF(value: TypeInspectInfo): WireFormat
+  def toWF(value: SymbolSearchResults): WireFormat
+  def toWF(value: ImportSuggestions): WireFormat
+  def toWF(value: SymbolSearchResult): WireFormat
+  def toWF(value: Position): WireFormat
+  def toWF(value: RangePosition): WireFormat
+  def toWF(value: FileRange): WireFormat
+  def toWF(value: SymbolDesignations): WireFormat
+
+  def toWF(value: RefactorFailure): WireFormat
+  def toWF(value: RefactorEffect): WireFormat
+  def toWF(value: RefactorResult): WireFormat
+  def toWF(value: Undo): WireFormat
+  def toWF(value: UndoResult): WireFormat
+  def toWF(value: Null): WireFormat
+  def toWF(vmStatus: DebugVmStatus): WireFormat
+  def toWF(method: MethodBytecode): WireFormat
+}

--- a/src/main/scala/org/ensime/protocol/SExpConversion.scala
+++ b/src/main/scala/org/ensime/protocol/SExpConversion.scala
@@ -1,0 +1,43 @@
+package org.ensime.protocol
+
+import org.ensime.util.SExp
+
+import scala.reflect.internal.util.{ RangePosition, Position }
+import scala.tools.nsc.io._
+
+object SExpConversion {
+
+  implicit def posToSExp(pos: Position): SExp = {
+    if (pos.isDefined) {
+      val underlying = pos.source.file.underlyingSource.orNull
+      val archive: SExp = underlying match {
+        case a: ZipArchive if a != pos.source.file => a.path
+        case _ => 'nil
+      }
+      SExp.propList(
+        (":file", pos.source.path),
+        (":archive", archive),
+        (":offset", pos.point))
+    } else {
+      'nil
+    }
+  }
+
+  implicit def posToSExp(pos: RangePosition): SExp = {
+    if (pos.isDefined) {
+      val underlying = pos.source.file.underlyingSource.orNull
+      val archive: SExp = underlying match {
+        case a: ZipArchive if a != pos.source.file => a.path
+        case _ => 'nil
+      }
+      SExp.propList(
+        (":file", pos.source.path),
+        (":archive", archive),
+        (":offset", pos.point),
+        (":start", pos.start),
+        (":end", pos.end))
+    } else {
+      'nil
+    }
+  }
+}

--- a/src/main/scala/org/ensime/protocol/SwankProtocol.scala
+++ b/src/main/scala/org/ensime/protocol/SwankProtocol.scala
@@ -1,31 +1,26 @@
 package org.ensime.protocol
 
 import java.io._
-import org.ensime.config.{ ProjectConfig, ReplConfig }
-import org.ensime.indexer.MethodBytecode
+import akka.actor.ActorRef
+import org.ensime.config.ProjectConfig
 import org.ensime.model._
 import org.ensime.server._
 import org.ensime.util._
 import org.ensime.util.SExp._
-import scala.actors._
-import scala.tools.nsc.io.ZipArchive
-import scala.tools.nsc.util.{ Position, RangePosition }
 import scala.util.parsing.input
 
-object SwankProtocol extends SwankProtocol {}
-
-trait SwankProtocol extends Protocol {
-
-  class ConnectionInfo {
-    val pid = None
-    val serverName: String = "ENSIME-ReferenceServer"
-    val protocolVersion: String = "0.8.7"
-  }
+class SwankProtocol extends Protocol {
 
   /**
-   * Protocol Version: 0.8.7
+   * Protocol Version: 0.8.9
    *
    * Protocol Change Log:
+   *   0.8.9
+   *     Remove Incremental builder - removed
+   *       swank:builder-init
+   *       swank:builder-update-files
+   *       swank:builder-add-files
+   *       swank:builder-remove-files
    *   0.8.8
    *     Add optional :archive member to Position and RangePosition
    *   0.8.7
@@ -72,12 +67,14 @@ trait SwankProtocol extends Protocol {
 
   import ProtocolConst._
 
-  private var outPeer: Actor = null
+  override val conversions: ProtocolConversions = new SwankProtocolConversions
+
+  private var outPeer: ActorRef = null
   private var rpcTarget: RPCTarget = null
 
   def peer = outPeer
 
-  def setOutputActor(peer: Actor) { outPeer = peer }
+  def setOutputActor(peer: ActorRef) { outPeer = peer }
 
   def setRPCTarget(target: RPCTarget) { this.rpcTarget = target }
 
@@ -95,7 +92,7 @@ trait SwankProtocol extends Protocol {
 
   private def fillArray(in: java.io.Reader, a: Array[Char]) {
     var n = 0
-    var l = a.length
+    val l = a.length
     var charsRead = 0
     while (n < l) {
       charsRead = in.read(a, n, l - n)
@@ -518,8 +515,7 @@ trait SwankProtocol extends Protocol {
 
     println("\nHandling RPC: " + form.toReadableString(debug = true))
 
-    def oops = sendRPCError(ErrMalformedRPC,
-      Some("Malformed " + callType + " call: " + form), callId)
+    def oops() = sendRPCError(ErrMalformedRPC, Some("Malformed " + callType + " call: " + form), callId)
 
     callType match {
 
@@ -550,7 +546,7 @@ trait SwankProtocol extends Protocol {
        *   :version "0.7")) 42)
        */
       case "swank:connection-info" =>
-        sendRPCReturn(toWF(new ConnectionInfo()), callId)
+        sendRPCReturn(conversions.toWF(new ConnectionInfo()), callId)
 
       /**
        * Doc RPC:
@@ -582,11 +578,9 @@ trait SwankProtocol extends Protocol {
           case SExpList(head :: (conf: SExpList) :: body) =>
             ProjectConfig.fromSExp(conf) match {
               case Right(config) => rpcTarget.rpcInitProject(config, callId)
-              case Left(t) => sendRPCError(ErrExceptionInRPC,
-                Some(t.toString),
-                callId)
+              case Left(t) => sendRPCError(ErrExceptionInRPC, Some(t.toString), callId)
             }
-          case _ => oops
+          case _ => oops()
         }
 
       /**
@@ -636,7 +630,7 @@ trait SwankProtocol extends Protocol {
         form match {
           case SExpList(head :: (IntAtom(id)) :: body) =>
             rpcTarget.rpcExecUndo(id, callId)
-          case _ => oops
+          case _ => oops()
         }
 
       /**
@@ -660,95 +654,6 @@ trait SwankProtocol extends Protocol {
 
       /**
        * Doc RPC:
-       *   swank:builder-init
-       * Summary:
-       *   Initialize the incremental builder and kick off a full rebuild.
-       * Arguments:
-       *   None
-       * Return:
-       *   None
-       * Example call:
-       *   (:swank-rpc (swank:builder-init) 42)
-       * Example return:
-       *   (:return (:ok ()) 42)
-       */
-      case "swank:builder-init" =>
-        rpcTarget.rpcBuilderInit(callId)
-
-      /**
-       * Doc RPC:
-       *   swank:builder-update-files
-       * Summary:
-       *   Signal to the incremental builder that the given files
-       *   have changed and must be rebuilt. Triggers rebuild.
-       * Arguments:
-       *   List of Strings:Filenames, absolute or relative to the project root.
-       * Return:
-       *   None
-       * Example call:
-       *   (:swank-rpc (swank:builder-update-files
-       *   ("/ensime/src/main/scala/org/ensime/server/Analyzer.scala")) 42)
-       * Example return:
-       *   (:return (:ok ()) 42)
-       */
-      case "swank:builder-update-files" =>
-        form match {
-          case SExpList(head :: SExpList(filenames) :: body) =>
-            val files = filenames.map(_.toString)
-            rpcTarget.rpcBuilderUpdateFiles(files, callId)
-          case _ => oops
-        }
-
-      /**
-       * Doc RPC:
-       *   swank:builder-add-files
-       * Summary:
-       *   Signal to the incremental builder that the given files
-       *   should be added to the build. Triggers rebuild.
-       * Arguments:
-       *   List of Strings:Filenames, absolute or relative to the project root.
-       * Return:
-       *   None
-       * Example call:
-       *   (:swank-rpc (swank:builder-add-files
-       *   ("/ensime/src/main/scala/org/ensime/server/Analyzer.scala")) 42)
-       * Example return:
-       *   (:return (:ok ()) 42)
-       */
-      case "swank:builder-add-files" =>
-        form match {
-          case SExpList(head :: SExpList(filenames) :: body) =>
-            val files = filenames.map(_.toString)
-            rpcTarget.rpcBuilderAddFiles(files, callId)
-          case _ => oops
-        }
-
-      /**
-       * Doc RPC:
-       *   swank:builder-remove-files
-       * Summary:
-       *   Signal to the incremental builder that the given files
-       *   should be removed from the build. Triggers rebuild.
-       * Arguments:
-       *   List of Strings:Filenames, absolute or relative to the project root.
-       * Return:
-       *   None
-       * Example call:
-       *   (:swank-rpc (swank:builder-remove-files
-       *   ("/ensime/src/main/scala/org/ensime/server/Analyzer.scala")) 42)
-       * Example return:
-       *   (:return (:ok ()) 42)
-       */
-      case "swank:builder-remove-files" =>
-        form match {
-          case SExpList(head :: SExpList(filenames) :: body) =>
-            val files = filenames.map(_.toString)
-            rpcTarget.rpcBuilderRemoveFiles(files, callId)
-          case _ => oops
-        }
-
-      /**
-       * Doc RPC:
        *   swank:remove-file
        * Summary:
        *   Remove a file from consideration by the ENSIME analyzer.
@@ -765,7 +670,7 @@ trait SwankProtocol extends Protocol {
         form match {
           case SExpList(head :: StringAtom(file) :: body) =>
             rpcTarget.rpcRemoveFile(file, callId)
-          case _ => oops
+          case _ => oops()
         }
 
       /**
@@ -789,7 +694,7 @@ trait SwankProtocol extends Protocol {
             rpcTarget.rpcTypecheckFiles(List(SourceFileInfo(new File(file), Some(contents))), callId)
           case SExpList(head :: StringAtom(file) :: body) =>
             rpcTarget.rpcTypecheckFiles(List(SourceFileInfo(file)), callId)
-          case _ => oops
+          case _ => oops()
         }
 
       /**
@@ -811,7 +716,7 @@ trait SwankProtocol extends Protocol {
           case SExpList(head :: SExpList(strings) :: body) =>
             val filenames = strings.collect { case StringAtom(s) => SourceFileInfo(s) }.toList
             rpcTarget.rpcTypecheckFiles(filenames, callId)
-          case _ => oops
+          case _ => oops()
         }
 
       /**
@@ -844,7 +749,7 @@ trait SwankProtocol extends Protocol {
               case _ => PatchInsert(0, "")
             }.toList
             rpcTarget.rpcPatchSource(file, edits, callId)
-          case _ => oops
+          case _ => oops()
         }
 
       /**
@@ -886,7 +791,7 @@ trait SwankProtocol extends Protocol {
           case SExpList(head :: SExpList(filenames) :: body) =>
             val files = filenames.map(_.toString)
             rpcTarget.rpcFormatFiles(files, callId)
-          case _ => oops
+          case _ => oops()
         }
 
       /**
@@ -911,7 +816,7 @@ trait SwankProtocol extends Protocol {
           case SExpList(head :: SExpList(keywords) :: IntAtom(maxResults) :: body) =>
             rpcTarget.rpcPublicSymbolSearch(
               keywords.map(_.toString).toList, maxResults, callId)
-          case _ => oops
+          case _ => oops()
         }
 
       /**
@@ -934,7 +839,7 @@ trait SwankProtocol extends Protocol {
        *   "/ensime/src/main/scala/org/ensime/server/Analyzer.scala"
        *   2300 (Actor) 10) 42)
        * Example return:
-       *   (:return (:ok (((:name "scala.actors.Actor" :local-name "Actor"
+       *   (:return (:ok (((:name "akka.actor.Actor" :local-name "Actor"
        *   :decl-as trait :pos (:file "/lib/scala-library.jar" :offset -1)))))
        *   42)
        */
@@ -944,7 +849,7 @@ trait SwankProtocol extends Protocol {
             SExpList(names) :: IntAtom(maxResults) :: body) =>
             rpcTarget.rpcImportSuggestions(file, point,
               names.map(_.toString).toList, maxResults, callId)
-          case _ => oops
+          case _ => oops()
         }
 
       /**
@@ -979,7 +884,7 @@ trait SwankProtocol extends Protocol {
             BooleanAtom(reload) :: body) =>
             rpcTarget.rpcCompletionsAtPoint(
               file, point, maxResults, caseSens, reload, callId)
-          case _ => oops
+          case _ => oops()
         }
 
       /**
@@ -1002,7 +907,7 @@ trait SwankProtocol extends Protocol {
         form match {
           case SExpList(head :: StringAtom(path) :: StringAtom(prefix) :: body) =>
             rpcTarget.rpcPackageMemberCompletion(path, prefix, callId)
-          case _ => oops
+          case _ => oops()
         }
 
       /**
@@ -1031,7 +936,7 @@ trait SwankProtocol extends Protocol {
         form match {
           case SExpList(head :: IntAtom(id) :: body) =>
             rpcTarget.rpcCallCompletion(id, callId)
-          case _ => oops
+          case _ => oops()
         }
 
       /**
@@ -1056,7 +961,7 @@ trait SwankProtocol extends Protocol {
         form match {
           case SExpList(head :: StringAtom(file) :: IntAtom(point) :: body) =>
             rpcTarget.rpcUsesOfSymAtPoint(file, point, callId)
-          case _ => oops
+          case _ => oops()
         }
 
       /**
@@ -1079,7 +984,7 @@ trait SwankProtocol extends Protocol {
         form match {
           case SExpList(head :: IntAtom(id) :: body) =>
             rpcTarget.rpcTypeById(id, callId)
-          case _ => oops
+          case _ => oops()
         }
 
       /**
@@ -1101,7 +1006,7 @@ trait SwankProtocol extends Protocol {
         form match {
           case SExpList(head :: StringAtom(name) :: body) =>
             rpcTarget.rpcTypeByName(name, callId)
-          case _ => oops
+          case _ => oops()
         }
 
       /**
@@ -1127,7 +1032,7 @@ trait SwankProtocol extends Protocol {
           case SExpList(head :: StringAtom(name) :: StringAtom(file) ::
             OffsetRangeExtractor(range) :: body) =>
             rpcTarget.rpcTypeByNameAtPoint(name, file, range, callId)
-          case _ => oops
+          case _ => oops()
         }
 
       /**
@@ -1152,7 +1057,7 @@ trait SwankProtocol extends Protocol {
           case SExpList(head :: StringAtom(file) ::
             OffsetRangeExtractor(range) :: body) =>
             rpcTarget.rpcTypeAtPoint(file, range, callId)
-          case _ => oops
+          case _ => oops()
         }
 
       /**
@@ -1178,7 +1083,7 @@ trait SwankProtocol extends Protocol {
           case SExpList(head :: StringAtom(file) ::
             OffsetRangeExtractor(range) :: body) =>
             rpcTarget.rpcInspectTypeAtPoint(file, range, callId)
-          case _ => oops
+          case _ => oops()
         }
 
       /**
@@ -1201,7 +1106,7 @@ trait SwankProtocol extends Protocol {
         form match {
           case SExpList(head :: IntAtom(id) :: body) =>
             rpcTarget.rpcInspectTypeById(id, callId)
-          case _ => oops
+          case _ => oops()
         }
 
       /**
@@ -1225,7 +1130,7 @@ trait SwankProtocol extends Protocol {
         form match {
           case SExpList(head :: StringAtom(file) :: IntAtom(point) :: body) =>
             rpcTarget.rpcSymbolAtPoint(file, point, callId)
-          case _ => oops
+          case _ => oops()
         }
 
       /**
@@ -1249,7 +1154,7 @@ trait SwankProtocol extends Protocol {
         form match {
           case SExpList(head :: StringAtom(path) :: body) =>
             rpcTarget.rpcInspectPackageByPath(path, callId)
-          case _ => oops
+          case _ => oops()
         }
 
       /**
@@ -1289,7 +1194,7 @@ trait SwankProtocol extends Protocol {
             (params: SExp) :: BooleanAtom(interactive) :: body) =>
             rpcTarget.rpcPrepareRefactor(Symbol(tpe), procId,
               listOrEmpty(params).toSymbolMap, interactive, callId)
-          case _ => oops
+          case _ => oops()
         }
 
       /**
@@ -1313,7 +1218,7 @@ trait SwankProtocol extends Protocol {
         form match {
           case SExpList(dude :: IntAtom(procId) :: SymbolAtom(tpe) :: body) =>
             rpcTarget.rpcExecRefactor(Symbol(tpe), procId, callId)
-          case _ => oops
+          case _ => oops()
         }
 
       /**
@@ -1335,7 +1240,7 @@ trait SwankProtocol extends Protocol {
         form match {
           case SExpList(head :: IntAtom(procId) :: body) =>
             rpcTarget.rpcCancelRefactor(procId, callId)
-          case _ => oops
+          case _ => oops()
         }
 
       /**
@@ -1370,7 +1275,7 @@ trait SwankProtocol extends Protocol {
               tpe => Symbol(tpe.toString)).toList
             rpcTarget.rpcSymbolDesignations(filename, start,
               end, requestedTypes, callId)
-          case _ => oops
+          case _ => oops()
         }
 
       /**
@@ -1396,7 +1301,7 @@ trait SwankProtocol extends Protocol {
           case SExpList(head :: StringAtom(filename) :: IntAtom(start) ::
             IntAtom(end) :: body) =>
             rpcTarget.rpcExpandSelection(filename, start, end, callId)
-          case _ => oops
+          case _ => oops()
         }
 
       /**
@@ -1426,7 +1331,7 @@ trait SwankProtocol extends Protocol {
           case SExpList(head :: StringAtom(filename) ::
             IntAtom(line) :: body) =>
             rpcTarget.rpcMethodBytecode(filename, line, callId)
-          case _ => oops
+          case _ => oops()
         }
 
       /**
@@ -1447,7 +1352,7 @@ trait SwankProtocol extends Protocol {
         form match {
           case SExpList(head :: body) =>
             rpcTarget.rpcDebugActiveVM(callId)
-          case _ => oops
+          case _ => oops()
         }
 
       /**
@@ -1469,7 +1374,7 @@ trait SwankProtocol extends Protocol {
         form match {
           case SExpList(head :: StringAtom(commandLine) :: body) =>
             rpcTarget.rpcDebugStartVM(commandLine, callId)
-          case _ => oops
+          case _ => oops()
         }
 
       /**
@@ -1491,7 +1396,7 @@ trait SwankProtocol extends Protocol {
         form match {
           case SExpList(head :: StringAtom(hostname) :: StringAtom(port) :: body) =>
             rpcTarget.rpcDebugAttachVM(hostname, port, callId)
-          case _ => oops
+          case _ => oops()
         }
 
       /**
@@ -1512,7 +1417,7 @@ trait SwankProtocol extends Protocol {
         form match {
           case SExpList(head :: body) =>
             rpcTarget.rpcDebugStopVM(callId)
-          case _ => oops
+          case _ => oops()
         }
 
       /**
@@ -1535,7 +1440,7 @@ trait SwankProtocol extends Protocol {
           case SExpList(head :: StringAtom(filename) ::
             IntAtom(line) :: body) =>
             rpcTarget.rpcDebugBreak(filename, line, callId)
-          case _ => oops
+          case _ => oops()
         }
 
       /**
@@ -1558,7 +1463,7 @@ trait SwankProtocol extends Protocol {
           case SExpList(head :: StringAtom(filename) ::
             IntAtom(line) :: body) =>
             rpcTarget.rpcDebugClearBreak(filename, line, callId)
-          case _ => oops
+          case _ => oops()
         }
 
       /**
@@ -1579,7 +1484,7 @@ trait SwankProtocol extends Protocol {
         form match {
           case SExpList(head :: body) =>
             rpcTarget.rpcDebugClearAllBreaks(callId)
-          case _ => oops
+          case _ => oops()
         }
 
       /**
@@ -1601,7 +1506,7 @@ trait SwankProtocol extends Protocol {
         form match {
           case SExpList(head :: body) =>
             rpcTarget.rpcDebugListBreaks(callId)
-          case _ => oops
+          case _ => oops()
         }
 
       /**
@@ -1622,7 +1527,7 @@ trait SwankProtocol extends Protocol {
         form match {
           case SExpList(head :: body) =>
             rpcTarget.rpcDebugRun(callId)
-          case _ => oops
+          case _ => oops()
         }
 
       /**
@@ -1643,7 +1548,7 @@ trait SwankProtocol extends Protocol {
         form match {
           case SExpList(head :: StringAtom(threadId) :: body) =>
             rpcTarget.rpcDebugContinue(threadId.toLong, callId)
-          case _ => oops
+          case _ => oops()
         }
 
       /**
@@ -1665,7 +1570,7 @@ trait SwankProtocol extends Protocol {
         form match {
           case SExpList(head :: StringAtom(threadId) :: body) =>
             rpcTarget.rpcDebugStep(threadId.toLong, callId)
-          case _ => oops
+          case _ => oops()
         }
 
       /**
@@ -1687,7 +1592,7 @@ trait SwankProtocol extends Protocol {
         form match {
           case SExpList(head :: StringAtom(threadId) :: body) =>
             rpcTarget.rpcDebugNext(threadId.toLong, callId)
-          case _ => oops
+          case _ => oops()
         }
 
       /**
@@ -1709,7 +1614,7 @@ trait SwankProtocol extends Protocol {
         form match {
           case SExpList(head :: StringAtom(threadId) :: body) =>
             rpcTarget.rpcDebugStepOut(threadId.toLong, callId)
-          case _ => oops
+          case _ => oops()
         }
 
       /**
@@ -1732,7 +1637,7 @@ trait SwankProtocol extends Protocol {
         form match {
           case SExpList(head :: StringAtom(threadId) :: StringAtom(name) :: body) =>
             rpcTarget.rpcDebugLocateName(threadId.toLong, name, callId)
-          case _ => oops
+          case _ => oops()
         }
 
       /**
@@ -1755,7 +1660,7 @@ trait SwankProtocol extends Protocol {
         form match {
           case SExpList(head :: DebugLocationExtractor(loc) :: body) =>
             rpcTarget.rpcDebugValue(loc, callId)
-          case _ => oops
+          case _ => oops()
         }
 
       /**
@@ -1779,7 +1684,7 @@ trait SwankProtocol extends Protocol {
         form match {
           case SExpList(head :: StringAtom(threadId) :: DebugLocationExtractor(loc) :: body) =>
             rpcTarget.rpcDebugToString(threadId.toLong, loc, callId)
-          case _ => oops
+          case _ => oops()
         }
 
       /**
@@ -1803,7 +1708,7 @@ trait SwankProtocol extends Protocol {
           case SExpList(head :: DebugLocationExtractor(loc) ::
             StringAtom(newValue) :: body) =>
             rpcTarget.rpcDebugSetValue(loc, newValue, callId)
-          case _ => oops
+          case _ => oops()
         }
 
       /**
@@ -1828,7 +1733,7 @@ trait SwankProtocol extends Protocol {
           case SExpList(head :: StringAtom(threadId) ::
             IntAtom(index) :: IntAtom(count) :: body) =>
             rpcTarget.rpcDebugBacktrace(threadId.toLong, index, count, callId)
-          case _ => oops
+          case _ => oops()
         }
 
       /**
@@ -1902,46 +1807,6 @@ trait SwankProtocol extends Protocol {
         detail.map(strToSExp).getOrElse(NilAtom())))
   }
 
-  object SExpConversion {
-
-    implicit def posToSExp(pos: Position): SExp = {
-      if (pos.isDefined) {
-        val underlying = pos.source.file.underlyingSource.orNull
-        val archive: SExp = underlying match {
-          case a: ZipArchive if a != pos.source.file => a.path
-          case _ => 'nil
-        }
-        SExp.propList(
-          (":file", pos.source.path),
-          (":archive", archive),
-          (":offset", pos.point))
-      } else {
-        'nil
-      }
-    }
-
-    implicit def posToSExp(pos: RangePosition): SExp = {
-      if (pos.isDefined) {
-        val underlying = pos.source.file.underlyingSource.orNull
-        val archive: SExp = underlying match {
-          case a: ZipArchive if a != pos.source.file => a.path
-          case _ => 'nil
-        }
-        SExp.propList(
-          (":file", pos.source.path),
-          (":archive", archive),
-          (":offset", pos.point),
-          (":start", pos.start),
-          (":end", pos.end))
-      } else {
-        'nil
-      }
-    }
-
-  }
-
-  import SExpConversion._
-
   object OffsetRangeExtractor {
     def unapply(sexp: SExp): Option[OffsetRange] = sexp match {
       case IntAtom(a) => Some(OffsetRange(a, a))
@@ -1983,709 +1848,6 @@ trait SwankProtocol extends Protocol {
         case _ => None
       }
     }
-  }
-
-  override def toWF(obj: DebugLocation): SExp = {
-    obj match {
-      case obj: DebugObjectReference => toWF(obj)
-      case obj: DebugArrayElement => toWF(obj)
-      case obj: DebugObjectField => toWF(obj)
-      case obj: DebugStackSlot => toWF(obj)
-    }
-  }
-  def toWF(obj: DebugObjectReference): SExp = {
-    SExp(
-      key(":type"), 'reference,
-      key(":object-id"), obj.objectId.toString)
-  }
-  def toWF(obj: DebugArrayElement): SExp = {
-    SExp(
-      key(":type"), 'element,
-      key(":object-id"), obj.objectId.toString,
-      key(":index"), obj.index)
-  }
-  def toWF(obj: DebugObjectField): SExp = {
-    SExp(
-      key(":type"), 'field,
-      key(":object-id"), obj.objectId.toString,
-      key(":field"), obj.name)
-  }
-  def toWF(obj: DebugStackSlot): SExp = {
-    SExp(
-      key(":type"), 'slot,
-      key(":thread-id"), obj.threadId.toString,
-      key(":frame"), obj.frame,
-      key(":offset"), obj.offset)
-  }
-
-  override def toWF(obj: DebugValue): SExp = {
-    obj match {
-      case obj: DebugPrimitiveValue => toWF(obj)
-      case obj: DebugObjectInstance => toWF(obj)
-      case obj: DebugArrayInstance => toWF(obj)
-      case obj: DebugStringInstance => toWF(obj)
-      case obj: DebugNullValue => toWF(obj)
-    }
-  }
-
-  override def toWF(obj: DebugNullValue): SExp = {
-    SExp(
-      key(":val-type"), 'null,
-      key(":type-name"), obj.typeName)
-  }
-
-  override def toWF(obj: DebugPrimitiveValue): SExp = {
-    SExp(
-      key(":val-type"), 'prim,
-      key(":summary"), obj.summary,
-      key(":type-name"), obj.typeName)
-  }
-
-  override def toWF(obj: DebugClassField): SExp = {
-    SExp(
-      key(":index"), obj.index,
-      key(":name"), obj.name,
-      key(":summary"), obj.summary,
-      key(":type-name"), obj.typeName)
-  }
-
-  override def toWF(obj: DebugObjectInstance): SExp = {
-    SExp(
-      key(":val-type"), 'obj,
-      key(":fields"), SExpList(obj.fields.map(toWF)),
-      key(":type-name"), obj.typeName,
-      key(":object-id"), obj.objectId.toString)
-  }
-
-  override def toWF(obj: DebugStringInstance): SExp = {
-    SExp(
-      key(":val-type"), 'str,
-      key(":summary"), obj.summary,
-      key(":fields"), SExpList(obj.fields.map(toWF)),
-      key(":type-name"), obj.typeName,
-      key(":object-id"), obj.objectId.toString)
-  }
-
-  override def toWF(obj: DebugArrayInstance): SExp = {
-    SExp(
-      key(":val-type"), 'arr,
-      key(":length"), obj.length,
-      key(":type-name"), obj.typeName,
-      key(":element-type-name"), obj.elementTypeName,
-      key(":object-id"), obj.objectId.toString)
-  }
-
-  override def toWF(obj: DebugStackLocal): SExp = {
-    SExp(
-      key(":index"), obj.index,
-      key(":name"), obj.name,
-      key(":summary"), obj.summary,
-      key(":type-name"), obj.typeName)
-  }
-
-  override def toWF(obj: DebugStackFrame): SExp = {
-    SExp(
-      key(":index"), obj.index,
-      key(":locals"), SExpList(obj.locals.map(toWF)),
-      key(":num-args"), obj.numArguments,
-      key(":class-name"), obj.className,
-      key(":method-name"), obj.methodName,
-      key(":pc-location"), toWF(obj.pcLocation),
-      key(":this-object-id"), obj.thisObjectId.toString)
-  }
-
-  override def toWF(obj: DebugBacktrace): SExp = {
-    SExp(
-      key(":frames"), SExpList(obj.frames.map(toWF)),
-      key(":thread-id"), obj.threadId.toString,
-      key(":thread-name"), obj.threadName)
-  }
-
-  override def toWF(pos: SourcePosition): SExp = {
-    SExp(
-      key(":file"), pos.file.getAbsolutePath,
-      key(":line"), pos.line)
-  }
-
-  def toWF(info: ConnectionInfo): SExp = {
-    SExp(
-      key(":pid"), 'nil,
-      key(":implementation"),
-      SExp(key(":name"), info.serverName),
-      key(":version"), info.protocolVersion)
-  }
-
-  override def toWF(evt: SendBackgroundMessageEvent): SExp = {
-    SExp(key(":background-message"), evt.code,
-      evt.detail.map(strToSExp).getOrElse(NilAtom()))
-  }
-
-  /**
-   * Doc Event:
-   *   :compiler-ready
-   * Summary:
-   *   Signal that the compiler has finished its initial compilation and the server
-   *   is ready to accept RPC calls.
-   * Structure:
-   *   (:compiler-ready)
-   */
-  def toWF(evt: AnalyzerReadyEvent): SExp = {
-    SExp(key(":compiler-ready"))
-  }
-
-  /**
-   * Doc Event:
-   *   :full-typecheck-finished
-   * Summary:
-   *   Signal that the compiler has finished compilation of the entire project.
-   * Structure:
-   *   (:full-typecheck-finished)
-   */
-  def toWF(evt: FullTypeCheckCompleteEvent): SExp = {
-    SExp(key(":full-typecheck-finished"))
-  }
-
-  /**
-   * Doc Event:
-   *   :indexer-ready
-   * Summary:
-   *   Signal that the indexer has finished indexing the classpath.
-   * Structure:
-   *   (:indexer-ready)
-   */
-  def toWF(evt: IndexerReadyEvent): SExp = {
-    SExp(key(":indexer-ready"))
-  }
-
-  /**
-   * Doc Event:
-   *   :scala-notes
-   * Summary:
-   *   Notify client when Scala compiler generates errors,warnings or other notes.
-   * Structure:
-   *   (:scala-notes
-   *   notes //List of Note
-   *   )
-   */
-  //-----------------------
-  /**
-   * Doc Event:
-   *   :java-notes
-   * Summary:
-   *   Notify client when Java compiler generates errors,warnings or other notes.
-   * Structure:
-   *   (:java-notes
-   *   notes //List of Note
-   *   )
-   */
-  def toWF(evt: NewNotesEvent): SExp = {
-    if (evt.lang == 'scala) SExp(key(":scala-notes"), toWF(evt.notelist))
-    else SExp(key(":java-notes"), toWF(evt.notelist))
-  }
-
-  /**
-   * Doc Event:
-   *   :clear-all-scala-notes
-   * Summary:
-   *   Notify client when Scala notes have become invalidated. Editor should consider
-   *   all Scala related notes to be stale at this point.
-   * Structure:
-   *   (:clear-all-scala-notes)
-   */
-  //-----------------------
-  /**
-   * Doc Event:
-   *   :clear-all-java-notes
-   * Summary:
-   *   Notify client when Java notes have become invalidated. Editor should consider
-   *   all Java related notes to be stale at this point.
-   * Structure:
-   *   (:clear-all-java-notes)
-   */
-  def toWF(evt: ClearAllNotesEvent): SExp = {
-    if (evt.lang == 'scala) SExp(key(":clear-all-scala-notes"))
-    else SExp(key(":clear-all-java-notes"))
-  }
-
-  def toWF(evt: DebugEvent): SExp = {
-    evt match {
-      /**
-       * Doc Event:
-       *   :debug-event (:type output)
-       * Summary:
-       *   Communicates stdout/stderr of debugged VM to client.
-       * Structure:
-       *   (:debug-event
-       *     (:type //Symbol: output
-       *      :body //String: A chunk of output text
-       *   ))
-       */
-      case DebugOutputEvent(out: String) =>
-        SExp(key(":debug-event"),
-          SExp(key(":type"), 'output,
-            key(":body"), out))
-
-      /**
-       * Doc Event:
-       *   :debug-event (:type step)
-       * Summary:
-       *   Signals that the debugged VM has stepped to a new location and is now
-       *     paused awaiting control.
-       * Structure:
-       *   (:debug-event
-       *     (:type //Symbol: step
-       *      :thread-id //String: The unique thread id of the paused thread.
-       *      :thread-name //String: The informal name of the paused thread.
-       *      :file //String: The source file the VM stepped into.
-       *      :line //Int: The source line the VM stepped to.
-       *   ))
-       */
-      case DebugStepEvent(threadId, threadName, pos) =>
-        SExp(key(":debug-event"),
-          SExp(key(":type"), 'step,
-            key(":thread-id"), threadId.toString,
-            key(":thread-name"), threadName,
-            key(":file"), pos.file.getAbsolutePath,
-            key(":line"), pos.line))
-
-      /**
-       * Doc Event:
-       *   :debug-event (:type breakpoint)
-       * Summary:
-       *   Signals that the debugged VM has stopped at a breakpoint.
-       * Structure:
-       *   (:debug-event
-       *     (:type //Symbol: breakpoint
-       *      :thread-id //String: The unique thread id of the paused thread.
-       *      :thread-name //String: The informal name of the paused thread.
-       *      :file //String: The source file the VM stepped into.
-       *      :line //Int: The source line the VM stepped to.
-       *   ))
-       */
-      case DebugBreakEvent(threadId, threadName, pos) =>
-        SExp(key(":debug-event"),
-          SExp(key(":type"), 'breakpoint,
-            key(":thread-id"), threadId.toString,
-            key(":thread-name"), threadName,
-            key(":file"), pos.file.getAbsolutePath,
-            key(":line"), pos.line))
-
-      /**
-       * Doc Event:
-       *   :debug-event (:type death)
-       * Summary:
-       *   Signals that the debugged VM has exited.
-       * Structure:
-       *   (:debug-event
-       *     (:type //Symbol: death
-       *   ))
-       */
-      case DebugVMDeathEvent() =>
-        SExp(key(":debug-event"),
-          SExp(key(":type"), 'death))
-
-      /**
-       * Doc Event:
-       *   :debug-event (:type start)
-       * Summary:
-       *   Signals that the debugged VM has started.
-       * Structure:
-       *   (:debug-event
-       *     (:type //Symbol: start
-       *   ))
-       */
-      case DebugVMStartEvent() =>
-        SExp(key(":debug-event"),
-          SExp(key(":type"), 'start))
-
-      /**
-       * Doc Event:
-       *   :debug-event (:type disconnect)
-       * Summary:
-       *   Signals that the debugger has disconnected form the debugged VM.
-       * Structure:
-       *   (:debug-event
-       *     (:type //Symbol: disconnect
-       *   ))
-       */
-      case DebugVMDisconnectEvent() =>
-        SExp(key(":debug-event"),
-          SExp(key(":type"), 'disconnect))
-
-      /**
-       * Doc Event:
-       *   :debug-event (:type exception)
-       * Summary:
-       *   Signals that the debugged VM has thrown an exception and is now paused
-       *     waiting for control.
-       * Structure:
-       *   (:debug-event
-       *     (:type //Symbol: exception
-       *      :exception //String: The unique object id of the exception.
-       *      :thread-id //String: The unique thread id of the paused thread.
-       *      :thread-name //String: The informal name of the paused thread.
-       *      :file //String: The source file where the exception was caught,
-       *         or nil if no location is known.
-       *      :line //Int: The source line where the exception was thrown,
-       *         or nil if no location is known.
-       *   ))
-       */
-      case DebugExceptionEvent(excId, threadId, threadName, maybePos) =>
-        SExp(key(":debug-event"),
-          SExp(key(":type"), 'exception,
-            key(":exception"), excId.toString,
-            key(":thread-id"), threadId.toString,
-            key(":thread-name"), threadName,
-            key(":file"), maybePos.map { p =>
-              StringAtom(p.file.getAbsolutePath)
-            }.getOrElse('nil),
-            key(":line"), maybePos.map { p =>
-              IntAtom(p.line)
-            }.getOrElse('nil)))
-
-      /**
-       * Doc Event:
-       *   :debug-event (:type threadStart)
-       * Summary:
-       *   Signals that a new thread has started.
-       * Structure:
-       *   (:debug-event
-       *     (:type //Symbol: threadStart
-       *      :thread-id //String: The unique thread id of the new thread.
-       *   ))
-       */
-      case DebugThreadStartEvent(threadId: Long) =>
-        SExp(key(":debug-event"),
-          SExp(key(":type"), 'threadStart,
-            key(":thread-id"), threadId.toString))
-
-      /**
-       * Doc Event:
-       *   :debug-event (:type threadDeath)
-       * Summary:
-       *   Signals that a new thread has died.
-       * Structure:
-       *   (:debug-event
-       *     (:type //Symbol: threadDeath
-       *      :thread-id //String: The unique thread id of the new thread.
-       *   ))
-       */
-      case DebugThreadDeathEvent(threadId: Long) =>
-        SExp(key(":debug-event"),
-          SExp(key(":type"), 'threadDeath,
-            key(":thread-id"), threadId.toString))
-      case _ => SExp(key(":debug-event"))
-    }
-
-  }
-
-  def toWF(bp: Breakpoint): SExp = {
-    SExp(
-      key(":file"), bp.pos.file.getAbsolutePath,
-      key(":line"), bp.pos.line)
-  }
-
-  def toWF(bps: BreakpointList): SExp = {
-    SExp(
-      key(":active"), SExpList(bps.active.map { toWF }),
-      key(":pending"), SExpList(bps.pending.map { toWF }))
-  }
-
-  def toWF(config: ProjectConfig): SExp = {
-    SExp(
-      key(":project-name"), config.name.map(StringAtom).getOrElse('nil),
-      key(":source-roots"), SExp(
-        (config.sourceRoots ++ config.referenceSourceRoots).map {
-          f => StringAtom(f.getPath)
-        }))
-  }
-
-  def toWF(config: ReplConfig): SExp = {
-    SExp.propList((":classpath", strToSExp(config.classpath)))
-  }
-
-  def toWF(value: Boolean): SExp = {
-    if (value) TruthAtom()
-    else NilAtom()
-  }
-
-  def toWF(value: Null): SExp = {
-    NilAtom()
-  }
-
-  def toWF(value: String): SExp = {
-    StringAtom(value)
-  }
-
-  def toWF(note: Note): SExp = {
-    SExp(
-      key(":severity"), note.friendlySeverity,
-      key(":msg"), note.msg,
-      key(":beg"), note.beg,
-      key(":end"), note.end,
-      key(":line"), note.line,
-      key(":col"), note.col,
-      key(":file"), note.file)
-  }
-
-  def toWF(notelist: NoteList): SExp = {
-    val NoteList(isFull, notes) = notelist
-    SExp(
-      key(":is-full"),
-      toWF(isFull),
-      key(":notes"),
-      SExpList(notes.map(toWF)))
-  }
-
-  def toWF(values: Iterable[WireFormat]): SExp = {
-    SExpList(values.map(ea => ea.asInstanceOf[SExp]))
-  }
-
-  def toWF(value: CompletionSignature): SExp = {
-    SExp(
-      SExp(value.sections.map { section =>
-        SExpList(section.map { param =>
-          SExp(param._1, param._2)
-        })
-      }),
-      value.result)
-  }
-
-  def toWF(value: CompletionInfo): SExp = {
-    SExp.propList(
-      (":name", value.name),
-      (":type-sig", toWF(value.tpeSig)),
-      (":type-id", value.tpeId),
-      (":is-callable", value.isCallable),
-      (":to-insert", value.toInsert.map(strToSExp).getOrElse('nil)))
-  }
-
-  def toWF(value: CompletionInfoList): SExp = {
-    SExp.propList(
-      (":prefix", value.prefix),
-      (":completions", SExpList(value.completions.map(toWF))))
-  }
-
-  def toWF(value: PackageMemberInfoLight): SExp = {
-    SExp(key(":name"), value.name)
-  }
-
-  def toWF(value: SymbolInfo): SExp = {
-    SExp.propList(
-      (":name", value.name),
-      (":local-name", value.localName),
-      (":type", toWF(value.tpe)),
-      (":decl-pos", value.declPos),
-      (":is-callable", value.isCallable),
-      (":owner-type-id", value.ownerTypeId.map(intToSExp).getOrElse('nil)))
-  }
-
-  def toWF(value: FileRange): SExp = {
-    SExp.propList(
-      (":file", value.file),
-      (":start", value.start),
-      (":end", value.end))
-  }
-
-  def toWF(value: Position): SExp = {
-    posToSExp(value)
-  }
-
-  def toWF(value: RangePosition): SExp = {
-    posToSExp(value)
-  }
-
-  def toWF(value: NamedTypeMemberInfoLight): SExp = {
-    SExp.propList(
-      (":name", value.name),
-      (":type-sig", value.tpeSig),
-      (":type-id", value.tpeId),
-      (":is-callable", value.isCallable))
-  }
-
-  override def toWF(value: NamedTypeMemberInfo): SExp = {
-    SExp.propList(
-      (":name", value.name),
-      (":type", toWF(value.tpe)),
-      (":pos", value.pos),
-      (":decl-as", value.declaredAs))
-  }
-
-  override def toWF(value: EntityInfo): SExp = {
-    value match {
-      case value: PackageInfo => toWF(value)
-      case value: TypeInfo => toWF(value)
-      case value: NamedTypeMemberInfo => toWF(value)
-      case value: NamedTypeMemberInfoLight => toWF(value)
-      case unknownValue => throw new IllegalStateException("Unknown EntityInfo: " + unknownValue)
-    }
-  }
-
-  def toWF(value: TypeInfo): SExp = {
-    value match {
-      case value: ArrowTypeInfo =>
-        SExp.propList(
-          (":name", value.name),
-          (":type-id", value.id),
-          (":arrow-type", true),
-          (":result-type", toWF(value.resultType)),
-          (":param-sections", SExp(value.paramSections.map(toWF))))
-      case value: TypeInfo =>
-        SExp.propList((":name", value.name),
-          (":type-id", value.id),
-          (":full-name", value.fullName),
-          (":decl-as", value.declaredAs),
-          (":type-args", SExp(value.args.map(toWF))),
-          (":members", SExp(value.members.map(toWF))),
-          (":pos", value.pos),
-          (":outer-type-id", value.outerTypeId.map(intToSExp).getOrElse('nil)))
-      case unknownValue => throw new IllegalStateException("Unknown TypeInfo: " + unknownValue)
-    }
-  }
-
-  def toWF(value: PackageInfo): SExp = {
-    SExp.propList((":name", value.name),
-      (":info-type", 'package),
-      (":full-name", value.fullname),
-      (":members", SExpList(value.members.map(toWF))))
-  }
-
-  def toWF(value: CallCompletionInfo): SExp = {
-    SExp.propList(
-      (":result-type", toWF(value.resultType)),
-      (":param-sections", SExp(value.paramSections.map(toWF))))
-  }
-
-  def toWF(value: ParamSectionInfo): SExp = {
-    SExp.propList(
-      (":params", SExp(value.params.map {
-        case (nm, tp) => SExp(nm, toWF(tp))
-      })),
-      (":is-implicit", value.isImplicit))
-
-  }
-
-  def toWF(value: InterfaceInfo): SExp = {
-    SExp.propList(
-      (":type", toWF(value.tpe)),
-      (":via-view", value.viaView.map(strToSExp).getOrElse('nil)))
-  }
-
-  def toWF(value: TypeInspectInfo): SExp = {
-    SExp.propList(
-      (":type", toWF(value.tpe)),
-      (":info-type", 'typeInspect),
-      (":companion-id", value.companionId match {
-        case Some(id) => id
-        case None => 'nil
-      }), (":interfaces", SExp(value.supers.map(toWF))))
-  }
-
-  def toWF(value: RefactorFailure): SExp = {
-    SExp.propList(
-      (":procedure-id", value.procedureId),
-      (":status", 'failure),
-      (":reason", value.message))
-  }
-
-  def toWF(value: RefactorEffect): SExp = {
-    SExp.propList(
-      (":procedure-id", value.procedureId),
-      (":refactor-type", value.refactorType),
-      (":status", 'success),
-      (":changes", SExpList(value.changes.map(changeToWF))))
-  }
-
-  def toWF(value: RefactorResult): SExp = {
-    SExp.propList(
-      (":procedure-id", value.procedureId),
-      (":refactor-type", value.refactorType),
-      (":status", 'success),
-      (":touched-files", SExpList(value.touched.map(f => strToSExp(f.getAbsolutePath)))))
-  }
-
-  def toWF(value: SymbolSearchResults): SExp = {
-    SExpList(value.syms.map(toWF))
-  }
-
-  def toWF(value: ImportSuggestions): SExp = {
-    SExpList(value.symLists.map { l => SExpList(l.map(toWF)) })
-  }
-
-  private def toWF(pos: Option[(String, Int)]): SExp = {
-    pos match {
-      case Some((f, o)) => SExp.propList((":file", f), (":offset", o))
-      case _ => 'nil
-    }
-  }
-
-  def toWF(value: SymbolSearchResult): SExp = {
-    value match {
-      case value: TypeSearchResult =>
-        SExp.propList(
-          (":name", value.name),
-          (":local-name", value.localName),
-          (":decl-as", value.declaredAs),
-          (":pos", toWF(value.pos)))
-      case value: MethodSearchResult =>
-        SExp.propList(
-          (":name", value.name),
-          (":local-name", value.localName),
-          (":decl-as", value.declaredAs),
-          (":pos", toWF(value.pos)),
-          (":owner-name", value.owner))
-    }
-  }
-
-  def toWF(value: Undo): SExp = {
-    SExp.propList(
-      (":id", value.id),
-      (":changes", SExpList(value.changes.map(changeToWF))),
-      (":summary", value.summary))
-  }
-
-  def toWF(value: UndoResult): SExp = {
-    SExp.propList(
-      (":id", value.id),
-      (":touched-files", SExpList(value.touched.map(f => strToSExp(f.getAbsolutePath)))))
-  }
-
-  def toWF(value: SymbolDesignations): SExp = {
-    SExp.propList(
-      (":file", value.file),
-      (":syms",
-        SExpList(value.syms.map { s =>
-          SExpList(List(s.symType, s.start, s.end))
-        })))
-  }
-
-  def toWF(vmStatus: DebugVmStatus): SExp = {
-    vmStatus match {
-      case DebugVmSuccess() => SExp(
-        key(":status"), "success")
-      case DebugVmError(code, details) => SExp(
-        key(":status"), "error",
-        key(":error-code"), code,
-        key(":details"), details)
-    }
-  }
-
-  def toWF(method: MethodBytecode): SExp = {
-    SExp.propList(
-      (":class-name", method.className),
-      (":name", method.methodName),
-      (":signature", method.methodSignature.map(strToSExp).getOrElse('nil)),
-      (":bytecode", SExpList(method.byteCode.map { op =>
-        SExp(op.op, op.description)
-      })))
-  }
-
-  private def changeToWF(ch: FileEdit): SExp = {
-    SExp.propList(
-      (":file", ch.file.getCanonicalPath),
-      (":text", ch.text),
-      (":from", ch.from),
-      (":to", ch.to))
   }
 
 }

--- a/src/main/scala/org/ensime/protocol/SwankProtocolConversions.scala
+++ b/src/main/scala/org/ensime/protocol/SwankProtocolConversions.scala
@@ -1,0 +1,718 @@
+package org.ensime.protocol
+
+import org.ensime.config.{ ReplConfig, ProjectConfig }
+import org.ensime.indexer.MethodBytecode
+import org.ensime.model._
+import org.ensime.protocol.SExpConversion._
+import org.ensime.server._
+import org.ensime.util._
+import org.ensime.util.SExp._
+
+import scala.reflect.internal.util.{ RangePosition, Position }
+
+class SwankProtocolConversions extends ProtocolConversions {
+
+  override def toWF(obj: DebugLocation): SExp = {
+    obj match {
+      case obj: DebugObjectReference => toWF(obj)
+      case obj: DebugArrayElement => toWF(obj)
+      case obj: DebugObjectField => toWF(obj)
+      case obj: DebugStackSlot => toWF(obj)
+    }
+  }
+  def toWF(obj: DebugObjectReference): SExp = {
+    SExp(
+      key(":type"), 'reference,
+      key(":object-id"), obj.objectId.toString)
+  }
+  def toWF(obj: DebugArrayElement): SExp = {
+    SExp(
+      key(":type"), 'element,
+      key(":object-id"), obj.objectId.toString,
+      key(":index"), obj.index)
+  }
+  def toWF(obj: DebugObjectField): SExp = {
+    SExp(
+      key(":type"), 'field,
+      key(":object-id"), obj.objectId.toString,
+      key(":field"), obj.name)
+  }
+  def toWF(obj: DebugStackSlot): SExp = {
+    SExp(
+      key(":type"), 'slot,
+      key(":thread-id"), obj.threadId.toString,
+      key(":frame"), obj.frame,
+      key(":offset"), obj.offset)
+  }
+
+  override def toWF(obj: DebugValue): SExp = {
+    obj match {
+      case obj: DebugPrimitiveValue => toWF(obj)
+      case obj: DebugObjectInstance => toWF(obj)
+      case obj: DebugArrayInstance => toWF(obj)
+      case obj: DebugStringInstance => toWF(obj)
+      case obj: DebugNullValue => toWF(obj)
+    }
+  }
+
+  override def toWF(obj: DebugNullValue): SExp = {
+    SExp(
+      key(":val-type"), 'null,
+      key(":type-name"), obj.typeName)
+  }
+
+  override def toWF(obj: DebugPrimitiveValue): SExp = {
+    SExp(
+      key(":val-type"), 'prim,
+      key(":summary"), obj.summary,
+      key(":type-name"), obj.typeName)
+  }
+
+  override def toWF(obj: DebugClassField): SExp = {
+    SExp(
+      key(":index"), obj.index,
+      key(":name"), obj.name,
+      key(":summary"), obj.summary,
+      key(":type-name"), obj.typeName)
+  }
+
+  override def toWF(obj: DebugObjectInstance): SExp = {
+    SExp(
+      key(":val-type"), 'obj,
+      key(":fields"), SExpList(obj.fields.map(toWF)),
+      key(":type-name"), obj.typeName,
+      key(":object-id"), obj.objectId.toString)
+  }
+
+  override def toWF(obj: DebugStringInstance): SExp = {
+    SExp(
+      key(":val-type"), 'str,
+      key(":summary"), obj.summary,
+      key(":fields"), SExpList(obj.fields.map(toWF)),
+      key(":type-name"), obj.typeName,
+      key(":object-id"), obj.objectId.toString)
+  }
+
+  override def toWF(obj: DebugArrayInstance): SExp = {
+    SExp(
+      key(":val-type"), 'arr,
+      key(":length"), obj.length,
+      key(":type-name"), obj.typeName,
+      key(":element-type-name"), obj.elementTypeName,
+      key(":object-id"), obj.objectId.toString)
+  }
+
+  override def toWF(obj: DebugStackLocal): SExp = {
+    SExp(
+      key(":index"), obj.index,
+      key(":name"), obj.name,
+      key(":summary"), obj.summary,
+      key(":type-name"), obj.typeName)
+  }
+
+  override def toWF(obj: DebugStackFrame): SExp = {
+    SExp(
+      key(":index"), obj.index,
+      key(":locals"), SExpList(obj.locals.map(toWF)),
+      key(":num-args"), obj.numArguments,
+      key(":class-name"), obj.className,
+      key(":method-name"), obj.methodName,
+      key(":pc-location"), toWF(obj.pcLocation),
+      key(":this-object-id"), obj.thisObjectId.toString)
+  }
+
+  override def toWF(obj: DebugBacktrace): SExp = {
+    SExp(
+      key(":frames"), SExpList(obj.frames.map(toWF)),
+      key(":thread-id"), obj.threadId.toString,
+      key(":thread-name"), obj.threadName)
+  }
+
+  override def toWF(pos: SourcePosition): SExp = {
+    SExp(
+      key(":file"), pos.file.getAbsolutePath,
+      key(":line"), pos.line)
+  }
+
+  override def toWF(info: ConnectionInfo): SExp = {
+    SExp(
+      key(":pid"), 'nil,
+      key(":implementation"),
+      SExp(key(":name"), info.serverName),
+      key(":version"), info.protocolVersion)
+  }
+
+  override def toWF(evt: SendBackgroundMessageEvent): SExp = {
+    SExp(key(":background-message"), evt.code,
+      evt.detail.map(strToSExp).getOrElse(NilAtom()))
+  }
+
+  /**
+   * Doc Event:
+   *   :compiler-ready
+   * Summary:
+   *   Signal that the compiler has finished its initial compilation and the server
+   *   is ready to accept RPC calls.
+   * Structure:
+   *   (:compiler-ready)
+   */
+  def toWF(evt: AnalyzerReadyEvent): SExp = {
+    SExp(key(":compiler-ready"))
+  }
+
+  /**
+   * Doc Event:
+   *   :full-typecheck-finished
+   * Summary:
+   *   Signal that the compiler has finished compilation of the entire project.
+   * Structure:
+   *   (:full-typecheck-finished)
+   */
+  def toWF(evt: FullTypeCheckCompleteEvent): SExp = {
+    SExp(key(":full-typecheck-finished"))
+  }
+
+  /**
+   * Doc Event:
+   *   :indexer-ready
+   * Summary:
+   *   Signal that the indexer has finished indexing the classpath.
+   * Structure:
+   *   (:indexer-ready)
+   */
+  def toWF(evt: IndexerReadyEvent): SExp = {
+    SExp(key(":indexer-ready"))
+  }
+
+  /**
+   * Doc Event:
+   *   :scala-notes
+   * Summary:
+   *   Notify client when Scala compiler generates errors,warnings or other notes.
+   * Structure:
+   *   (:scala-notes
+   *   notes //List of Note
+   *   )
+   */
+  //-----------------------
+  /**
+   * Doc Event:
+   *   :java-notes
+   * Summary:
+   *   Notify client when Java compiler generates errors,warnings or other notes.
+   * Structure:
+   *   (:java-notes
+   *   notes //List of Note
+   *   )
+   */
+  override def toWF(evt: NewNotesEvent): SExp = {
+    if (evt.lang == 'scala) SExp(key(":scala-notes"), toWF(evt.notelist))
+    else SExp(key(":java-notes"), toWF(evt.notelist))
+  }
+
+  /**
+   * Doc Event:
+   *   :clear-all-scala-notes
+   * Summary:
+   *   Notify client when Scala notes have become invalidated. Editor should consider
+   *   all Scala related notes to be stale at this point.
+   * Structure:
+   *   (:clear-all-scala-notes)
+   */
+  //-----------------------
+  /**
+   * Doc Event:
+   *   :clear-all-java-notes
+   * Summary:
+   *   Notify client when Java notes have become invalidated. Editor should consider
+   *   all Java related notes to be stale at this point.
+   * Structure:
+   *   (:clear-all-java-notes)
+   */
+  override def toWF(evt: ClearAllNotesEvent): SExp = {
+    if (evt.lang == 'scala) SExp(key(":clear-all-scala-notes"))
+    else SExp(key(":clear-all-java-notes"))
+  }
+
+  override def toWF(evt: DebugEvent): SExp = {
+    evt match {
+      /**
+       * Doc Event:
+       *   :debug-event (:type output)
+       * Summary:
+       *   Communicates stdout/stderr of debugged VM to client.
+       * Structure:
+       *   (:debug-event
+       *     (:type //Symbol: output
+       *      :body //String: A chunk of output text
+       *   ))
+       */
+      case DebugOutputEvent(out: String) =>
+        SExp(key(":debug-event"),
+          SExp(key(":type"), 'output,
+            key(":body"), out))
+
+      /**
+       * Doc Event:
+       *   :debug-event (:type step)
+       * Summary:
+       *   Signals that the debugged VM has stepped to a new location and is now
+       *     paused awaiting control.
+       * Structure:
+       *   (:debug-event
+       *     (:type //Symbol: step
+       *      :thread-id //String: The unique thread id of the paused thread.
+       *      :thread-name //String: The informal name of the paused thread.
+       *      :file //String: The source file the VM stepped into.
+       *      :line //Int: The source line the VM stepped to.
+       *   ))
+       */
+      case DebugStepEvent(threadId, threadName, pos) =>
+        SExp(key(":debug-event"),
+          SExp(key(":type"), 'step,
+            key(":thread-id"), threadId.toString,
+            key(":thread-name"), threadName,
+            key(":file"), pos.file.getAbsolutePath,
+            key(":line"), pos.line))
+
+      /**
+       * Doc Event:
+       *   :debug-event (:type breakpoint)
+       * Summary:
+       *   Signals that the debugged VM has stopped at a breakpoint.
+       * Structure:
+       *   (:debug-event
+       *     (:type //Symbol: breakpoint
+       *      :thread-id //String: The unique thread id of the paused thread.
+       *      :thread-name //String: The informal name of the paused thread.
+       *      :file //String: The source file the VM stepped into.
+       *      :line //Int: The source line the VM stepped to.
+       *   ))
+       */
+      case DebugBreakEvent(threadId, threadName, pos) =>
+        SExp(key(":debug-event"),
+          SExp(key(":type"), 'breakpoint,
+            key(":thread-id"), threadId.toString,
+            key(":thread-name"), threadName,
+            key(":file"), pos.file.getAbsolutePath,
+            key(":line"), pos.line))
+
+      /**
+       * Doc Event:
+       *   :debug-event (:type death)
+       * Summary:
+       *   Signals that the debugged VM has exited.
+       * Structure:
+       *   (:debug-event
+       *     (:type //Symbol: death
+       *   ))
+       */
+      case DebugVMDeathEvent() =>
+        SExp(key(":debug-event"),
+          SExp(key(":type"), 'death))
+
+      /**
+       * Doc Event:
+       *   :debug-event (:type start)
+       * Summary:
+       *   Signals that the debugged VM has started.
+       * Structure:
+       *   (:debug-event
+       *     (:type //Symbol: start
+       *   ))
+       */
+      case DebugVMStartEvent() =>
+        SExp(key(":debug-event"),
+          SExp(key(":type"), 'start))
+
+      /**
+       * Doc Event:
+       *   :debug-event (:type disconnect)
+       * Summary:
+       *   Signals that the debugger has disconnected form the debugged VM.
+       * Structure:
+       *   (:debug-event
+       *     (:type //Symbol: disconnect
+       *   ))
+       */
+      case DebugVMDisconnectEvent() =>
+        SExp(key(":debug-event"),
+          SExp(key(":type"), 'disconnect))
+
+      /**
+       * Doc Event:
+       *   :debug-event (:type exception)
+       * Summary:
+       *   Signals that the debugged VM has thrown an exception and is now paused
+       *     waiting for control.
+       * Structure:
+       *   (:debug-event
+       *     (:type //Symbol: exception
+       *      :exception //String: The unique object id of the exception.
+       *      :thread-id //String: The unique thread id of the paused thread.
+       *      :thread-name //String: The informal name of the paused thread.
+       *      :file //String: The source file where the exception was caught,
+       *         or nil if no location is known.
+       *      :line //Int: The source line where the exception was thrown,
+       *         or nil if no location is known.
+       *   ))
+       */
+      case DebugExceptionEvent(excId, threadId, threadName, maybePos) =>
+        SExp(key(":debug-event"),
+          SExp(key(":type"), 'exception,
+            key(":exception"), excId.toString,
+            key(":thread-id"), threadId.toString,
+            key(":thread-name"), threadName,
+            key(":file"), maybePos.map { p =>
+              StringAtom(p.file.getAbsolutePath)
+            }.getOrElse('nil),
+            key(":line"), maybePos.map { p =>
+              IntAtom(p.line)
+            }.getOrElse('nil)))
+
+      /**
+       * Doc Event:
+       *   :debug-event (:type threadStart)
+       * Summary:
+       *   Signals that a new thread has started.
+       * Structure:
+       *   (:debug-event
+       *     (:type //Symbol: threadStart
+       *      :thread-id //String: The unique thread id of the new thread.
+       *   ))
+       */
+      case DebugThreadStartEvent(threadId: Long) =>
+        SExp(key(":debug-event"),
+          SExp(key(":type"), 'threadStart,
+            key(":thread-id"), threadId.toString))
+
+      /**
+       * Doc Event:
+       *   :debug-event (:type threadDeath)
+       * Summary:
+       *   Signals that a new thread has died.
+       * Structure:
+       *   (:debug-event
+       *     (:type //Symbol: threadDeath
+       *      :thread-id //String: The unique thread id of the new thread.
+       *   ))
+       */
+      case DebugThreadDeathEvent(threadId: Long) =>
+        SExp(key(":debug-event"),
+          SExp(key(":type"), 'threadDeath,
+            key(":thread-id"), threadId.toString))
+      case _ => SExp(key(":debug-event"))
+    }
+
+  }
+
+  def toWF(bp: Breakpoint): SExp = {
+    SExp(
+      key(":file"), bp.pos.file.getAbsolutePath,
+      key(":line"), bp.pos.line)
+  }
+
+  override def toWF(bps: BreakpointList): SExp = {
+    SExp(
+      key(":active"), SExpList(bps.active.map { toWF }),
+      key(":pending"), SExpList(bps.pending.map { toWF }))
+  }
+
+  override def toWF(config: ProjectConfig): SExp = {
+    SExp(
+      key(":project-name"), config.name.map(StringAtom).getOrElse('nil),
+      key(":source-roots"), SExp(
+        (config.sourceRoots ++ config.referenceSourceRoots).map {
+          f => StringAtom(f.getPath)
+        }))
+  }
+
+  override def toWF(config: ReplConfig): SExp = {
+    SExp.propList((":classpath", strToSExp(config.classpath)))
+  }
+
+  override def toWF(value: Boolean): SExp = {
+    if (value) TruthAtom()
+    else NilAtom()
+  }
+
+  override def toWF(value: Null): SExp = {
+    NilAtom()
+  }
+
+  override def toWF(value: String): SExp = {
+    StringAtom(value)
+  }
+
+  override def toWF(note: Note): SExp = {
+    SExp(
+      key(":severity"), note.friendlySeverity,
+      key(":msg"), note.msg,
+      key(":beg"), note.beg,
+      key(":end"), note.end,
+      key(":line"), note.line,
+      key(":col"), note.col,
+      key(":file"), note.file)
+  }
+
+  override def toWF(notelist: NoteList): SExp = {
+    val NoteList(isFull, notes) = notelist
+    SExp(
+      key(":is-full"),
+      toWF(isFull),
+      key(":notes"),
+      SExpList(notes.map(toWF)))
+  }
+
+  override def toWF(values: Iterable[WireFormat]): SExp = {
+    SExpList(values.map(ea => ea.asInstanceOf[SExp]))
+  }
+
+  def toWF(value: CompletionSignature): SExp = {
+    SExp(
+      SExp(value.sections.map { section =>
+        SExpList(section.map { param =>
+          SExp(param._1, param._2)
+        })
+      }),
+      value.result)
+  }
+
+  override def toWF(value: CompletionInfo): SExp = {
+    SExp.propList(
+      (":name", value.name),
+      (":type-sig", toWF(value.tpeSig)),
+      (":type-id", value.tpeId),
+      (":is-callable", value.isCallable),
+      (":to-insert", value.toInsert.map(strToSExp).getOrElse('nil)))
+  }
+
+  override def toWF(value: CompletionInfoList): SExp = {
+    SExp.propList(
+      (":prefix", value.prefix),
+      (":completions", SExpList(value.completions.map(toWF))))
+  }
+
+  def toWF(value: PackageMemberInfoLight): SExp = {
+    SExp(key(":name"), value.name)
+  }
+
+  def toWF(value: SymbolInfo): SExp = {
+    SExp.propList(
+      (":name", value.name),
+      (":local-name", value.localName),
+      (":type", toWF(value.tpe)),
+      (":decl-pos", value.declPos),
+      (":is-callable", value.isCallable),
+      (":owner-type-id", value.ownerTypeId.map(intToSExp).getOrElse('nil)))
+  }
+
+  def toWF(value: FileRange): SExp = {
+    SExp.propList(
+      (":file", value.file),
+      (":start", value.start),
+      (":end", value.end))
+  }
+
+  def toWF(value: Position): SExp = {
+    posToSExp(value)
+  }
+
+  def toWF(value: RangePosition): SExp = {
+    posToSExp(value)
+  }
+
+  def toWF(value: NamedTypeMemberInfoLight): SExp = {
+    SExp.propList(
+      (":name", value.name),
+      (":type-sig", value.tpeSig),
+      (":type-id", value.tpeId),
+      (":is-callable", value.isCallable))
+  }
+
+  override def toWF(value: NamedTypeMemberInfo): SExp = {
+    SExp.propList(
+      (":name", value.name),
+      (":type", toWF(value.tpe)),
+      (":pos", value.pos),
+      (":decl-as", value.declaredAs))
+  }
+
+  override def toWF(value: EntityInfo): SExp = {
+    value match {
+      case value: PackageInfo => toWF(value)
+      case value: TypeInfo => toWF(value)
+      case value: NamedTypeMemberInfo => toWF(value)
+      case value: NamedTypeMemberInfoLight => toWF(value)
+      case unknownValue => throw new IllegalStateException("Unknown EntityInfo: " + unknownValue)
+    }
+  }
+
+  def toWF(value: TypeInfo): SExp = {
+    value match {
+      case value: ArrowTypeInfo =>
+        SExp.propList(
+          (":name", value.name),
+          (":type-id", value.id),
+          (":arrow-type", true),
+          (":result-type", toWF(value.resultType)),
+          (":param-sections", SExp(value.paramSections.map(toWF))))
+      case value: TypeInfo =>
+        SExp.propList((":name", value.name),
+          (":type-id", value.id),
+          (":full-name", value.fullName),
+          (":decl-as", value.declaredAs),
+          (":type-args", SExp(value.args.map(toWF))),
+          (":members", SExp(value.members.map(toWF))),
+          (":pos", value.pos),
+          (":outer-type-id", value.outerTypeId.map(intToSExp).getOrElse('nil)))
+      case unknownValue => throw new IllegalStateException("Unknown TypeInfo: " + unknownValue)
+    }
+  }
+
+  def toWF(value: PackageInfo): SExp = {
+    SExp.propList((":name", value.name),
+      (":info-type", 'package),
+      (":full-name", value.fullname),
+      (":members", SExpList(value.members.map(toWF))))
+  }
+
+  def toWF(value: CallCompletionInfo): SExp = {
+    SExp.propList(
+      (":result-type", toWF(value.resultType)),
+      (":param-sections", SExp(value.paramSections.map(toWF))))
+  }
+
+  def toWF(value: ParamSectionInfo): SExp = {
+    SExp.propList(
+      (":params", SExp(value.params.map {
+        case (nm, tp) => SExp(nm, toWF(tp))
+      })),
+      (":is-implicit", value.isImplicit))
+
+  }
+
+  def toWF(value: InterfaceInfo): SExp = {
+    SExp.propList(
+      (":type", toWF(value.tpe)),
+      (":via-view", value.viaView.map(strToSExp).getOrElse('nil)))
+  }
+
+  def toWF(value: TypeInspectInfo): SExp = {
+    SExp.propList(
+      (":type", toWF(value.tpe)),
+      (":info-type", 'typeInspect),
+      (":companion-id", value.companionId match {
+        case Some(id) => id
+        case None => 'nil
+      }), (":interfaces", SExp(value.supers.map(toWF))))
+  }
+
+  def toWF(value: RefactorFailure): SExp = {
+    SExp.propList(
+      (":procedure-id", value.procedureId),
+      (":status", 'failure),
+      (":reason", value.message))
+  }
+
+  def toWF(value: RefactorEffect): SExp = {
+    SExp.propList(
+      (":procedure-id", value.procedureId),
+      (":refactor-type", value.refactorType),
+      (":status", 'success),
+      (":changes", SExpList(value.changes.map(changeToWF))))
+  }
+
+  def toWF(value: RefactorResult): SExp = {
+    SExp.propList(
+      (":procedure-id", value.procedureId),
+      (":refactor-type", value.refactorType),
+      (":status", 'success),
+      (":touched-files", SExpList(value.touched.map(f => strToSExp(f.getAbsolutePath)))))
+  }
+
+  def toWF(value: SymbolSearchResults): SExp = {
+    SExpList(value.syms.map(toWF))
+  }
+
+  def toWF(value: ImportSuggestions): SExp = {
+    SExpList(value.symLists.map { l => SExpList(l.map(toWF)) })
+  }
+
+  private def toWF(pos: Option[(String, Int)]): SExp = {
+    pos match {
+      case Some((f, o)) => SExp.propList((":file", f), (":offset", o))
+      case _ => 'nil
+    }
+  }
+
+  def toWF(value: SymbolSearchResult): SExp = {
+    value match {
+      case value: TypeSearchResult =>
+        SExp.propList(
+          (":name", value.name),
+          (":local-name", value.localName),
+          (":decl-as", value.declaredAs),
+          (":pos", toWF(value.pos)))
+      case value: MethodSearchResult =>
+        SExp.propList(
+          (":name", value.name),
+          (":local-name", value.localName),
+          (":decl-as", value.declaredAs),
+          (":pos", toWF(value.pos)),
+          (":owner-name", value.owner))
+    }
+  }
+
+  def toWF(value: Undo): SExp = {
+    SExp.propList(
+      (":id", value.id),
+      (":changes", SExpList(value.changes.map(changeToWF))),
+      (":summary", value.summary))
+  }
+
+  def toWF(value: UndoResult): SExp = {
+    SExp.propList(
+      (":id", value.id),
+      (":touched-files", SExpList(value.touched.map(f => strToSExp(f.getAbsolutePath)))))
+  }
+
+  def toWF(value: SymbolDesignations): SExp = {
+    SExp.propList(
+      (":file", value.file),
+      (":syms",
+        SExpList(value.syms.map { s =>
+          SExpList(List(s.symType, s.start, s.end))
+        })))
+  }
+
+  def toWF(vmStatus: DebugVmStatus): SExp = {
+    vmStatus match {
+      case DebugVmSuccess() => SExp(
+        key(":status"), "success")
+      case DebugVmError(code, details) => SExp(
+        key(":status"), "error",
+        key(":error-code"), code,
+        key(":details"), details)
+    }
+  }
+
+  def toWF(method: MethodBytecode): SExp = {
+    SExp.propList(
+      (":class-name", method.className),
+      (":name", method.methodName),
+      (":signature", method.methodSignature.map(strToSExp).getOrElse('nil)),
+      (":bytecode", SExpList(method.byteCode.map { op =>
+        SExp(op.op, op.description)
+      })))
+  }
+
+  private def changeToWF(ch: FileEdit): SExp = {
+    SExp.propList(
+      (":file", ch.file.getCanonicalPath),
+      (":text", ch.text),
+      (":from", ch.from),
+      (":to", ch.to))
+  }
+
+}

--- a/src/main/scala/org/ensime/protocol/messages.scala
+++ b/src/main/scala/org/ensime/protocol/messages.scala
@@ -1,0 +1,8 @@
+
+
+case class RPCRequest(data: RPCCall, callId: Int)
+
+sealed trait RPCCall
+
+case class ExecUndoRequest(id: Int) extends RPCCall
+

--- a/src/main/scala/org/ensime/server/Analyzer.scala
+++ b/src/main/scala/org/ensime/server/Analyzer.scala
@@ -1,6 +1,7 @@
 package org.ensime.server
 
 import java.io.File
+import akka.actor.{ Actor, ActorRef }
 import org.ensime.config.ProjectConfig
 import org.ensime.model.SourceFileInfo
 import org.ensime.model.SymbolDesignations
@@ -8,7 +9,7 @@ import org.ensime.model.OffsetRange
 import org.ensime.protocol.ProtocolConversions
 import org.ensime.protocol.ProtocolConst._
 import org.ensime.util._
-import scala.actors._
+import scala.concurrent.Future
 import scala.tools.nsc.util.RangePosition
 import scala.tools.nsc.Settings
 import scala.tools.nsc.util.OffsetPosition
@@ -18,7 +19,7 @@ case class CompilerFatalError(e: Throwable)
 
 class Analyzer(
   val project: Project,
-  val indexer: Actor,
+  val indexer: ActorRef,
   val protocol: ProtocolConversions,
   val config: ProjectConfig)
     extends Actor with RefactoringHandler {
@@ -55,7 +56,7 @@ class Analyzer(
   private val reporter = new PresentationReporter(reportHandler)
 
   protected val scalaCompiler: RichCompilerControl = new RichPresentationCompiler(
-    settings, reporter, this, indexer, config)
+    settings, reporter, self, indexer, config)
   protected val javaCompiler: JavaCompiler = new JavaCompiler(
     config, reportHandler, indexer)
   protected var awaitingInitialCompile = true
@@ -63,222 +64,229 @@ class Analyzer(
 
   import scalaCompiler._
 
-  def act() {
+  override def preStart(): Unit = {
     project.bgMessage("Initializing Analyzer. Please wait...")
     initTime = System.currentTimeMillis()
 
-    if (!config.disableSourceLoadOnStartup) {
-      println("Building Java sources...")
-      javaCompiler.compileAll()
-      println("Building Scala sources...")
-      reporter.disable()
-      scalaCompiler.askReloadAllFiles()
-      scalaCompiler.askNotifyWhenReady()
-    } else {
-      this ! FullTypeCheckCompleteEvent()
+    implicit val ec = context.dispatcher
+
+    Future {
+      if (!config.disableSourceLoadOnStartup) {
+        println("Building Java sources...")
+        javaCompiler.compileAll()
+        println("Building Scala sources...")
+        reporter.disable()
+        scalaCompiler.askReloadAllFiles()
+        scalaCompiler.askNotifyWhenReady()
+      } else {
+        self ! FullTypeCheckCompleteEvent()
+      }
     }
+  }
 
-    loop {
+  override def receive = {
+    case x: Any =>
       try {
-        receive {
-          case AnalyzerShutdownEvent() =>
-            javaCompiler.shutdown()
-            scalaCompiler.askClearTypeCache()
-            scalaCompiler.askShutdown()
-            exit('stop)
-
-          case FullTypeCheckCompleteEvent() =>
-            if (awaitingInitialCompile) {
-              awaitingInitialCompile = false
-              val elapsed = System.currentTimeMillis() - initTime
-              println("Analyzer ready in " + elapsed / 1000.0 + " seconds.")
-              reporter.enable()
-              project ! AsyncEvent(toWF(AnalyzerReadyEvent()))
-              indexer ! CommitReq()
-            }
-            project ! AsyncEvent(toWF(FullTypeCheckCompleteEvent()))
-
-          case rpcReq @ RPCRequestEvent(req: Any, callId: Int) =>
-            try {
-              if (awaitingInitialCompile) {
-                project.sendRPCError(ErrAnalyzerNotReady,
-                  Some("Analyzer is not ready! Please wait."), callId)
-              } else {
-
-                reporter.enable()
-
-                req match {
-
-                  case RemoveFileReq(file: File) =>
-                    askRemoveDeleted(file)
-                    project ! RPCResultEvent(toWF(value = true), callId)
-
-                  case ReloadAllReq() =>
-                    javaCompiler.reset()
-                    javaCompiler.compileAll()
-                    scalaCompiler.askRemoveAllDeleted()
-                    scalaCompiler.askReloadAllFiles()
-                    scalaCompiler.askNotifyWhenReady()
-                    project ! RPCResultEvent(toWF(value = true), callId)
-
-                  case ReloadFilesReq(files) =>
-                    val (javas, scalas) = files.filter(_.file.exists).partition(
-                      _.file.getName.endsWith(".java"))
-                    if (javas.nonEmpty) {
-                      javaCompiler.compileFiles(javas)
-                    }
-                    if (scalas.nonEmpty) {
-                      scalaCompiler.askReloadFiles(scalas.map(createSourceFile))
-                      scalaCompiler.askNotifyWhenReady()
-                      project ! RPCResultEvent(toWF(value = true), callId)
-                    }
-
-                  case PatchSourceReq(file, edits) =>
-                    if (!file.exists()) {
-                      project.sendRPCError(ErrFileDoesNotExist,
-                        Some(file.getPath), callId)
-                    } else {
-                      val f = createSourceFile(file)
-                      val revised = PatchSource.applyOperations(f, edits)
-                      reporter.disable()
-                      scalaCompiler.askReloadFile(revised)
-                      project ! RPCResultEvent(toWF(value = true), callId)
-                    }
-
-                  case req: RefactorPerformReq =>
-                    handleRefactorRequest(req, callId)
-
-                  case req: RefactorExecReq =>
-                    handleRefactorExec(req, callId)
-
-                  case req: RefactorCancelReq =>
-                    handleRefactorCancel(req, callId)
-
-                  case CompletionsReq(file: File, point: Int,
-                    maxResults: Int, caseSens: Boolean, reload: Boolean) =>
-                    val p = if (reload) pos(file, point) else posNoRead(file, point)
-                    reporter.disable()
-                    val info = scalaCompiler.askCompletionsAt(
-                      p, maxResults, caseSens)
-                    project ! RPCResultEvent(toWF(info), callId)
-
-                  case ImportSuggestionsReq(_, _, _, _) =>
-                    indexer ! rpcReq
-
-                  case PublicSymbolSearchReq(_, _) =>
-                    indexer ! rpcReq
-
-                  case UsesOfSymAtPointReq(file: File, point: Int) =>
-                    val p = pos(file, point)
-                    val uses = scalaCompiler.askUsesOfSymAtPoint(p)
-                    project ! RPCResultEvent(toWF(uses.map(toWF)), callId)
-
-                  case PackageMemberCompletionReq(path: String, prefix: String) =>
-                    val members = scalaCompiler.askCompletePackageMember(path, prefix)
-                    project ! RPCResultEvent(toWF(members.map(toWF)), callId)
-
-                  case InspectTypeReq(file: File, range: OffsetRange) =>
-                    val p = pos(file, range)
-                    val result = scalaCompiler.askInspectTypeAt(p) match {
-                      case Some(info) => toWF(info)
-                      case None => toWF(null)
-                    }
-                    project ! RPCResultEvent(result, callId)
-
-                  case InspectTypeByIdReq(id: Int) =>
-                    val result = scalaCompiler.askInspectTypeById(id) match {
-                      case Some(info) => toWF(info)
-                      case None => toWF(null)
-                    }
-                    project ! RPCResultEvent(result, callId)
-
-                  case SymbolAtPointReq(file: File, point: Int) =>
-                    val p = pos(file, point)
-                    val result = scalaCompiler.askSymbolInfoAt(p) match {
-                      case Some(info) => toWF(info)
-                      case None => toWF(null)
-                    }
-                    project ! RPCResultEvent(result, callId)
-
-                  case InspectPackageByPathReq(path: String) =>
-                    val result = scalaCompiler.askPackageByPath(path) match {
-                      case Some(info) => toWF(info)
-                      case None => toWF(null)
-                    }
-                    project ! RPCResultEvent(result, callId)
-
-                  case TypeAtPointReq(file: File, range: OffsetRange) =>
-                    val p = pos(file, range)
-                    val result = scalaCompiler.askTypeInfoAt(p) match {
-                      case Some(info) => toWF(info)
-                      case None => toWF(null)
-                    }
-                    project ! RPCResultEvent(result, callId)
-
-                  case TypeByIdReq(id: Int) =>
-                    val result = scalaCompiler.askTypeInfoById(id) match {
-                      case Some(info) => toWF(info)
-                      case None => toWF(null)
-                    }
-                    project ! RPCResultEvent(result, callId)
-
-                  case TypeByNameReq(name: String) =>
-                    val result = scalaCompiler.askTypeInfoByName(name) match {
-                      case Some(info) => toWF(info)
-                      case None => toWF(null)
-                    }
-                    project ! RPCResultEvent(result, callId)
-
-                  case TypeByNameAtPointReq(name: String, file: File, range: OffsetRange) =>
-                    val p = pos(file, range)
-                    val result = scalaCompiler.askTypeInfoByNameAt(name, p) match {
-                      case Some(info) => toWF(info)
-                      case None => toWF(null)
-                    }
-
-                    project ! RPCResultEvent(result, callId)
-
-                  case CallCompletionReq(id: Int) =>
-                    val result = scalaCompiler.askCallCompletionInfoById(id) match {
-                      case Some(info) => toWF(info)
-                      case None => toWF(null)
-                    }
-                    project ! RPCResultEvent(result, callId)
-
-                  case SymbolDesignationsReq(file, start, end, tpes) =>
-                    if (!FileUtils.isScalaSourceFile(file)) {
-                      project ! RPCResultEvent(
-                        toWF(SymbolDesignations(file.getPath, List())), callId)
-                    } else {
-                      val f = createSourceFile(file)
-                      val clampedEnd = math.max(end, start)
-                      val pos = new RangePosition(f, start, start, clampedEnd)
-                      if (tpes.nonEmpty) {
-                        val syms = scalaCompiler.askSymbolDesignationsInRegion(
-                          pos, tpes)
-                        project ! RPCResultEvent(toWF(syms), callId)
-                      } else {
-                        project ! RPCResultEvent(
-                          toWF(SymbolDesignations(f.path, List())), callId)
-                      }
-                    }
-                }
-              }
-            } catch {
-              case e: Throwable =>
-                System.err.println("Error handling RPC: " + e + " :\n" +
-                  e.getStackTraceString)
-                project.sendRPCError(ErrExceptionInAnalyzer,
-                  Some("Error occurred in Analyzer. Check the server log."), callId)
-            }
-          case other =>
-            println("Analyzer: WTF, what's " + other)
-        }
-
+        process(x)
       } catch {
         case e: Exception =>
           System.err.println("Error at Compiler message loop: " + e + " :\n" + e.getStackTraceString)
       }
+  }
+
+  def process(msg: Any): Unit = {
+    msg match {
+      case AnalyzerShutdownEvent() =>
+        javaCompiler.shutdown()
+        scalaCompiler.askClearTypeCache()
+        scalaCompiler.askShutdown()
+        context.stop(self)
+      case FullTypeCheckCompleteEvent() =>
+        if (awaitingInitialCompile) {
+          awaitingInitialCompile = false
+          val elapsed = System.currentTimeMillis() - initTime
+          println("Analyzer ready in " + elapsed / 1000.0 + " seconds.")
+          reporter.enable()
+          project ! AsyncEvent(toWF(AnalyzerReadyEvent()))
+          indexer ! CommitReq()
+        }
+        project ! AsyncEvent(toWF(FullTypeCheckCompleteEvent()))
+
+      case rpcReq @ RPCRequestEvent(req: Any, callId: Int) =>
+        try {
+          if (awaitingInitialCompile) {
+            project.sendRPCError(ErrAnalyzerNotReady,
+              Some("Analyzer is not ready! Please wait."), callId)
+          } else {
+
+            reporter.enable()
+
+            req match {
+
+              case RemoveFileReq(file: File) =>
+                askRemoveDeleted(file)
+                project ! RPCResultEvent(toWF(value = true), callId)
+
+              case ReloadAllReq() =>
+                javaCompiler.reset()
+                javaCompiler.compileAll()
+                scalaCompiler.askRemoveAllDeleted()
+                scalaCompiler.askReloadAllFiles()
+                scalaCompiler.askNotifyWhenReady()
+                project ! RPCResultEvent(toWF(value = true), callId)
+
+              case ReloadFilesReq(files) =>
+                val (javas, scalas) = files.filter(_.file.exists).partition(
+                  _.file.getName.endsWith(".java"))
+                if (javas.nonEmpty) {
+                  javaCompiler.compileFiles(javas)
+                }
+                if (scalas.nonEmpty) {
+                  scalaCompiler.askReloadFiles(scalas.map(createSourceFile))
+                  scalaCompiler.askNotifyWhenReady()
+                  project ! RPCResultEvent(toWF(value = true), callId)
+                }
+
+              case PatchSourceReq(file, edits) =>
+                if (!file.exists()) {
+                  project.sendRPCError(ErrFileDoesNotExist,
+                    Some(file.getPath), callId)
+                } else {
+                  val f = createSourceFile(file)
+                  val revised = PatchSource.applyOperations(f, edits)
+                  reporter.disable()
+                  scalaCompiler.askReloadFile(revised)
+                  project ! RPCResultEvent(toWF(value = true), callId)
+                }
+
+              case req: RefactorPerformReq =>
+                handleRefactorRequest(req, callId)
+
+              case req: RefactorExecReq =>
+                handleRefactorExec(req, callId)
+
+              case req: RefactorCancelReq =>
+                handleRefactorCancel(req, callId)
+
+              case CompletionsReq(file: File, point: Int,
+                maxResults: Int, caseSens: Boolean, reload: Boolean) =>
+                val p = if (reload) pos(file, point) else posNoRead(file, point)
+                reporter.disable()
+                val info = scalaCompiler.askCompletionsAt(
+                  p, maxResults, caseSens)
+                project ! RPCResultEvent(toWF(info), callId)
+
+              case ImportSuggestionsReq(_, _, _, _) =>
+                indexer ! rpcReq
+
+              case PublicSymbolSearchReq(_, _) =>
+                indexer ! rpcReq
+
+              case UsesOfSymAtPointReq(file: File, point: Int) =>
+                val p = pos(file, point)
+                val uses = scalaCompiler.askUsesOfSymAtPoint(p)
+                project ! RPCResultEvent(toWF(uses.map(toWF)), callId)
+
+              case PackageMemberCompletionReq(path: String, prefix: String) =>
+                val members = scalaCompiler.askCompletePackageMember(path, prefix)
+                project ! RPCResultEvent(toWF(members.map(toWF)), callId)
+
+              case InspectTypeReq(file: File, range: OffsetRange) =>
+                val p = pos(file, range)
+                val result = scalaCompiler.askInspectTypeAt(p) match {
+                  case Some(info) => toWF(info)
+                  case None => toWF(null)
+                }
+                project ! RPCResultEvent(result, callId)
+
+              case InspectTypeByIdReq(id: Int) =>
+                val result = scalaCompiler.askInspectTypeById(id) match {
+                  case Some(info) => toWF(info)
+                  case None => toWF(null)
+                }
+                project ! RPCResultEvent(result, callId)
+
+              case SymbolAtPointReq(file: File, point: Int) =>
+                val p = pos(file, point)
+                val result = scalaCompiler.askSymbolInfoAt(p) match {
+                  case Some(info) => toWF(info)
+                  case None => toWF(null)
+                }
+                project ! RPCResultEvent(result, callId)
+
+              case InspectPackageByPathReq(path: String) =>
+                val result = scalaCompiler.askPackageByPath(path) match {
+                  case Some(info) => toWF(info)
+                  case None => toWF(null)
+                }
+                project ! RPCResultEvent(result, callId)
+
+              case TypeAtPointReq(file: File, range: OffsetRange) =>
+                val p = pos(file, range)
+                val result = scalaCompiler.askTypeInfoAt(p) match {
+                  case Some(info) => toWF(info)
+                  case None => toWF(null)
+                }
+                project ! RPCResultEvent(result, callId)
+
+              case TypeByIdReq(id: Int) =>
+                val result = scalaCompiler.askTypeInfoById(id) match {
+                  case Some(info) => toWF(info)
+                  case None => toWF(null)
+                }
+                project ! RPCResultEvent(result, callId)
+
+              case TypeByNameReq(name: String) =>
+                val result = scalaCompiler.askTypeInfoByName(name) match {
+                  case Some(info) => toWF(info)
+                  case None => toWF(null)
+                }
+                project ! RPCResultEvent(result, callId)
+
+              case TypeByNameAtPointReq(name: String, file: File, range: OffsetRange) =>
+                val p = pos(file, range)
+                val result = scalaCompiler.askTypeInfoByNameAt(name, p) match {
+                  case Some(info) => toWF(info)
+                  case None => toWF(null)
+                }
+
+                project ! RPCResultEvent(result, callId)
+
+              case CallCompletionReq(id: Int) =>
+                val result = scalaCompiler.askCallCompletionInfoById(id) match {
+                  case Some(info) => toWF(info)
+                  case None => toWF(null)
+                }
+                project ! RPCResultEvent(result, callId)
+
+              case SymbolDesignationsReq(file, start, end, tpes) =>
+                if (!FileUtils.isScalaSourceFile(file)) {
+                  project ! RPCResultEvent(
+                    toWF(SymbolDesignations(file.getPath, List())), callId)
+                } else {
+                  val f = createSourceFile(file)
+                  val clampedEnd = math.max(end, start)
+                  val pos = new RangePosition(f, start, start, clampedEnd)
+                  if (tpes.nonEmpty) {
+                    val syms = scalaCompiler.askSymbolDesignationsInRegion(
+                      pos, tpes)
+                    project ! RPCResultEvent(toWF(syms), callId)
+                  } else {
+                    project ! RPCResultEvent(
+                      toWF(SymbolDesignations(f.path, List())), callId)
+                  }
+                }
+            }
+          }
+        } catch {
+          case e: Throwable =>
+            System.err.println("Error handling RPC: " + e + " :\n" +
+              e.getStackTraceString)
+            project.sendRPCError(ErrExceptionInAnalyzer,
+              Some("Error occurred in Analyzer. Check the server log."), callId)
+        }
+      case other =>
+        println("Analyzer: WTF, what's " + other)
     }
   }
 

--- a/src/main/scala/org/ensime/server/Completion.scala
+++ b/src/main/scala/org/ensime/server/Completion.scala
@@ -1,10 +1,14 @@
 package org.ensime.server
 
+import akka.pattern.Patterns
+import akka.util.Timeout
 import org.ensime.model.CompletionInfoList
 import scala.collection.mutable
+import scala.concurrent.Await
 import scala.tools.nsc.util.{ SourceFile, BatchSourceFile }
 import org.ensime.util.Arrays
 import org.ensime.model.{ CompletionInfo, CompletionSignature, SymbolSearchResult }
+import scala.concurrent.duration._
 
 trait CompletionControl {
   self: RichPresentationCompiler =>
@@ -50,12 +54,18 @@ trait CompletionControl {
 
     def makeTypeSearchCompletions(prefix: String): List[CompletionInfo] = {
       val req = TypeCompletionsReq(prefix, maxResults)
-      indexer !? (1000, req) match {
-        case Some(syms: List[SymbolSearchResult]) =>
-          syms.map { s =>
+
+      import scala.concurrent.ExecutionContext.Implicits.global
+      val askRes = Patterns.ask(indexer, req, Timeout(1000.milliseconds))
+      val optFut = askRes map (Some(_)) recover { case _ => None }
+      val result = Await.result(askRes, Duration.Inf)
+
+      result match {
+        case Some(s: SymbolSearchResults) =>
+          s.syms.map { s =>
             CompletionInfo(s.localName, CompletionSignature(List(), s.name),
               -1, isCallable = false, 40, Some(s.name))
-          }
+          }.toList
         case _ => List()
       }
     }
@@ -128,7 +138,7 @@ trait CompletionControl {
   private val nonIdent = "[^a-zA-Z0-9_]"
   private val ws = "[ \n\r\t]"
 
-  trait CompletionContext {}
+  trait CompletionContext
 
   private val packRE = ("^.*?(?:package|import)[ ]+((?:[a-z0-9]+\\.)*)(?:(" + ident + "*)|\\{.*?(" + ident + "*))$").r
   case class PackageContext(path: String, prefix: String) extends CompletionContext

--- a/src/main/scala/org/ensime/server/Indexer.scala
+++ b/src/main/scala/org/ensime/server/Indexer.scala
@@ -1,9 +1,11 @@
 package org.ensime.server
 
 import java.io.File
+import akka.actor.Actor
 import org.ensime.config.ProjectConfig
 import org.ensime.indexer.ClassFileIndex
 import org.ensime.indexer.LuceneIndex
+import scala.reflect.io.AbstractFile
 import org.ensime.model.{
   ImportSuggestions,
   MethodSearchResult,
@@ -13,7 +15,6 @@ import org.ensime.model.{
 }
 import org.ensime.protocol.ProtocolConst._
 import org.ensime.protocol.ProtocolConversions
-import scala.actors._
 import scala.collection.mutable.ArrayBuffer
 
 case class IndexerShutdownReq()
@@ -25,93 +26,94 @@ case class RemoveSymbolsReq(syms: Iterable[String])
 case class ReindexClassFilesReq(files: Iterable[File])
 case class CommitReq()
 
+case class AbstractFiles(files: Set[AbstractFile])
+
 /**
  * The main index actor.
  */
-class Indexer(
-    project: Project,
+class Indexer(project: Project,
     protocol: ProtocolConversions,
     config: ProjectConfig) extends Actor {
 
   import protocol._
 
-  val index = new LuceneIndex {}
+  val index = new LuceneIndex
   val classFileIndex = new ClassFileIndex(config)
 
-  def act() {
-    loop {
-      try {
-        receive {
-          case IndexerShutdownReq() =>
-            index.close()
-            exit('stop)
-          case RebuildStaticIndexReq() =>
-            index.initialize(
-              config.root,
-              config.allFilesOnClasspath,
-              config.onlyIncludeInIndex,
-              config.excludeFromIndex)
-            classFileIndex.indexFiles(
-              config.allFilesOnClasspath
-                ++ List(config.target, config.testTarget).flatten
-            )
-            project ! AsyncEvent(toWF(IndexerReadyEvent()))
-          case ReindexClassFilesReq(files) =>
-            classFileIndex.indexFiles(files)
-          case CommitReq() =>
-            index.commit()
-          case AddSymbolsReq(syms) =>
-            syms.foreach { info =>
-              index.insert(info)
-            }
-          case RemoveSymbolsReq(syms) =>
-            syms.foreach { s => index.remove(s) }
-          case TypeCompletionsReq(prefix: String, maxResults: Int) =>
-            val suggestions = index.keywordSearch(List(prefix), maxResults, restrictToTypes = true)
-            sender ! suggestions
-          case SourceFileCandidatesReq(enclosingPackage, classNamePrefix) =>
-            sender ! classFileIndex.sourceFileCandidates(
-              enclosingPackage,
-              classNamePrefix)
-          case RPCRequestEvent(req: Any, callId: Int) =>
-            try {
-              req match {
-                case ImportSuggestionsReq(file, point, names, maxResults) =>
-                  val suggestions = ImportSuggestions(index.getImportSuggestions(
-                    names, maxResults))
-                  project ! RPCResultEvent(toWF(suggestions), callId)
-                case PublicSymbolSearchReq(keywords, maxResults) =>
-                  println("Received keywords: " + keywords)
-                  val suggestions = SymbolSearchResults(
-                    index.keywordSearch(keywords, maxResults))
-                  project ! RPCResultEvent(toWF(suggestions), callId)
-                case MethodBytecodeReq(sourceName: String, line: Int) =>
-                  classFileIndex.locateBytecode(sourceName, line) match {
-                    case method :: rest =>
-                      project ! RPCResultEvent(
-                        toWF(method), callId)
-                    case _ => project.sendRPCError(ErrExceptionInIndexer,
-                      Some("Failed to find method bytecode"), callId)
-                  }
-              }
-            } catch {
-              case e: Exception =>
-                System.err.println("Error handling RPC: " +
-                  e + " :\n" +
-                  e.getStackTraceString)
-                project.sendRPCError(ErrExceptionInIndexer,
-                  Some("Error occurred in indexer. Check the server log."),
-                  callId)
-            }
-          case other =>
-            println("Indexer: WTF, what's " + other)
-        }
+  override def receive = {
+    case msg: Any => try {
+      process(msg)
+    } catch {
+      case e: Exception =>
+        System.err.println("Error at Indexer message loop: " +
+          e + " :\n" + e.getStackTraceString)
+    }
+  }
 
-      } catch {
-        case e: Exception =>
-          System.err.println("Error at Indexer message loop: " +
-            e + " :\n" + e.getStackTraceString)
-      }
+  def process(msg: Any) {
+    msg match {
+      case IndexerShutdownReq() =>
+        index.close()
+        context.stop(self)
+      case RebuildStaticIndexReq() =>
+        index.initialize(
+          context.system,
+          config.root,
+          config.allFilesOnClasspath,
+          config.onlyIncludeInIndex,
+          config.excludeFromIndex)
+        classFileIndex.indexFiles(
+          config.allFilesOnClasspath
+            ++ List(config.target, config.testTarget).flatten
+        )
+        project ! AsyncEvent(toWF(IndexerReadyEvent()))
+      case ReindexClassFilesReq(files) =>
+        classFileIndex.indexFiles(files)
+      case CommitReq() =>
+        index.commit()
+      case AddSymbolsReq(syms) =>
+        syms.foreach { info =>
+          index.insert(info)
+        }
+      case RemoveSymbolsReq(syms) =>
+        syms.foreach { s => index.remove(s) }
+      case TypeCompletionsReq(prefix: String, maxResults: Int) =>
+        val suggestions = index.keywordSearch(List(prefix), maxResults, restrictToTypes = true)
+        sender ! SymbolSearchResults(suggestions)
+      case SourceFileCandidatesReq(enclosingPackage, classNamePrefix) =>
+        sender ! AbstractFiles(classFileIndex.sourceFileCandidates(enclosingPackage, classNamePrefix))
+      case RPCRequestEvent(req: Any, callId: Int) =>
+        try {
+          req match {
+            case ImportSuggestionsReq(file, point, names, maxResults) =>
+              val suggestions = ImportSuggestions(index.getImportSuggestions(
+                names, maxResults))
+              project ! RPCResultEvent(toWF(suggestions), callId)
+            case PublicSymbolSearchReq(keywords, maxResults) =>
+              println("Received keywords: " + keywords)
+              val suggestions = SymbolSearchResults(
+                index.keywordSearch(keywords, maxResults))
+              project ! RPCResultEvent(toWF(suggestions), callId)
+            case MethodBytecodeReq(sourceName: String, line: Int) =>
+              classFileIndex.locateBytecode(sourceName, line) match {
+                case method :: rest =>
+                  project ! RPCResultEvent(
+                    toWF(method), callId)
+                case _ => project.sendRPCError(ErrExceptionInIndexer,
+                  Some("Failed to find method bytecode"), callId)
+              }
+          }
+        } catch {
+          case e: Exception =>
+            System.err.println("Error handling RPC: " +
+              e + " :\n" +
+              e.getStackTraceString)
+            project.sendRPCError(ErrExceptionInIndexer,
+              Some("Error occurred in indexer. Check the server log."),
+              callId)
+        }
+      case other =>
+        println("Indexer: WTF, what's " + other)
     }
   }
 

--- a/src/main/scala/org/ensime/server/JavaCompiler.scala
+++ b/src/main/scala/org/ensime/server/JavaCompiler.scala
@@ -1,5 +1,7 @@
 package org.ensime.server
 
+import akka.actor.ActorRef
+
 import scala.collection.mutable.ArrayBuffer
 import java.io.ByteArrayOutputStream
 import java.util.Locale
@@ -13,14 +15,13 @@ import org.eclipse.jdt.internal.compiler.problem.DefaultProblemFactory
 import org.ensime.config.ProjectConfig
 import org.ensime.model._
 import org.ensime.util._
-import scala.actors._
 import scala.collection.{ mutable, Iterable }
 import scala.collection.JavaConversions._
 
 class JavaCompiler(
     config: ProjectConfig,
     val reportHandler: ReportHandler,
-    val indexer: Actor) {
+    val indexer: ActorRef) {
 
   private val javaUnitForFile = new mutable.HashMap[String, ICompilationUnit]()
 

--- a/src/main/scala/org/ensime/server/Project.scala
+++ b/src/main/scala/org/ensime/server/Project.scala
@@ -1,6 +1,7 @@
 package org.ensime.server
 
 import java.io.File
+import akka.actor.{ Actor, ActorRef, Props, ActorSystem }
 import org.ensime.config.ProjectConfig
 
 import org.ensime.model.PatchOp
@@ -8,7 +9,7 @@ import org.ensime.model.SourceFileInfo
 import org.ensime.model.OffsetRange
 import org.ensime.protocol._
 import org.ensime.util._
-import scala.actors._
+import org.slf4j.LoggerFactory
 import scala.collection.mutable
 
 case class RPCResultEvent(value: WireFormat, callId: Int)
@@ -48,61 +49,72 @@ case class AddUndo(summary: String, changes: List[FileEdit])
 case class Undo(id: Int, summary: String, changes: List[FileEdit])
 case class UndoResult(id: Int, touched: Iterable[File])
 
-class Project(val protocol: Protocol) extends Actor with RPCTarget {
+class Project(val protocol: Protocol, actorSystem: ActorSystem) extends ProjectRPCTarget {
+  val log = LoggerFactory.getLogger(this.getClass)
 
+  private val actor = actorSystem.actorOf(Props(new ProjectActor()), "project")
+
+  def !(msg: AnyRef) {
+    actor ! msg
+  }
+  // TODO This is lethal - Project is both an actor and a threaded callback target
   protocol.setRPCTarget(this)
 
   protected var config: ProjectConfig = ProjectConfig.nullConfig
 
-  protected var analyzer: Option[Actor] = None
-  protected var indexer: Option[Actor] = None
-  protected var builder: Option[Actor] = None
-  protected var debugger: Option[Actor] = None
+  protected var analyzer: Option[ActorRef] = None
+  protected var indexer: Option[ActorRef] = None
+  protected var debugger: Option[ActorRef] = None
 
-  def getAnalyzer: Actor = {
-    analyzer.getOrElse(throw new RuntimeException(
-      "Analyzer unavailable."))
+  def getAnalyzer: ActorRef = {
+    analyzer.getOrElse(throw new RuntimeException("Analyzer unavailable."))
   }
-  def getIndexer: Actor = {
-    indexer.getOrElse(throw new RuntimeException(
-      "Indexer unavailable."))
+  def getIndexer: ActorRef = {
+    indexer.getOrElse(throw new RuntimeException("Indexer unavailable."))
   }
 
   private var undoCounter = 0
   private val undos: mutable.LinkedHashMap[Int, Undo] = new mutable.LinkedHashMap[Int, Undo]
 
   def sendRPCError(code: Int, detail: Option[String], callId: Int) {
-    this ! RPCErrorEvent(code, detail, callId)
+    actor ! RPCErrorEvent(code, detail, callId)
   }
   def sendRPCError(detail: String, callId: Int) {
     sendRPCError(ProtocolConst.ErrExceptionInRPC, Some(detail), callId)
   }
 
   def bgMessage(msg: String) {
-    this ! AsyncEvent(protocol.toWF(SendBackgroundMessageEvent(
+    actor ! AsyncEvent(protocol.conversions.toWF(SendBackgroundMessageEvent(
       ProtocolConst.MsgMisc,
       Some(msg))))
   }
 
-  def act() {
-    println("Project waiting for init...")
-    loop {
-      try {
-        receive {
-          case IncomingMessageEvent(msg: WireFormat) =>
-            protocol.handleIncomingMessage(msg)
-          case AddUndo(sum, changes) =>
-            addUndo(sum, changes)
-          case RPCResultEvent(value, callId) =>
-            protocol.sendRPCReturn(value, callId)
-          case AsyncEvent(value) =>
-            protocol.sendEvent(value)
-          case RPCErrorEvent(code, detail, callId) =>
-            protocol.sendRPCError(code, detail, callId)
+  class ProjectActor extends Actor {
+    override def receive = {
+      case x: Any =>
+        try {
+          process(x)
+        } catch {
+          case e: Exception =>
+            println("Error at Project message loop: " + e + " :\n" + e.getStackTraceString)
         }
-      } catch {
-        case e: Exception =>
-          println("Error at Project message loop: " + e + " :\n" + e.getStackTraceString)
+
+    }
+
+    log.info("Project waiting for init...")
+
+    def process(msg: Any): Unit = {
+      msg match {
+        case IncomingMessageEvent(msg: WireFormat) =>
+          protocol.handleIncomingMessage(msg)
+        case AddUndo(sum, changes) =>
+          addUndo(sum, changes)
+        case RPCResultEvent(value, callId) =>
+          protocol.sendRPCReturn(value, callId)
+        case AsyncEvent(value) =>
+          protocol.sendEvent(value)
+        case RPCErrorEvent(code, detail, callId) =>
+          protocol.sendRPCError(code, detail, callId)
       }
     }
   }
@@ -139,7 +151,6 @@ class Project(val protocol: Protocol) extends Actor with RPCTarget {
     config = conf
     restartIndexer()
     restartCompiler()
-    shutdownBuilder()
     shutdownDebugger()
     undos.clear()
     undoCounter = 0
@@ -149,9 +160,8 @@ class Project(val protocol: Protocol) extends Actor with RPCTarget {
     for (ea <- indexer) {
       ea ! IndexerShutdownReq()
     }
-    val newIndexer = new Indexer(this, protocol, config)
+    val newIndexer = actorSystem.actorOf(Props(new Indexer(this, protocol.conversions, config)))
     println("Initing Indexer...")
-    newIndexer.start()
     if (!config.disableIndexOnStartup) {
       newIndexer ! RebuildStaticIndexReq()
     }
@@ -164,45 +174,24 @@ class Project(val protocol: Protocol) extends Actor with RPCTarget {
     }
     indexer match {
       case Some(indexer) =>
-        val newAnalyzer = new Analyzer(this, indexer, protocol, config)
-        newAnalyzer.start()
+        val newAnalyzer = actorSystem.actorOf(Props(new Analyzer(this, indexer, protocol.conversions, config)), "analyzer")
         analyzer = Some(newAnalyzer)
       case None =>
         throw new RuntimeException("Indexer must be started before analyzer.")
     }
   }
 
-  protected def getOrStartBuilder(): Actor = {
-    builder match {
-      case Some(b) => b
-      case None =>
-        val b = new IncrementalBuilder(this, protocol, config)
-        builder = Some(b)
-        b.start()
-        b
-    }
-  }
-
-  protected def getOrStartDebugger(): Actor = {
+  protected def getOrStartDebugger(): ActorRef = {
     ((debugger, indexer) match {
       case (Some(b), _) => Some(b)
       case (None, Some(indexer)) =>
-        val b = new DebugManager(this, indexer, protocol, config)
+        val b = actorSystem.actorOf(Props(new DebugManager(this, indexer, protocol.conversions, config)))
         debugger = Some(b)
-        b.start()
         Some(b)
       case _ => None
-    }).getOrElse(throw new RuntimeException(
-      "Indexer must be started before debug manager."
-    ))
+    }).getOrElse(throw new RuntimeException("Indexer must be started before debug manager."))
   }
 
-  protected def shutdownBuilder() {
-    for (b <- builder) {
-      b ! BuilderShutdownEvent
-    }
-    builder = None
-  }
   protected def shutdownDebugger() {
     for (d <- debugger) {
       d ! DebuggerShutdownEvent

--- a/src/main/scala/org/ensime/server/RPCTarget.scala
+++ b/src/main/scala/org/ensime/server/RPCTarget.scala
@@ -11,215 +11,282 @@ import scalariform.formatter.ScalaFormatter
 import scalariform.parser.ScalaParserException
 import scalariform.utils.Range
 
-trait RPCTarget { self: Project =>
+trait RPCTarget {
+
+  def rpcShutdownServer(callId: Int)
+
+  def rpcInitProject(conf: ProjectConfig, callId: Int)
+  def rpcPeekUndo(callId: Int)
+  def rpcExecUndo(undoId: Int, callId: Int)
+  def rpcReplConfig(callId: Int)
+
+  def rpcSymbolDesignations(f: String, start: Int, end: Int, requestedTypes: List[Symbol], callId: Int)
+  def rpcMethodBytecode(f: String, line: Int, callId: Int)
+  def rpcDebugStartVM(commandLine: String, callId: Int)
+  def rpcDebugAttachVM(hostname: String, port: String, callId: Int)
+  def rpcDebugStopVM(callId: Int)
+  def rpcDebugRun(callId: Int)
+  def rpcDebugContinue(threadId: Long, callId: Int)
+  def rpcDebugBreak(file: String, line: Int, callId: Int)
+  def rpcDebugClearBreak(file: String, line: Int, callId: Int)
+  def rpcDebugClearAllBreaks(callId: Int)
+  def rpcDebugListBreaks(callId: Int)
+  def rpcDebugNext(threadId: Long, callId: Int)
+  def rpcDebugStep(threadId: Long, callId: Int)
+  def rpcDebugStepOut(threadId: Long, callId: Int)
+  def rpcDebugLocateName(threadId: Long, name: String, callId: Int)
+  def rpcDebugValue(loc: DebugLocation, callId: Int)
+  def rpcDebugToString(threadId: Long, loc: DebugLocation, callId: Int)
+  def rpcDebugSetValue(loc: DebugLocation, newValue: String, callId: Int)
+  def rpcDebugBacktrace(threadId: Long, index: Int, count: Int, callId: Int)
+  def rpcDebugActiveVM(callId: Int)
+  def rpcPatchSource(f: String, edits: List[PatchOp], callId: Int)
+  def rpcTypecheckFiles(fs: List[SourceFileInfo], callId: Int)
+  def rpcRemoveFile(f: String, callId: Int)
+  def rpcTypecheckAll(callId: Int)
+  def rpcCompletionsAtPoint(f: String, point: Int, maxResults: Int,
+    caseSens: Boolean, reload: Boolean, callId: Int)
+  def rpcPackageMemberCompletion(path: String, prefix: String, callId: Int)
+  def rpcInspectTypeAtPoint(f: String, range: OffsetRange, callId: Int)
+
+  def rpcInspectTypeById(id: Int, callId: Int)
+
+  def rpcSymbolAtPoint(f: String, point: Int, callId: Int)
+
+  def rpcTypeById(id: Int, callId: Int)
+
+  def rpcTypeByName(name: String, callId: Int)
+
+  def rpcTypeByNameAtPoint(name: String, f: String, range: OffsetRange, callId: Int)
+
+  def rpcCallCompletion(id: Int, callId: Int)
+
+  def rpcImportSuggestions(f: String, point: Int, names: List[String], maxResults: Int, callId: Int)
+  def rpcPublicSymbolSearch(names: List[String], maxResults: Int, callId: Int)
+
+  def rpcUsesOfSymAtPoint(f: String, point: Int, callId: Int)
+
+  def rpcTypeAtPoint(f: String, range: OffsetRange, callId: Int)
+
+  def rpcInspectPackageByPath(path: String, callId: Int)
+
+  def rpcPrepareRefactor(refactorType: Symbol, procId: Int,
+    params: immutable.Map[Symbol, Any], interactive: Boolean, callId: Int)
+
+  def rpcExecRefactor(refactorType: Symbol, procId: Int, callId: Int)
+
+  def rpcCancelRefactor(procId: Int, callId: Int)
+
+  def rpcExpandSelection(filename: String, start: Int, stop: Int, callId: Int)
+
+  def rpcFormatFiles(filenames: Iterable[String], callId: Int)
+}
+
+trait ProjectRPCTarget extends RPCTarget { self: Project =>
 
   import protocol._
+  import protocol.conversions._
 
-  def rpcShutdownServer(callId: Int) {
+  override def rpcShutdownServer(callId: Int) {
     sendRPCReturn(toWF(value = true), callId)
     shutdownServer()
   }
 
-  def rpcInitProject(conf: ProjectConfig, callId: Int) {
+  override def rpcInitProject(conf: ProjectConfig, callId: Int) {
     initProject(conf)
     sendRPCReturn(toWF(conf), callId)
   }
 
-  def rpcPeekUndo(callId: Int) {
-    peekUndo match {
+  override def rpcPeekUndo(callId: Int) {
+    peekUndo() match {
       case Right(result) => sendRPCReturn(toWF(result), callId)
       case Left(msg) => sendRPCError(ErrPeekUndoFailed, Some(msg), callId)
     }
   }
 
-  def rpcExecUndo(undoId: Int, callId: Int) {
+  override def rpcExecUndo(undoId: Int, callId: Int) {
     execUndo(undoId) match {
       case Right(result) => sendRPCReturn(toWF(result), callId)
       case Left(msg) => sendRPCError(ErrExecUndoFailed, Some(msg), callId)
     }
   }
 
-  def rpcReplConfig(callId: Int) {
+  override def rpcReplConfig(callId: Int) {
     sendRPCReturn(toWF(config.replConfig), callId)
   }
 
-  def rpcBuilderInit(callId: Int) {
-    getOrStartBuilder ! RPCRequestEvent(RebuildAllReq(), callId)
-  }
-
-  def rpcBuilderAddFiles(filenames: Iterable[String], callId: Int) {
-    val files = filenames.map(s => new File(s.toString))
-    val b = getOrStartBuilder
-    b ! RPCRequestEvent(AddSourceFilesReq(files), callId)
-  }
-
-  def rpcBuilderUpdateFiles(filenames: Iterable[String], callId: Int) {
-    val files = filenames.map(s => new File(s.toString))
-    val b = getOrStartBuilder
-    b ! RPCRequestEvent(UpdateSourceFilesReq(files), callId)
-  }
-
-  def rpcBuilderRemoveFiles(filenames: Iterable[String], callId: Int) {
-    val files = filenames.map(s => new File(s.toString))
-    val b = getOrStartBuilder
-    b ! RPCRequestEvent(RemoveSourceFilesReq(files), callId)
-  }
-
-  def rpcSymbolDesignations(f: String, start: Int, end: Int, requestedTypes: List[Symbol], callId: Int) {
+  override def rpcSymbolDesignations(f: String, start: Int, end: Int, requestedTypes: List[Symbol], callId: Int) {
     val file: File = new File(f)
     getAnalyzer ! RPCRequestEvent(SymbolDesignationsReq(file, start, end, requestedTypes), callId)
   }
 
-  def rpcMethodBytecode(f: String, line: Int, callId: Int) {
+  override def rpcMethodBytecode(f: String, line: Int, callId: Int) {
     getIndexer ! RPCRequestEvent(MethodBytecodeReq(new File(f).getName, line), callId)
   }
 
-  def rpcDebugStartVM(commandLine: String, callId: Int) {
+  override def rpcDebugStartVM(commandLine: String, callId: Int) {
     getOrStartDebugger ! RPCRequestEvent(DebugStartVMReq(commandLine), callId)
   }
-  def rpcDebugAttachVM(hostname: String, port: String, callId: Int) {
+
+  override def rpcDebugAttachVM(hostname: String, port: String, callId: Int) {
     getOrStartDebugger ! RPCRequestEvent(DebugAttachVMReq(hostname, port), callId)
   }
-  def rpcDebugStopVM(callId: Int) {
+
+  override def rpcDebugStopVM(callId: Int) {
     getOrStartDebugger ! RPCRequestEvent(DebugStopVMReq(), callId)
   }
-  def rpcDebugRun(callId: Int) {
+
+  override def rpcDebugRun(callId: Int) {
     getOrStartDebugger ! RPCRequestEvent(DebugRunReq(), callId)
   }
-  def rpcDebugContinue(threadId: Long, callId: Int) {
+
+  override def rpcDebugContinue(threadId: Long, callId: Int) {
     getOrStartDebugger ! RPCRequestEvent(DebugContinueReq(threadId), callId)
   }
-  def rpcDebugBreak(file: String, line: Int, callId: Int) {
+
+  override def rpcDebugBreak(file: String, line: Int, callId: Int) {
     getOrStartDebugger ! RPCRequestEvent(DebugBreakReq(file, line), callId)
   }
-  def rpcDebugClearBreak(file: String, line: Int, callId: Int) {
+
+  override def rpcDebugClearBreak(file: String, line: Int, callId: Int) {
     getOrStartDebugger ! RPCRequestEvent(DebugClearBreakReq(file, line), callId)
   }
-  def rpcDebugClearAllBreaks(callId: Int) {
+
+  override def rpcDebugClearAllBreaks(callId: Int) {
     getOrStartDebugger ! RPCRequestEvent(DebugClearAllBreaksReq(), callId)
   }
-  def rpcDebugListBreaks(callId: Int) {
+
+  override def rpcDebugListBreaks(callId: Int) {
     getOrStartDebugger ! RPCRequestEvent(DebugListBreaksReq(), callId)
   }
-  def rpcDebugNext(threadId: Long, callId: Int) {
+
+  override def rpcDebugNext(threadId: Long, callId: Int) {
     getOrStartDebugger ! RPCRequestEvent(DebugNextReq(threadId), callId)
   }
-  def rpcDebugStep(threadId: Long, callId: Int) {
+
+  override def rpcDebugStep(threadId: Long, callId: Int) {
     getOrStartDebugger ! RPCRequestEvent(DebugStepReq(threadId), callId)
   }
-  def rpcDebugStepOut(threadId: Long, callId: Int) {
+
+  override def rpcDebugStepOut(threadId: Long, callId: Int) {
     getOrStartDebugger ! RPCRequestEvent(DebugStepOutReq(threadId), callId)
   }
-  def rpcDebugLocateName(threadId: Long, name: String, callId: Int) {
+
+  override def rpcDebugLocateName(threadId: Long, name: String, callId: Int) {
     getOrStartDebugger ! RPCRequestEvent(DebugLocateNameReq(threadId, name), callId)
   }
-  def rpcDebugValue(loc: DebugLocation, callId: Int) {
+
+  override def rpcDebugValue(loc: DebugLocation, callId: Int) {
     getOrStartDebugger ! RPCRequestEvent(DebugValueReq(loc), callId)
   }
+
   def rpcDebugToString(threadId: Long, loc: DebugLocation, callId: Int) {
     getOrStartDebugger ! RPCRequestEvent(DebugToStringReq(threadId, loc), callId)
   }
-  def rpcDebugSetValue(loc: DebugLocation, newValue: String, callId: Int) {
+
+  override def rpcDebugSetValue(loc: DebugLocation, newValue: String, callId: Int) {
     getOrStartDebugger ! RPCRequestEvent(DebugSetValueReq(loc, newValue), callId)
   }
-  def rpcDebugBacktrace(threadId: Long, index: Int, count: Int, callId: Int) {
+
+  override def rpcDebugBacktrace(threadId: Long, index: Int, count: Int, callId: Int) {
     getOrStartDebugger ! RPCRequestEvent(DebugBacktraceReq(threadId, index, count), callId)
   }
-  def rpcDebugActiveVM(callId: Int) {
+
+  override def rpcDebugActiveVM(callId: Int) {
     getOrStartDebugger ! RPCRequestEvent(DebugActiveVMReq(), callId)
   }
 
-  def rpcPatchSource(f: String, edits: List[PatchOp], callId: Int) {
+  override def rpcPatchSource(f: String, edits: List[PatchOp], callId: Int) {
     val file: File = new File(f)
     getAnalyzer ! RPCRequestEvent(PatchSourceReq(file, edits), callId)
   }
 
-  def rpcTypecheckFiles(fs: List[SourceFileInfo], callId: Int) {
+  override def rpcTypecheckFiles(fs: List[SourceFileInfo], callId: Int) {
     getAnalyzer ! RPCRequestEvent(ReloadFilesReq(fs), callId)
   }
 
-  def rpcRemoveFile(f: String, callId: Int) {
+  override def rpcRemoveFile(f: String, callId: Int) {
     val file: File = new File(f)
     getAnalyzer ! RPCRequestEvent(RemoveFileReq(file), callId)
     sendRPCAckOK(callId)
   }
 
-  def rpcTypecheckAll(callId: Int) {
+  override def rpcTypecheckAll(callId: Int) {
     getAnalyzer ! RPCRequestEvent(ReloadAllReq(), callId)
   }
 
-  def rpcCompletionsAtPoint(f: String, point: Int, maxResults: Int,
+  override def rpcCompletionsAtPoint(f: String, point: Int, maxResults: Int,
     caseSens: Boolean, reload: Boolean, callId: Int) {
     getAnalyzer ! RPCRequestEvent(
       CompletionsReq(new File(f), point, maxResults, caseSens, reload), callId)
   }
 
-  def rpcPackageMemberCompletion(path: String, prefix: String, callId: Int) {
+  override def rpcPackageMemberCompletion(path: String, prefix: String, callId: Int) {
     getAnalyzer ! RPCRequestEvent(PackageMemberCompletionReq(path, prefix), callId)
   }
 
-  def rpcInspectTypeAtPoint(f: String, range: OffsetRange, callId: Int) {
+  override def rpcInspectTypeAtPoint(f: String, range: OffsetRange, callId: Int) {
     getAnalyzer ! RPCRequestEvent(InspectTypeReq(new File(f), range), callId)
   }
 
-  def rpcInspectTypeById(id: Int, callId: Int) {
+  override def rpcInspectTypeById(id: Int, callId: Int) {
     getAnalyzer ! RPCRequestEvent(InspectTypeByIdReq(id), callId)
   }
 
-  def rpcSymbolAtPoint(f: String, point: Int, callId: Int) {
+  override def rpcSymbolAtPoint(f: String, point: Int, callId: Int) {
     getAnalyzer ! RPCRequestEvent(SymbolAtPointReq(new File(f), point), callId)
   }
 
-  def rpcTypeById(id: Int, callId: Int) {
+  override def rpcTypeById(id: Int, callId: Int) {
     getAnalyzer ! RPCRequestEvent(TypeByIdReq(id), callId)
   }
 
-  def rpcTypeByName(name: String, callId: Int) {
+  override def rpcTypeByName(name: String, callId: Int) {
     getAnalyzer ! RPCRequestEvent(TypeByNameReq(name), callId)
   }
 
-  def rpcTypeByNameAtPoint(name: String, f: String, range: OffsetRange, callId: Int) {
+  override def rpcTypeByNameAtPoint(name: String, f: String, range: OffsetRange, callId: Int) {
     getAnalyzer ! RPCRequestEvent(TypeByNameAtPointReq(name, new File(f), range), callId)
   }
 
-  def rpcCallCompletion(id: Int, callId: Int) {
+  override def rpcCallCompletion(id: Int, callId: Int) {
     getAnalyzer ! RPCRequestEvent(CallCompletionReq(id), callId)
   }
 
-  def rpcImportSuggestions(f: String, point: Int, names: List[String], maxResults: Int, callId: Int) {
+  override def rpcImportSuggestions(f: String, point: Int, names: List[String], maxResults: Int, callId: Int) {
     getAnalyzer ! RPCRequestEvent(ImportSuggestionsReq(new File(f), point, names, maxResults), callId)
   }
 
-  def rpcPublicSymbolSearch(names: List[String], maxResults: Int, callId: Int) {
+  override def rpcPublicSymbolSearch(names: List[String], maxResults: Int, callId: Int) {
     getAnalyzer ! RPCRequestEvent(PublicSymbolSearchReq(names, maxResults), callId)
   }
 
-  def rpcUsesOfSymAtPoint(f: String, point: Int, callId: Int) {
+  override def rpcUsesOfSymAtPoint(f: String, point: Int, callId: Int) {
     getAnalyzer ! RPCRequestEvent(UsesOfSymAtPointReq(new File(f), point), callId)
   }
 
-  def rpcTypeAtPoint(f: String, range: OffsetRange, callId: Int) {
+  override def rpcTypeAtPoint(f: String, range: OffsetRange, callId: Int) {
     getAnalyzer ! RPCRequestEvent(TypeAtPointReq(new File(f), range), callId)
   }
 
-  def rpcInspectPackageByPath(path: String, callId: Int) {
+  override def rpcInspectPackageByPath(path: String, callId: Int) {
     getAnalyzer ! RPCRequestEvent(InspectPackageByPathReq(path), callId)
   }
 
-  def rpcPrepareRefactor(refactorType: Symbol, procId: Int, params: immutable.Map[Symbol, Any], interactive: Boolean, callId: Int) {
+  override def rpcPrepareRefactor(refactorType: Symbol, procId: Int, params: immutable.Map[Symbol, Any], interactive: Boolean, callId: Int) {
     getAnalyzer ! RPCRequestEvent(RefactorPerformReq(
       procId, refactorType, params, interactive), callId)
   }
 
-  def rpcExecRefactor(refactorType: Symbol, procId: Int, callId: Int) {
+  override def rpcExecRefactor(refactorType: Symbol, procId: Int, callId: Int) {
     getAnalyzer ! RPCRequestEvent(RefactorExecReq(procId, refactorType), callId)
   }
 
-  def rpcCancelRefactor(procId: Int, callId: Int) {
+  override def rpcCancelRefactor(procId: Int, callId: Int) {
     getAnalyzer ! RPCRequestEvent(RefactorCancelReq(procId), callId)
   }
 
-  def rpcExpandSelection(filename: String, start: Int, stop: Int, callId: Int) {
+  override def rpcExpandSelection(filename: String, start: Int, stop: Int, callId: Int) {
     try {
       FileUtils.readFile(new File(filename)) match {
         case Right(contents) =>
@@ -239,7 +306,7 @@ trait RPCTarget { self: Project =>
     }
   }
 
-  def rpcFormatFiles(filenames: Iterable[String], callId: Int) {
+  override def rpcFormatFiles(filenames: Iterable[String], callId: Int) {
     val files = filenames.map { new File(_) }
     try {
       val changeList = files.map { f =>

--- a/src/main/scala/org/ensime/server/RichPresentationCompiler.scala
+++ b/src/main/scala/org/ensime/server/RichPresentationCompiler.scala
@@ -1,9 +1,9 @@
 package org.ensime.server
 
 import java.io.File
+import akka.actor.ActorRef
 import org.ensime.config.ProjectConfig
 import org.ensime.model._
-import scala.actors.Actor
 import scala.collection.mutable
 import scala.tools.nsc.interactive.{ CompilerControl, Global }
 import scala.tools.nsc.util._
@@ -144,8 +144,8 @@ trait RichCompilerControl extends CompilerControl with RefactoringControl with C
 class RichPresentationCompiler(
   settings: Settings,
   val richReporter: Reporter,
-  var parent: Actor,
-  var indexer: Actor,
+  var parent: ActorRef,
+  var indexer: ActorRef,
   val config: ProjectConfig) extends Global(settings, richReporter)
     with NamespaceTraversal with ModelBuilders with RichCompilerControl
     with RefactoringImpl with IndexerInterface with SemanticHighlighting with Completion with Helpers {

--- a/src/main/scala/org/ensime/server/SemanticHighlighting.scala
+++ b/src/main/scala/org/ensime/server/SemanticHighlighting.scala
@@ -98,8 +98,7 @@ trait SemanticHighlighting { self: Global with Helpers =>
                 catch { case _: Throwable => treeP.end }
                 addAt(start, end, 'constructor)
               } else if (sym.isMethod) {
-                if (sym.nameString == "apply" ||
-                  sym.nameString == "update") {}
+                if (sym.nameString == "apply" || sym.nameString == "update") {}
                 else if (selector.isOperatorName) {
                   addAt(start, end, 'operator)
                 } else {

--- a/src/main/scala/org/ensime/util/FileUtil.scala
+++ b/src/main/scala/org/ensime/util/FileUtil.scala
@@ -15,7 +15,8 @@ trait FileEdit {
   def from: Int
   def to: Int
 }
-case class TextEdit(file: File, from: Int, to: Int, text: String) extends FileEdit {}
+case class TextEdit(file: File, from: Int, to: Int, text: String) extends FileEdit
+
 case class NewFile(file: File, text: String) extends FileEdit {
   def from: Int = 0
   def to: Int = text.length - 1
@@ -60,7 +61,7 @@ object RichFile {
   implicit def toRichFile(file: File) = new RichFile(file)
 }
 
-class CanonFile private (path: String) extends File(path) {}
+class CanonFile private (path: String) extends File(path)
 
 object CanonFile {
   def apply(file: File) = {
@@ -383,7 +384,6 @@ object FileUtils {
    * disk writes, return Right(Left(exception)). Otherwise, return Right(Right(()))
    */
   def rewriteFiles(changes: Iterable[(File, String)]): Either[Exception, Either[Exception, Unit]] = {
-    val touchedFiles = new mutable.ListBuffer[File]
     try {
 
       // Try to fail fast, before writing anything to disk.

--- a/src/test/scala/org/ensime/test/SwankProtocolConversionsSpec.scala
+++ b/src/test/scala/org/ensime/test/SwankProtocolConversionsSpec.scala
@@ -5,6 +5,7 @@ import java.io.File
 import org.ensime.config.{ ProjectConfig, ReplConfig }
 import org.ensime.indexer.{ Op, MethodBytecode }
 import org.ensime.model._
+import org.ensime.protocol.SwankProtocol
 import org.ensime.server._
 import org.scalatest.FunSpec
 import org.scalatest.matchers.ShouldMatchers
@@ -45,7 +46,8 @@ class SwankProtocolConversionsSpec extends FunSpec with ShouldMatchers {
 
   describe("SwankProtocolConversionsSpec") {
 
-    import org.ensime.protocol.SwankProtocol._
+    val protocol = new SwankProtocol
+    import protocol.conversions._
     it("should encode all message types correctly") {
       assert(toWF(SendBackgroundMessageEvent(1, Some("ABCDEF"))).toWireString === """(:background-message 1 "ABCDEF")""")
       assert(toWF(SendBackgroundMessageEvent(1, None)).toWireString === "(:background-message 1 nil)")

--- a/src/test/scala/org/ensime/test/SwankProtocolSpec.scala
+++ b/src/test/scala/org/ensime/test/SwankProtocolSpec.scala
@@ -1,22 +1,98 @@
 package org.ensime.test
+
+import java.io.{ ByteArrayInputStream, ByteArrayOutputStream }
+
+import akka.actor.TypedActor.MethodCall
+import akka.actor.{ TypedProps, TypedActor, ActorSystem }
+import akka.testkit.TestProbe
+import org.ensime.server.RPCTarget
+import org.ensime.util.SExp
+import org.scalatest.{ BeforeAndAfterAll, FunSpec, ShouldMatchers }
+import org.ensime.protocol.{ OutgoingMessageEvent, SExpConversion }
 import org.scalatest.FunSpec
 import org.scalatest.matchers.ShouldMatchers
 import org.ensime.protocol.SwankProtocol
 import scala.tools.nsc.util.RangePosition
 import scala.tools.nsc.util.BatchSourceFile
 import scala.tools.nsc.io.{ VirtualFile, PlainFile, ZipArchive }
+import scala.concurrent.duration._
 
-class SwankProtocolSpec extends FunSpec with ShouldMatchers {
+class SwankProtocolSpec extends FunSpec with ShouldMatchers with BeforeAndAfterAll {
 
   class MockZipEntry(entry: String, archive: ZipArchive) extends VirtualFile(entry, entry) {
     override def underlyingSource: Option[ZipArchive] = Some(archive)
   }
 
+  def withTestConfig(f: (SwankProtocol, TestProbe, TestProbe) => Unit) {
+
+    implicit val actorSystem = ActorSystem.create()
+    try {
+      val typedSystem = TypedActor(actorSystem)
+
+      val rpcTargetProbe = TestProbe()
+      val outputProbe = TestProbe()
+      val rpcProxy = typedSystem.typedActorOf(TypedProps[RPCTarget], rpcTargetProbe.ref)
+
+      val protocol = new SwankProtocol()
+      protocol.setRPCTarget(rpcProxy)
+      protocol.setOutputActor(outputProbe.ref)
+
+      f(protocol, rpcTargetProbe, outputProbe)
+
+    } finally {
+      actorSystem.shutdown()
+    }
+  }
+
+  def testRPCMethod(msg: String, methodName: String, args: Any*) {
+    withTestConfig { (protocol, rpcProbe, outputProbe) =>
+      val encodedMsg = SExp.read(msg)
+      protocol.handleIncomingMessage(encodedMsg)
+
+      val rpcCall = rpcProbe.expectMsgType[MethodCall]
+      assert(rpcCall.method.getName == methodName)
+      val actualParams = rpcCall.parameters.toList
+      val expectedParams = args.toList
+      assert(expectedParams == actualParams)
+
+      outputProbe.expectNoMsg()
+    }
+  }
+
   describe("SwankProtocol") {
+    it("replies to connection info request") {
+      withTestConfig { (protocol, rpcProbe, outputProbe) =>
+        protocol.handleIncomingMessage(SExp.read("""(:swank-rpc (swank:connection-info) 42)"""))
+
+        val expected = SExp.read("""(:return (:ok (:pid nil :implementation (:name "ENSIME-ReferenceServer") :version "0.8.9")) 42))""")
+        outputProbe.expectMsg(1.seconds, OutgoingMessageEvent(expected))
+        rpcProbe.expectNoMsg()
+      }
+    }
+
+    it("processes remove-file request") {
+      testRPCMethod("""(:swank-rpc (swank:remove-file "Analyzer.scala") 42)""",
+        "rpcRemoveFile",
+        "Analyzer.scala", 42)
+    }
+
+    it("can encode and decode sexp to wire") {
+      val msg = SExp.read("""(:XXXX "abc") """)
+      val protocol = new SwankProtocol()
+
+      val os = new ByteArrayOutputStream()
+      protocol.writeMessage(msg, os)
+
+      val is = new ByteArrayInputStream(os.toByteArray)
+      val incomingMsg = protocol.readMessage(is).asInstanceOf[SExp]
+
+      assert(msg == incomingMsg)
+    }
+
     it("can convert a Position") {
       val f = new BatchSourceFile(new PlainFile("stuff"), "ABCDEF")
       val p = f.position(2)
-      val s = SwankProtocol.SExpConversion.posToSExp(p)
+      val s = SExpConversion.posToSExp(p)
       val expected = """(:file "stuff" :offset 2)"""
       val got = s.toReadableString(debug = false)
       assert(got == expected, got + " != " + expected)
@@ -26,7 +102,7 @@ class SwankProtocolSpec extends FunSpec with ShouldMatchers {
       val a = ZipArchive.fromPath("stuff.zip")
       val f = new BatchSourceFile(new MockZipEntry("stuff", a), "ABCDEF")
       val p = f.position(2)
-      val s = SwankProtocol.SExpConversion.posToSExp(p)
+      val s = SExpConversion.posToSExp(p)
       val expected = """(:file "stuff" :archive "stuff.zip" :offset 2)"""
       val got = s.toReadableString(debug = false)
       assert(got == expected, got + " != " + expected)
@@ -35,7 +111,7 @@ class SwankProtocolSpec extends FunSpec with ShouldMatchers {
     it("can convert a RangePosition") {
       val f = new BatchSourceFile(new PlainFile("stuff"), "ABCDEF")
       val p = new RangePosition(f, 1, 2, 3)
-      val s = SwankProtocol.SExpConversion.posToSExp(p)
+      val s = SExpConversion.posToSExp(p)
       val expected = """(:file "stuff" :offset 2 :start 1 :end 3)"""
       val got = s.toReadableString(debug = false)
       assert(got == expected, got + " != " + expected)
@@ -45,7 +121,7 @@ class SwankProtocolSpec extends FunSpec with ShouldMatchers {
       val a = ZipArchive.fromPath("stuff.zip")
       val f = new BatchSourceFile(new MockZipEntry("stuff", a), "ABCDEF")
       val p = new RangePosition(f, 1, 2, 3)
-      val s = SwankProtocol.SExpConversion.posToSExp(p)
+      val s = SExpConversion.posToSExp(p)
       val expected = """(:file "stuff" :archive "stuff.zip" :offset 2 :start 1 :end 3)"""
       val got = s.toReadableString(debug = false)
       assert(got == expected, got + " != " + expected)

--- a/src/test/scala/org/ensime/test/util/Helpers.scala
+++ b/src/test/scala/org/ensime/test/util/Helpers.scala
@@ -1,6 +1,8 @@
 package org.ensime.test.util
 
-import scala.actors.Actor._
+import akka.actor.ActorSystem
+import akka.testkit.TestProbe
+
 import scala.tools.nsc.Settings
 import scala.tools.nsc.reporters.StoreReporter
 import scala.tools.nsc.util.BatchSourceFile
@@ -11,13 +13,20 @@ import org.scalatest.exceptions.TestFailedException
 object Helpers {
 
   def withPresCompiler(action: RichCompilerControl => Any) = {
+    implicit val actorSystem = ActorSystem.create()
     val settings = new Settings(Console.println)
     settings.embeddedDefaults[RichCompilerControl]
     val reporter = new StoreReporter()
+    val indexer = TestProbe()
+    val parent = TestProbe()
     val cc = new RichPresentationCompiler(
-      settings, reporter, actor {}, actor {}, ProjectConfig.nullConfig)
-    action(cc)
-    cc.askShutdown()
+      settings, reporter, parent.ref, indexer.ref, ProjectConfig.nullConfig)
+    try {
+      action(cc)
+    } finally {
+      cc.askShutdown()
+      actorSystem.shutdown()
+    }
   }
 
   def srcFile(name: String, content: String) = new BatchSourceFile(name, content)


### PR DESCRIPTION
Move to akka actors
Cleanup/separate protocol
Added basic slf4j/logback config

This is the 2.9 mirror of #497.  I don't think the 2.9 branch is fully updated with all master changes - so this is more a marker so that @fommil can play with it and fixup the 2.9 branch based on the updates here.

The key differences between the 2.9 and master patch are some package changes in akka and some different ask behaviour between akka 2.0.5 and akka 2.3.4
