### PR TITLE
Suport Scala 2.11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ language: scala
 jdk:
 - openjdk6
 scala:
-- 2.10.4
+- 2.11.1
 script:
 - sbt ++$TRAVIS_SCALA_VERSION clean test
 - ./.check-diff.sh

--- a/build.sbt
+++ b/build.sbt
@@ -8,7 +8,7 @@ organization := "org.ensime"
 
 name := "ensime"
 
-scalaVersion := "2.10.4"
+scalaVersion := "2.11.1"
 
 version := "0.9.10-SNAPSHOT"
 
@@ -19,7 +19,7 @@ libraryDependencies <<= scalaVersion { scalaVersion => Seq(
   "org.ow2.asm"                %  "asm-util"             % "5.0.3",
   "com.googlecode.json-simple" %  "json-simple"          % "1.1.1" intransitive(),
   "org.scalatest"              %% "scalatest"            % "2.2.0" % "test",
-  "org.scalariform"            %% "scalariform"          % "0.1.4",
+  "com.danieltrinh"            %% "scalariform"          % "0.1.5",
   "org.scala-lang"             %  "scala-compiler"       % scalaVersion,
   "org.scala-lang"             %  "scala-reflect"        % scalaVersion,
   "com.typesafe.akka"          %% "akka-actor" 	         % "2.3.4",
@@ -55,7 +55,7 @@ val JavaTools = List[Option[String]] (
 internalDependencyClasspath in Compile += { Attributed.blank(JavaTools) }
 
 // 0.10 is busted
-addCompilerPlugin("org.brianmckenna" %% "wartremover" % "0.9")
+addCompilerPlugin("org.brianmckenna" % "wartremover_2.11.0-RC4" % "0.9")
 
 scalacOptions in Compile ++= Seq(
   "-encoding", "UTF-8", "-target:jvm-1.6", "-feature", "-deprecation",

--- a/src/main/java/org/ensime/server/ConsoleRedirect.java
+++ b/src/main/java/org/ensime/server/ConsoleRedirect.java
@@ -1,0 +1,14 @@
+package org.ensime.server;
+
+import java.io.OutputStream;
+
+@SuppressWarnings("deprecation")
+class ConsoleRedirect {
+    public static void setOut(OutputStream out) {
+        scala.Console$.MODULE$.setOut(out);
+    }
+
+    public static void setErr(OutputStream err) {
+        scala.Console$.MODULE$.setErr(err);
+    }
+}

--- a/src/main/scala/org/ensime/config/ProjectConfig.scala
+++ b/src/main/scala/org/ensime/config/ProjectConfig.scala
@@ -83,6 +83,7 @@ object ProjectConfig {
           return List()
       }.toList
       case Some(NilAtom()) => List()
+      case Some(_) => List()
       case None => List()
     }
 
@@ -94,6 +95,7 @@ object ProjectConfig {
           return List()
       }.toList
       case Some(NilAtom()) => List()
+      case Some(_) => List()
       case None => List()
     }
 
@@ -559,7 +561,7 @@ object ProjectConfig {
      * 	  {\bf :indentSpaces} & 1-10  \\ \hline
      * 	  {\bf :indentWithTabs} & t or nil  \\ \hline
      * 	  {\bf :multilineScaladocCommentsStartOnFirstLine} & t or nil  \\ \hline
-     * 	  {\bf :preserveDanglingCloseParenthesis} & t or nil \\ \hline
+     * 	  {\bf :preserveDanglingCloseParenthesis} (Note: Not supported in 2.11 and later) & t or nil \\ \hline
      * 	  {\bf :preserveSpaceBeforeArguments} & t or nil  \\ \hline
      * 	  {\bf :rewriteArrowSymbols} & t or nil  \\ \hline
      * 	  {\bf :spaceBeforeColon} & t or nil  \\ \hline
@@ -805,8 +807,6 @@ case class ProjectConfig(
           fp.setPreference(MultilineScaladocCommentsStartOnFirstLine, value)
         case ('placeScaladocAsterisksBeneathSecondAsterisk, value: Boolean) =>
           fp.setPreference(PlaceScaladocAsterisksBeneathSecondAsterisk, value)
-        case ('preserveDanglingCloseParenthesis, value: Boolean) =>
-          fp.setPreference(PreserveDanglingCloseParenthesis, value)
         case ('preserveSpaceBeforeArguments, value: Boolean) =>
           fp.setPreference(PreserveSpaceBeforeArguments, value)
         case ('spaceInsideBrackets, value: Boolean) =>

--- a/src/main/scala/org/ensime/model/Model.scala
+++ b/src/main/scala/org/ensime/model/Model.scala
@@ -369,7 +369,7 @@ trait ModelBuilders { self: RichPresentationCompiler =>
       try {
         if (sym == RootPackage) {
           Some(root)
-        } else if (sym.isPackage) {
+        } else if (sym.hasPackageFlag) {
           Some(fromSymbol(sym))
         } else if (!sym.nameString.contains("$") && (sym != NoSymbol) && (sym.tpe != NoType)) {
           if (sym.isClass || sym.isTrait || sym.isModule ||

--- a/src/main/scala/org/ensime/server/Analyzer.scala
+++ b/src/main/scala/org/ensime/server/Analyzer.scala
@@ -79,9 +79,9 @@ class Analyzer(
 
     Future {
       if (!config.disableSourceLoadOnStartup) {
-        println("Building Java sources...")
+        log.info("Building Java sources...")
         javaCompiler.compileAll()
-        println("Building Scala sources...")
+        log.info("Building Scala sources...")
         reporter.disable()
         scalaCompiler.askReloadAllFiles()
         scalaCompiler.askNotifyWhenReady()

--- a/src/main/scala/org/ensime/server/Completion.scala
+++ b/src/main/scala/org/ensime/server/Completion.scala
@@ -24,9 +24,9 @@ trait CompletionControl {
     var score = 0
     if (sym.nameString.startsWith(prefix)) score += 10
     if (!inherited) score += 10
-    if (!sym.isPackage) score += 10
+    if (!sym.hasPackageFlag) score += 10
     if (!sym.isType) score += 10
-    if (sym.isLocal) score += 10
+    if (sym.isLocalToBlock) score += 10
     if (sym.isPublic) score += 10
     if (viaView == NoSymbol) score += 10
     if (sym.owner != definitions.AnyClass &&
@@ -264,7 +264,7 @@ trait CompletionControl {
           " ()")
 
         // Move point back to target of method selection.
-        val newP = p.withSource(src, 0).withPoint(p.point - prefix.length - dot.length)
+        val newP = p.withSource(src).withPoint(p.point - prefix.length - dot.length)
 
         Some(MemberContext(newP, prefix, constructing))
       case None => None
@@ -295,7 +295,7 @@ trait Completion { self: RichPresentationCompiler =>
           s == NoSymbol || s.nameString.contains("$")
         }
         memberSyms.flatMap { s =>
-          val name = if (s.isPackage) { s.nameString } else { typeShortName(s) }
+          val name = if (s.hasPackageFlag) { s.nameString } else { typeShortName(s) }
           if (name.startsWith(prefix)) {
             Some(CompletionInfo(name, CompletionSignature(List(), ""), -1, isCallable = false, 50, None))
           } else None

--- a/src/main/scala/org/ensime/server/Helpers.scala
+++ b/src/main/scala/org/ensime/server/Helpers.scala
@@ -143,7 +143,7 @@ trait Helpers { self: Global =>
 
   def packageSymFromPath(path: String): Option[Symbol] = {
     val candidates = symsAtQualifiedPath(path, RootPackage)
-    candidates.find { s => s.isPackage }
+    candidates.find { s => s.hasPackageFlag }
   }
 
   // Where path is the qualified name of a symbol that is a direct or
@@ -222,7 +222,7 @@ trait Helpers { self: Global =>
       "name" -> sym.toString(),
       "  isMethod" -> sym.isMethod,
       "  isAbstractClass" -> sym.isAbstractClass,
-      "  isPackage" -> sym.isPackage,
+      "  isPackage" -> sym.hasPackageFlag,
       "  isValue" -> sym.isValue,
       "  isVariable" -> sym.isVariable,
       "  isClass" -> sym.isClass,

--- a/src/main/scala/org/ensime/server/Indexer.scala
+++ b/src/main/scala/org/ensime/server/Indexer.scala
@@ -45,7 +45,7 @@ class Indexer(project: Project,
       process(msg)
     } catch {
       case e: Exception =>
-        log.error("Error at Indexer message loop: " + e + " :" + e.getStackTraceString)
+        log.error("Error at Indexer message loop: ", e)
     }
   }
 

--- a/src/main/scala/org/ensime/server/NamespaceTraversal.scala
+++ b/src/main/scala/org/ensime/server/NamespaceTraversal.scala
@@ -11,7 +11,7 @@ trait NamespaceTraversal { self: RichPresentationCompiler =>
 
   def traverse(v: NamespaceVisitor, sym: Symbol) {
     try {
-      if (sym.isPackage) {
+      if (sym.hasPackageFlag) {
         v.visitPackage(sym)
         traverseMembers(v, sym)
       } else if (!sym.nameString.contains("$") && (sym != NoSymbol) && (sym.tpe != NoType)) {

--- a/src/main/scala/org/ensime/server/Project.scala
+++ b/src/main/scala/org/ensime/server/Project.scala
@@ -96,7 +96,7 @@ class Project(val protocol: Protocol, actorSystem: ActorSystem) extends ProjectR
           process(x)
         } catch {
           case e: Exception =>
-            println("Error at Project message loop: " + e + " :\n" + e.getStackTraceString)
+            log.error("Error at Project message loop: ", e)
         }
 
     }
@@ -161,7 +161,7 @@ class Project(val protocol: Protocol, actorSystem: ActorSystem) extends ProjectR
       ea ! IndexerShutdownReq()
     }
     val newIndexer = actorSystem.actorOf(Props(new Indexer(this, protocol.conversions, config)), "indexer")
-    println("Initing Indexer...")
+    log.info("Initing Indexer...")
     if (!config.disableIndexOnStartup) {
       newIndexer ! RebuildStaticIndexReq()
     }
@@ -200,8 +200,7 @@ class Project(val protocol: Protocol, actorSystem: ActorSystem) extends ProjectR
   }
 
   protected def shutdownServer() {
-    System.out.println("Server is exiting...")
-    System.out.flush()
+    log.info("Server is exiting...")
     System.exit(0)
   }
 

--- a/src/main/scala/org/ensime/server/RichPresentationCompiler.scala
+++ b/src/main/scala/org/ensime/server/RichPresentationCompiler.scala
@@ -478,7 +478,7 @@ class RichPresentationCompiler(
       case ri: ReloadItem if ri.sources == sources => Some(ri)
       case _ => None
     }
-    superseeded.foreach(_.response.set())
+    superseeded.foreach(_.response.set(()))
     wrap[Unit](r => new ReloadItem(sources, r).apply(), _ => ())
   }
 

--- a/src/main/scala/org/ensime/server/SemanticHighlighting.scala
+++ b/src/main/scala/org/ensime/server/SemanticHighlighting.scala
@@ -1,6 +1,7 @@
 package org.ensime.server
 
 import org.ensime.model.{ Helpers, SymbolDesignation, SymbolDesignations }
+import org.slf4j.LoggerFactory
 import scala.collection.mutable.ListBuffer
 import scala.tools.nsc.interactive.Global
 import scala.reflect.internal.util.RangePosition
@@ -9,7 +10,7 @@ import scala.tools.nsc.symtab.Flags._
 trait SemanticHighlighting { self: Global with Helpers =>
 
   class SymDesigsTraverser(p: RangePosition, tpeSet: Set[scala.Symbol]) extends Traverser {
-
+    private val log = LoggerFactory.getLogger(getClass)
     val syms = ListBuffer[SymbolDesignation]()
 
     override def traverse(t: Tree) {
@@ -51,7 +52,7 @@ trait SemanticHighlighting { self: Global with Helpers =>
                   add('param)
                 } else if (sym.isMethod) {
                   add('functionCall)
-                } else if (sym.isPackage) {
+                } else if (sym.hasPackageFlag) {
                   add('package)
                 } else if (sym.isTrait) {
                   add('trait)
@@ -59,9 +60,9 @@ trait SemanticHighlighting { self: Global with Helpers =>
                   add('class)
                 } else if (sym.isModule) {
                   add('object)
-                } else if (sym.isVariable && sym.isLocal) {
+                } else if (sym.isVariable && sym.isLocalToBlock) {
                   add('var)
-                } else if (sym.isValue && sym.isLocal) {
+                } else if (sym.isValue && sym.isLocalToBlock) {
                   add('val)
                 } else if (sym.isVariable) {
                   add('varField)
@@ -104,7 +105,7 @@ trait SemanticHighlighting { self: Global with Helpers =>
                 } else {
                   addAt(start, end, 'functionCall)
                 }
-              } else if (sym.isPackage) {
+              } else if (sym.hasPackageFlag) {
                 addAt(start, end, 'package)
               } else if (sym.isTrait) {
                 addAt(start, end, 'trait)
@@ -171,8 +172,7 @@ trait SemanticHighlighting { self: Global with Helpers =>
           }
         } catch {
           case e: Throwable =>
-            System.err.println("Error in AST traverse:")
-            e.printStackTrace(System.err);
+            log.error("Error in AST traverse:  ", e)
         }
         super.traverse(t)
       }

--- a/src/main/scala/org/ensime/server/Server.scala
+++ b/src/main/scala/org/ensime/server/Server.scala
@@ -19,8 +19,8 @@ import org.slf4j.bridge.SLF4JBridgeHandler
 object ConsoleOutputWorkaround {
   def redirectScalaConsole(): Unit = {
     // workaround SI-8717
-    Console.setOut(OutLog)
-    Console.setErr(ErrLog)
+    ConsoleRedirect.setOut(OutLog)
+    ConsoleRedirect.setErr(ErrLog)
   }
 
   private val blacklist = Set("sun.", "java.", "scala.Console", "scala.Predef")

--- a/src/main/scala/org/ensime/util/FileUtil.scala
+++ b/src/main/scala/org/ensime/util/FileUtil.scala
@@ -5,7 +5,8 @@ import java.nio.charset.Charset
 import java.security.MessageDigest
 import scala.collection.Seq
 import scala.collection.mutable
-import scala.tools.nsc.io.{ AbstractFile, ZipArchive }
+import scala.reflect.io.ZipArchive
+import scala.tools.nsc.io.{ AbstractFile }
 
 // This routine copied from http://rosettacode.org/wiki/Walk_a_directory/Recursively#Scala
 
@@ -114,10 +115,18 @@ object FileUtils {
     }).toSet
   }
 
+  // NOTE: Taken from ZipArchive internals to replace deepIterator that was removed 2.11
+  private def walkIterator(its: Iterator[AbstractFile]): Iterator[AbstractFile] = {
+    its flatMap { f =>
+      if (f.isDirectory) walkIterator(f.iterator)
+      else Iterator(f)
+    }
+  }
+
   def expandSourceJars(fileList: Iterable[CanonFile]): Iterable[AbstractFile] = {
     fileList.flatMap { f =>
       if (isValidArchive(f)) {
-        ZipArchive.fromFile(f).deepIterator.filter(f => isValidSourceName(f.name))
+        walkIterator(ZipArchive.fromFile(f).iterator).filter(f => isValidSourceName(f.name))
       } else {
         Seq(AbstractFile.getFile(f))
       }

--- a/src/main/scala/org/ensime/util/Reporter.scala
+++ b/src/main/scala/org/ensime/util/Reporter.scala
@@ -45,8 +45,8 @@ class PresentationReporter(handler: ReportHandler) extends Reporter {
             f,
             formatMessage(msg),
             severity.id,
-            pos.startOrPoint,
-            pos.endOrPoint,
+            pos.start,
+            pos.end,
             pos.line,
             pos.column)
           handler.reportScalaNotes(List(note))

--- a/src/test/scala/org/ensime/test/SwankProtocolSpec.scala
+++ b/src/test/scala/org/ensime/test/SwankProtocolSpec.scala
@@ -1,6 +1,6 @@
 package org.ensime.test
 
-import java.io.{ ByteArrayInputStream, ByteArrayOutputStream }
+import java.io.{ File, ByteArrayInputStream, ByteArrayOutputStream }
 
 import akka.actor.TypedActor.MethodCall
 import akka.actor.{ TypedProps, TypedActor, ActorSystem }
@@ -12,7 +12,8 @@ import org.ensime.protocol.{ OutgoingMessageEvent, SExpConversion }
 import org.ensime.protocol.SwankProtocol
 import scala.reflect.internal.util.RangePosition
 import scala.reflect.internal.util.BatchSourceFile
-import scala.tools.nsc.io.{ VirtualFile, PlainFile, ZipArchive }
+import scala.reflect.io.ZipArchive
+import scala.tools.nsc.io.{ VirtualFile, PlainFile }
 import scala.concurrent.duration._
 
 class SwankProtocolSpec extends FunSpec with ShouldMatchers with BeforeAndAfterAll {
@@ -97,7 +98,7 @@ class SwankProtocolSpec extends FunSpec with ShouldMatchers with BeforeAndAfterA
     }
 
     it("can convert a Position in a ZipArchive entry") {
-      val a = ZipArchive.fromPath("stuff.zip")
+      val a = ZipArchive.fromFile(new File("stuff.zip"))
       val f = new BatchSourceFile(new MockZipEntry("stuff", a), "ABCDEF")
       val p = f.position(2)
       val s = SExpConversion.posToSExp(p)
@@ -116,7 +117,7 @@ class SwankProtocolSpec extends FunSpec with ShouldMatchers with BeforeAndAfterA
     }
 
     it("can convert a RangePosition in a ZipArchive entry") {
-      val a = ZipArchive.fromPath("stuff.zip")
+      val a = ZipArchive.fromFile(new File("stuff.zip"))
       val f = new BatchSourceFile(new MockZipEntry("stuff", a), "ABCDEF")
       val p = new RangePosition(f, 1, 2, 3)
       val s = SExpConversion.posToSExp(p)


### PR DESCRIPTION
This adds support for Scala 2.11 to ENSIME.

Some notes an things that changed:
1. The main Scalariform project in github has gone silent and has not updated to support 2.11. Daniel-trinh has picked up support for Scalaiform and made the necessary changes. If the main Scalariform project comes back online we can investigate switching back.
2. I'm using a wartremover from a slightly older 2.11 release because only wartermover-0.10 is built with the current 2.11 but that release is broken and we need to use version 0.9. I'll switch to a new version as soon as one becomes available.
3. The build no longer uses fatal warnings because of the deprecation of `Console.setOut`. The replacement `Console.withOut` doesn't really meet our needs. Hopefully the need to deal with `Console` will go away before this becomes an issue.
4. The preserveDanglingCloseParenthesis option was removed in Scalariform-0.1.5. This was removed from ProjectConfig.scala and the doc was updated to note that it is not supported in 2.11 and later.
5. The rest of the changes are pretty minor and just deal with changes in some compiler constants, stricter pattern matching completeness checks, etc. 
