### PR TITLE
Handle differences between RangePositions and OffsetPositions.

### DIFF
--- a/src/main/scala/org/ensime/server/SemanticHighlighting.scala
+++ b/src/main/scala/org/ensime/server/SemanticHighlighting.scala
@@ -73,10 +73,10 @@ trait SemanticHighlighting { self: Global with Helpers =>
               }
             case Select(qual, selector: Name) =>
               val sym = t.symbol
-              val start = try {
+              val start = if (qual.pos.isRange) {
                 qual.pos.end + 1
-              } catch {
-                case _: Throwable => treeP.start
+              } else {
+                treeP.start
               }
               val len = selector.decode.length()
               val end = start + len


### PR DESCRIPTION
This applies a code change from @edanl to address a change in behavior between Scala 2.10 and 2.11 for `Position`s. 

This change can be applied to both Scala 2.11 and Scala 2.10.
