### PR TITLE
Properly highlight setter operators taking into account the _= suffix.

### DIFF
--- a/src/main/scala/org/ensime/server/SemanticHighlighting.scala
+++ b/src/main/scala/org/ensime/server/SemanticHighlighting.scala
@@ -96,7 +96,13 @@ trait SemanticHighlighting { self: Global with Helpers =>
               } else if (sym.isMethod) {
                 if (sym.nameString == "apply" || sym.nameString == "update") {}
                 else if (selector.isOperatorName) {
-                  addAt(start, end, 'operator)
+                  if (nme.isSetterName(selector)) {
+                    val end = treeP.end
+                    val start = end - selector.dropSetter.length
+                    addAt(start, end, 'operator)
+                  } else {
+                    addAt(start, end, 'operator)
+                  }
                 } else {
                   addAt(start, end, 'functionCall)
                 }

--- a/src/test/scala/org/ensime/test/SemanticHighlightingSpec.scala
+++ b/src/test/scala/org/ensime/test/SemanticHighlightingSpec.scala
@@ -373,6 +373,29 @@ class SemanticHighlightingSpec extends FunSpec with Matchers {
       }
     }
 
+    it("should highlight setter operators") {
+      Helpers.withPresCompiler { cc =>
+        val sds = getSymbolDesignations(
+          cc, """
+            package com.example
+            object Fubar {
+               private var v: Int = 0
+               def value = v
+               def value_=(a: Int) v = a
+            }
+            class Test {
+              Fubar.value = false
+            }
+          """,
+          List('operator)
+        )
+        // TODO There should be no "=" or ":"
+        assert(sds === List(
+          ('operator, "value")
+        ))
+      }
+    }
+
     it("selects should not be confused by whitespace") {
       Helpers.withPresCompiler { cc =>
         val sds = getSymbolDesignations(


### PR DESCRIPTION
Fixes a semantic highlighting problem for setter operators. Before calculating the starting position of the setter operator the _= suffix must be dropped or the starting position of the operator will be two characters too early. An instance of this can be seen in Analyzer.scala. In the following code `value` is a setter operator and it was being highlighted starting with the 'g', 'e', and 'e' respectively.

NOTE: This commit is not compatible with Scala 2.10 or 2.9. I will work on separate PRs for the previous Scala versions.

``` scala
  settings.YpresentationDebug.value = presCompLog.isTraceEnabled
  settings.YpresentationVerbose.value = presCompLog.isDebugEnabled
  settings.verbose.value = presCompLog.isDebugEnabled
```
