### PR TITLE
Fix #437.  Do not fetch symbol source location when listing type members

### DIFF
--- a/src/main/scala/org/ensime/model/Model.scala
+++ b/src/main/scala/org/ensime/model/Model.scala
@@ -389,7 +389,7 @@ trait ModelBuilders { self: RichPresentationCompiler =>
 
   object TypeInfo {
 
-    def apply(t: Type, members: Iterable[EntityInfo] = List()): TypeInfo = {
+    def apply(t: Type, members: Iterable[EntityInfo] = List(), locateSymPos: Boolean = false): TypeInfo = {
       val tpe = t match {
         // TODO: Instead of throwing away this information, would be better to
         // alert the user that the type is existentially quantified.
@@ -404,6 +404,7 @@ trait ModelBuilders { self: RichPresentationCompiler =>
           val typeSym = tpe.typeSymbol
           val sym = if (typeSym.isModuleClass)
             typeSym.sourceModule else typeSym
+          val symPos = if (locateSymPos) locateSymbolPos(sym) else ask(() => sym.pos)
           val outerTypeId = outerClass(typeSym).map(s => cacheType(s.tpe))
           new TypeInfo(
             typeShortName(tpe),
@@ -412,7 +413,7 @@ trait ModelBuilders { self: RichPresentationCompiler =>
             typeFullName(tpe),
             args,
             members,
-            locateSymbolPos(sym),
+            symPos,
             outerTypeId)
         case _ => nullInfo
       }

--- a/src/main/scala/org/ensime/server/RichPresentationCompiler.scala
+++ b/src/main/scala/org/ensime/server/RichPresentationCompiler.scala
@@ -41,13 +41,13 @@ trait RichCompilerControl extends CompilerControl with RefactoringControl with C
     askOption(symbolAt(p).map(SymbolInfo(_))).getOrElse(None)
 
   def askTypeInfoAt(p: Position): Option[TypeInfo] =
-    askOption(typeAt(p).map(TypeInfo(_))).getOrElse(None)
+    askOption(typeAt(p).map(TypeInfo(_, locateSymPos = true))).getOrElse(None)
 
   def askTypeInfoById(id: Int): Option[TypeInfo] =
-    askOption(typeById(id).map(TypeInfo(_))).getOrElse(None)
+    askOption(typeById(id).map(TypeInfo(_, locateSymPos = true))).getOrElse(None)
 
   def askTypeInfoByName(name: String): Option[TypeInfo] =
-    askOption(typeByName(name).map(TypeInfo(_))).getOrElse(None)
+    askOption(typeByName(name).map(TypeInfo(_, locateSymPos = true))).getOrElse(None)
 
   def askTypeInfoByNameAt(name: String, p: Position): Option[TypeInfo] = {
     val nameSegs = name.split("\\.")
@@ -60,7 +60,7 @@ trait RichCompilerControl extends CompilerControl with RefactoringControl with C
         val roots = filterMembersByPrefix(members, firstName, matchEntire = true, caseSens = true).map { _.sym }
         val restOfPath = nameSegs.drop(1).mkString(".")
         val syms = roots.flatMap { symsAtQualifiedPath(restOfPath, _) }
-        syms.find(_.tpe != NoType).map { sym => TypeInfo(sym.tpe) }
+        syms.find(_.tpe != NoType).map { sym => TypeInfo(sym.tpe, locateSymPos = true) }
       }
     ) yield infos).getOrElse(None)
   }
@@ -261,7 +261,7 @@ class RichPresentationCompiler(
 
   protected def inspectType(tpe: Type): TypeInspectInfo = {
     new TypeInspectInfo(
-      TypeInfo(tpe),
+      TypeInfo(tpe, locateSymPos = true),
       companionTypeOf(tpe).map(cacheType),
       prepareSortedInterfaceInfo(typePublicMembers(tpe.asInstanceOf[Type])))
   }
@@ -271,7 +271,7 @@ class RichPresentationCompiler(
     val preparedMembers = prepareSortedInterfaceInfo(members)
     typeAt(p).map { t =>
       new TypeInspectInfo(
-        TypeInfo(t),
+        TypeInfo(t, locateSymPos = true),
         companionTypeOf(t).map(cacheType),
         preparedMembers)
     }


### PR DESCRIPTION
This stops calling `locateSymbolPos` unless specifically requested.

As a result, the type inspector no longer shows links to source on every parent class: the user must inspect the desired class in order to see the source link. If this is too much hassle, we can change the elisp code to show source links anyway, and determine the source only when the link is clicked.
