### PR TITLE
Support for Scala 2.11.2.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -8,7 +8,7 @@ organization := "org.ensime"
 
 name := "ensime"
 
-scalaVersion := "2.11.1"
+scalaVersion := "2.11.2"
 
 version := "0.9.10-SNAPSHOT"
 

--- a/src/main/scala/org/ensime/util/Reporter.scala
+++ b/src/main/scala/org/ensime/util/Reporter.scala
@@ -26,30 +26,27 @@ class PresentationReporter(handler: ReportHandler) extends Reporter {
     }
   }
 
-  override def info(pos: Position, msg: String, force: Boolean) {
-    if (msg.contains("MissingRequirementError: object scala not found") ||
-      msg.contains("MissingRequirementError: class scala.runtime.BooleanRef not found")) {
-      handler.messageUser("Fatal Error: Scala language library not found on classpath. You may need to run 'sbt update', or 'mvn update'.")
-    }
-    println("INFO: " + msg)
-  }
-
   override def info0(pos: Position, msg: String, severity: Severity, force: Boolean) {
     severity.count += 1
     try {
-      if (enabled) {
-        if (pos.isDefined) {
-          val source = pos.source
-          val f = source.file.absolute.path
-          val note = new Note(
-            f,
-            formatMessage(msg),
-            severity.id,
-            pos.start,
-            pos.end,
-            pos.line,
-            pos.column)
-          handler.reportScalaNotes(List(note))
+      if (severity.id == 0) {
+        println("INFO: " + msg)
+      } else {
+        if (enabled) {
+          if (pos.isDefined) {
+            val source = pos.source
+            val f = source.file.absolute.path
+            val note = new Note(
+              f,
+              formatMessage(msg),
+              severity.id,
+              pos.start,
+              pos.end,
+              pos.line,
+              pos.column
+            )
+            handler.reportScalaNotes(List(note))
+          }
         }
       }
     } catch {


### PR DESCRIPTION
The recently released Scala 2.11.2 broke the PresentationReporter. The `Reporter.info()` method is now declared final and delegates to the `info0()` method with severity set to `INFO`. 

@aemoncannon do you think the "MissingRequirement" checks are still needed? I tried to come up with a way to reproduce that message but didn't have any luck.
