### PR TITLE
silence the presentation compiler

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -25,7 +25,8 @@ libraryDependencies <<= scalaVersion { scalaVersion => Seq(
   "com.typesafe.akka"          %% "akka-actor" 	         % "2.3.4",
   "com.typesafe.akka"          %% "akka-slf4j"           % "2.3.4",
   "com.typesafe.akka"          %% "akka-testkit"         % "2.3.4" % "test",
-  "ch.qos.logback"             % "logback-classic"       % "1.0.13",
+  "ch.qos.logback"             %  "logback-classic"      % "1.0.13",
+  "org.slf4j"                  %  "jul-to-slf4j"         % "1.7.7",
   "org.scala-refactoring"      %% "org.scala-refactoring.library" % "0.6.2"
 )}
 

--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -8,7 +8,14 @@
     </encoder>
   </appender>
 
-  <root level="debug">
+  <contextListener class="ch.qos.logback.classic.jul.LevelChangePropagator">
+    <resetJUL>true</resetJUL>
+  </contextListener>
+  
+  <!-- <logger name="org.ensime.indexer" level="DEBUG"/> -->
+  <logger name="scala.tools" level="WARN"/>
+  
+  <root level="INFO">
     <appender-ref ref="STDOUT" />
   </root>
 </configuration>

--- a/src/main/scala/org/ensime/server/Server.scala
+++ b/src/main/scala/org/ensime/server/Server.scala
@@ -1,16 +1,71 @@
 package org.ensime.server
 
+import java.io.PrintStream
 import java.io._
 import java.net.{ ServerSocket, Socket, InetAddress }
 import akka.actor.{ ActorRef, Actor, Props, ActorSystem }
 import org.ensime.protocol._
 import org.ensime.util.WireFormat
 import org.ensime.config.Environment
-import org.slf4j.LoggerFactory
+import org.slf4j._
+import scala.Console
 import scala.util.Properties._
+import org.slf4j.bridge.SLF4JBridgeHandler
+
+/**
+ * For when your upstream dependencies can't be trusted with
+ * stdout and stderr.
+ */
+object ConsoleOutputWorkaround {
+  def redirectScalaConsole(): Unit = {
+    // workaround SI-8717
+    Console.setOut(OutLog)
+    Console.setErr(ErrLog)
+  }
+
+  private val blacklist = Set("sun.", "java.", "scala.Console", "scala.Predef")
+  private abstract class StreamToLog extends OutputStream {
+    val buffer = new StringBuilder
+
+    override def write(b: Int): Unit = try {
+      val c = b.toChar
+      if (c == '\n') {
+        val message = buffer.toString
+        buffer.clear()
+
+        // reasonably expensive, but not as bad as printing to the
+        // screen (which is very slow and blocking)
+        val breadcrumbs = Thread.currentThread.getStackTrace.
+          toList.drop(2).map(_.getClassName).filterNot {
+            c => blacklist.exists(c.startsWith)
+          }
+        val logName = breadcrumbs.headOption.getOrElse("UNKNOWN SOURCE")
+        val log = LoggerFactory.getLogger(logName)
+
+        doLog(log, message)
+      } else buffer.append(c)
+    } catch {
+      case t: Throwable => // bad logging shouldn't kill the app
+    }
+
+    protected def doLog(log: Logger, message: String): Unit
+  }
+
+  private object ErrLog extends StreamToLog {
+    def doLog(log: Logger, m: String) = log.warn(m)
+  }
+
+  private object OutLog extends StreamToLog {
+    def doLog(log: Logger, m: String) = log.info(m)
+  }
+}
 
 object Server {
-  val logger = LoggerFactory.getLogger("Server")
+  SLF4JBridgeHandler.removeHandlersForRootLogger()
+  SLF4JBridgeHandler.install()
+  ConsoleOutputWorkaround.redirectScalaConsole()
+
+  val log = LoggerFactory.getLogger(classOf[Server])
 
   def main(args: Array[String]): Unit = {
     def setFallbackProp(name: String, fallback: String): Unit = {
@@ -23,7 +78,7 @@ object Server {
 
     val (cacheDir, host, requestedPort) = if (args.length > 0) {
       // legacy interface
-      logger.warn("WARNING: org.ensime.server.Server now takes properties instead of arguments")
+      log.warn("WARNING: org.ensime.server.Server now takes properties instead of arguments")
       args match {
         case Array(a, b, c) => (
           new File(new File(a).getParentFile, ".ensime_cache"), b, c.toInt)
@@ -45,7 +100,7 @@ object Server {
 
 class Server(cacheDir: File, host: String, requestedPort: Int) {
 
-  import Server.logger
+  import Server.log
 
   def startServer: Unit = {
     require(!cacheDir.exists || cacheDir.isDirectory, cacheDir + " is not a valid cache directory")
@@ -55,9 +110,9 @@ class Server(cacheDir: File, host: String, requestedPort: Int) {
     val listener = new ServerSocket(requestedPort, 0, InetAddress.getByName(host))
     val actualPort = listener.getLocalPort
 
-    logger.info("ENSIME Server on " + host + ":" + actualPort)
-    logger.info("cacheDir=" + cacheDir)
-    logger.info(Environment.info)
+    log.info("ENSIME Server on " + host + ":" + actualPort)
+    log.info("cacheDir=" + cacheDir)
+    log.info(Environment.info)
 
     writePort(cacheDir, actualPort)
 
@@ -68,11 +123,11 @@ class Server(cacheDir: File, host: String, requestedPort: Int) {
       while (true) {
         try {
           val socket = listener.accept()
-          logger.info("Got connection, creating handler...")
+          log.info("Got connection, creating handler...")
           val handler = actorSystem.actorOf(Props(classOf[SocketHandler], socket, protocol, project))
         } catch {
           case e: IOException =>
-            logger.error("ENSIME Server: ", e)
+            log.error("ENSIME Server: ", e)
         }
       }
     } finally {
@@ -84,7 +139,7 @@ class Server(cacheDir: File, host: String, requestedPort: Int) {
     val portfile = new File(cacheDir, "port")
     println("")
     if (!portfile.exists()) {
-      logger.info("CREATING " + portfile)
+      log.info("CREATING " + portfile)
       portfile.createNewFile()
     } else if (portfile.length > 0)
       // LEGACY: older clients create an empty file


### PR DESCRIPTION
bit of an evil hack, but the problem goes all the way down to `println` calls inside the scala compiler so we can't do much else.

If you really need to `println`, then use `System.out.println` instead of `Predef.println`.

goes someway toward #374
