### PR TITLE
Update SExp rendering and cleanup code

### DIFF
--- a/src/main/scala/org/ensime/config/ProjectConfig.scala
+++ b/src/main/scala/org/ensime/config/ProjectConfig.scala
@@ -167,7 +167,10 @@ object ProjectConfig {
       }
       main.map { p: KeyMap =>
         val deps = (p.get(dependsOnModulesKey) match {
-          case Some(names: SExpList) => names.map(_.toString)
+          case Some(names: SExpList) => names.map {
+            case StringAtom(v) => v
+            case x => x.toString
+          }
           case _ => List()
         }).flatMap { subproject(m, _) }
         deps.foldLeft(p)(mergeWithDependency)

--- a/src/main/scala/org/ensime/indexer/LuceneIndexer.scala
+++ b/src/main/scala/org/ensime/indexer/LuceneIndexer.scala
@@ -31,7 +31,6 @@ import scala.util.matching.Regex
 import scala.collection.mutable.ListBuffer
 import org.objectweb.asm.Opcodes
 import org.json.simple._
-import scala.util.Properties._
 import akka.pattern.ask
 
 object LuceneIndex extends StringSimilarity {

--- a/src/main/scala/org/ensime/protocol/Protocol.scala
+++ b/src/main/scala/org/ensime/protocol/Protocol.scala
@@ -141,7 +141,7 @@ trait Protocol {
    * @param  callId The id of the failed RPC call.
    * @return        Void
    */
-  def sendRPCError(code: Int, detail: Option[String], callId: Int)
+  def sendRPCError(code: Int, detail: String, callId: Int)
 
   /**
    * Notify the client that a message was received
@@ -151,6 +151,5 @@ trait Protocol {
    * @param  detail  A message describing the problem.
    * @return        Void
    */
-  def sendProtocolError(code: Int, detail: Option[String])
-
+  def sendProtocolError(code: Int, detail: String)
 }

--- a/src/main/scala/org/ensime/server/Analyzer.scala
+++ b/src/main/scala/org/ensime/server/Analyzer.scala
@@ -122,8 +122,7 @@ class Analyzer(
       case rpcReq @ RPCRequestEvent(req: Any, callId: Int) =>
         try {
           if (awaitingInitialCompile) {
-            project.sendRPCError(ErrAnalyzerNotReady,
-              Some("Analyzer is not ready! Please wait."), callId)
+            project.sendRPCError(ErrAnalyzerNotReady, "Analyzer is not ready! Please wait.", callId)
           } else {
             reporter.enable()
 
@@ -154,8 +153,7 @@ class Analyzer(
 
               case PatchSourceReq(file, edits) =>
                 if (!file.exists()) {
-                  project.sendRPCError(ErrFileDoesNotExist,
-                    Some(file.getPath), callId)
+                  project.sendRPCError(ErrFileDoesNotExist, file.getPath, callId)
                 } else {
                   val f = createSourceFile(file)
                   val revised = PatchSource.applyOperations(f, edits)
@@ -286,8 +284,7 @@ class Analyzer(
         } catch {
           case e: Throwable =>
             log.error(e, "Error handling RPC: " + e)
-            project.sendRPCError(ErrExceptionInAnalyzer,
-              Some("Error occurred in Analyzer. Check the server log."), callId)
+            project.sendRPCError(ErrExceptionInAnalyzer, "Error occurred in Analyzer. Check the server log.", callId)
         }
       case other =>
         log.error("Unknown message type: " + other)

--- a/src/main/scala/org/ensime/server/DebugManager.scala
+++ b/src/main/scala/org/ensime/server/DebugManager.scala
@@ -438,9 +438,7 @@ class DebugManager(project: Project, indexer: ActorRef,
         } catch {
           case e: Throwable =>
             log.error(e, "Error handling RPC:")
-            project.sendRPCError(ErrExceptionInDebugger,
-              Some("Error occurred in Debug Manager. Check the server log."),
-              callId)
+            project.sendRPCError(ErrExceptionInDebugger, "Error occurred in Debug Manager. Check the server log.", callId)
         }
       case other =>
         log.error("Unknown event type: " + other)

--- a/src/main/scala/org/ensime/server/Indexer.scala
+++ b/src/main/scala/org/ensime/server/Indexer.scala
@@ -99,16 +99,13 @@ class Indexer(project: Project,
                 case method :: rest =>
                   project ! RPCResultEvent(
                     toWF(method), callId)
-                case _ => project.sendRPCError(ErrExceptionInIndexer,
-                  Some("Failed to find method bytecode"), callId)
+                case _ => project.sendRPCError(ErrExceptionInIndexer, "Failed to find method bytecode", callId)
               }
           }
         } catch {
           case e: Exception =>
             log.error(e, "Error handling RPC: " + req)
-            project.sendRPCError(ErrExceptionInIndexer,
-              Some("Error occurred in indexer. Check the server log."),
-              callId)
+            project.sendRPCError(ErrExceptionInIndexer, "Error occurred in indexer. Check the server log.", callId)
         }
       case other =>
         log.warning("Indexer: WTF, what's " + other)

--- a/src/main/scala/org/ensime/server/Project.scala
+++ b/src/main/scala/org/ensime/server/Project.scala
@@ -13,7 +13,7 @@ import org.slf4j.LoggerFactory
 import scala.collection.mutable
 
 case class RPCResultEvent(value: WireFormat, callId: Int)
-case class RPCErrorEvent(code: Int, detail: Option[String], callId: Int)
+case class RPCErrorEvent(code: Int, detail: String, callId: Int)
 case class RPCRequestEvent(req: Any, callId: Int)
 case class AsyncEvent(evt: WireFormat)
 
@@ -76,11 +76,8 @@ class Project(cacheDir: File, val protocol: Protocol, actorSystem: ActorSystem) 
   private var undoCounter = 0
   private val undos: mutable.LinkedHashMap[Int, Undo] = new mutable.LinkedHashMap[Int, Undo]
 
-  def sendRPCError(code: Int, detail: Option[String], callId: Int) {
+  def sendRPCError(code: Int, detail: String, callId: Int) {
     actor ! RPCErrorEvent(code, detail, callId)
-  }
-  def sendRPCError(detail: String, callId: Int) {
-    sendRPCError(ProtocolConst.ErrExceptionInRPC, Some(detail), callId)
   }
 
   def bgMessage(msg: String) {

--- a/src/main/scala/org/ensime/server/RPCTarget.scala
+++ b/src/main/scala/org/ensime/server/RPCTarget.scala
@@ -100,14 +100,14 @@ trait ProjectRPCTarget extends RPCTarget { self: Project =>
   override def rpcPeekUndo(callId: Int) {
     peekUndo() match {
       case Right(result) => sendRPCReturn(toWF(result), callId)
-      case Left(msg) => sendRPCError(ErrPeekUndoFailed, Some(msg), callId)
+      case Left(msg) => sendRPCError(ErrPeekUndoFailed, msg, callId)
     }
   }
 
   override def rpcExecUndo(undoId: Int, callId: Int) {
     execUndo(undoId) match {
       case Right(result) => sendRPCReturn(toWF(result), callId)
-      case Left(msg) => sendRPCError(ErrExecUndoFailed, Some(msg), callId)
+      case Left(msg) => sendRPCError(ErrExecUndoFailed, msg, callId)
     }
   }
 
@@ -301,8 +301,7 @@ trait ProjectRPCTarget extends RPCTarget { self: Project =>
       }
     } catch {
       case e: ScalaParserException =>
-        sendRPCError(ErrFormatFailed,
-          Some("Could not parse broken syntax: " + e), callId)
+        sendRPCError(ErrFormatFailed, "Could not parse broken syntax: " + e, callId)
     }
   }
 
@@ -323,13 +322,11 @@ trait ProjectRPCTarget extends RPCTarget { self: Project =>
       FileUtils.writeChanges(changeList) match {
         case Right(_) => sendRPCAckOK(callId)
         case Left(e) =>
-          sendRPCError(ErrFormatFailed,
-            Some("Could not write any formatting changes: " + e), callId)
+          sendRPCError(ErrFormatFailed, "Could not write any formatting changes: " + e, callId)
       }
     } catch {
       case e: ScalaParserException =>
-        sendRPCError(ErrFormatFailed,
-          Some("Cannot format broken syntax: " + e), callId)
+        sendRPCError(ErrFormatFailed, "Cannot format broken syntax: " + e, callId)
     }
   }
 

--- a/src/main/scala/org/ensime/server/RichPresentationCompiler.scala
+++ b/src/main/scala/org/ensime/server/RichPresentationCompiler.scala
@@ -93,7 +93,7 @@ trait RichCompilerControl extends CompilerControl with RefactoringControl with C
 
   def askReloadAllFiles() = {
     val all = (config.sourceFilenames.map(getSourceFile) ++
-      activeUnits.map(_.source)).toSet.toList
+      activeUnits().map(_.source)).toSet.toList
     askReloadFiles(all)
   }
 
@@ -407,7 +407,7 @@ class RichPresentationCompiler(
 
   private var notifyWhenReady = false
 
-  override def isOutOfDate(): Boolean = {
+  override def isOutOfDate: Boolean = {
     if (notifyWhenReady && !super.isOutOfDate) {
       parent ! FullTypeCheckCompleteEvent()
       notifyWhenReady = false

--- a/src/main/scala/org/ensime/server/Server.scala
+++ b/src/main/scala/org/ensime/server/Server.scala
@@ -4,7 +4,7 @@ import java.io._
 import java.net.{ ServerSocket, Socket, InetAddress }
 import akka.actor.{ ActorRef, Actor, Props, ActorSystem }
 import org.ensime.protocol._
-import org.ensime.util.{ SExp, WireFormat }
+import org.ensime.util.{ SExpParser, SExp, WireFormat }
 import org.ensime.config.{ ProjectConfig, Environment }
 import org.slf4j._
 import scala.io.Source
@@ -88,7 +88,7 @@ object Server {
     val configSrc = Source.fromFile(ensimeFile)
     try {
       val content = configSrc.getLines().filterNot(_.startsWith(";;")).mkString("\n")
-      ProjectConfig.fromSExp(SExp.read(content)) match {
+      ProjectConfig.fromSExp(SExpParser.read(content)) match {
         case Right(config) =>
           config
         case Left(ex) =>
@@ -127,7 +127,7 @@ class Server(cacheDir: File, host: String, requestedPort: Int) {
         try {
           val socket = listener.accept()
           log.info("Got connection, creating handler...")
-          val handler = actorSystem.actorOf(Props(classOf[SocketHandler], socket, protocol, project))
+          actorSystem.actorOf(Props(classOf[SocketHandler], socket, protocol, project))
         } catch {
           case e: IOException =>
             log.error("ENSIME Server: ", e)

--- a/src/main/scala/org/ensime/util/ClassIterator.scala
+++ b/src/main/scala/org/ensime/util/ClassIterator.scala
@@ -10,7 +10,7 @@ import org.objectweb.asm.ClassReader
 import java.io._
 import java.util.jar.{ JarFile, Manifest => JarManifest }
 import java.util.zip._
-import java.io.{ File, InputStream, IOException }
+import java.io.{ File, InputStream }
 
 trait ClassHandler {
   def onClass(name: String, location: String, flags: Int) {}
@@ -186,7 +186,7 @@ object ClassIterator {
 
   private def isClass(e: FileEntry): Boolean = {
     import scala.language.reflectiveCalls
-    (!e.isDirectory) && e.getName.toLowerCase.endsWith(".class")
+    (!e.isDirectory) && e.getName().toLowerCase.endsWith(".class")
   }
 
   private def processDirectory(dir: File, callback: Callback) {

--- a/src/main/scala/org/ensime/util/SExpParser.scala
+++ b/src/main/scala/org/ensime/util/SExpParser.scala
@@ -1,0 +1,72 @@
+package org.ensime.util
+
+import scala.util.parsing.combinator.RegexParsers
+import scala.util.parsing.input
+
+object SExpParser extends RegexParsers {
+
+  object StringParser extends RegexParsers {
+    override def skipWhitespace = false
+
+    def string = "\"" ~ rep(string_char) ~ "\"" ^^ {
+      case "\"" ~ l ~ "\"" => l.mkString
+    }
+
+    lazy val string_char = string_escaped_char | string_lone_backslash | string_normal_chars
+    lazy val string_escaped_char = """\\["\\ntr]""".r ^^ {
+      _.charAt(1) match {
+        case 'n' => '\n'
+        case 't' => '\t'
+        case 'r' => '\r'
+        case x => x
+      }
+    }
+    lazy val string_lone_backslash = "\\"
+    lazy val string_normal_chars = """[^"\\]+""".r ^^ {
+      _.mkString
+    }
+  }
+
+  // Parse strings using an auxiliary parser. This is because
+  // spaces inside strings shouldn't be skipped.
+  lazy val string = new Parser[StringAtom] {
+    def apply(in: Input) = {
+      val source = in.source
+      val offset = in.offset
+      val start = handleWhiteSpace(source, offset)
+      StringParser.string(in.drop(start - offset)) match {
+        case StringParser.Success(value, next) => Success(StringAtom(value), next)
+        case StringParser.Failure(errMsg, next) => Failure(errMsg, next)
+        case StringParser.Error(errMsg, next) => Error(errMsg, next)
+      }
+    }
+  }
+  lazy val sym = regex("[a-zA-Z][a-zA-Z0-9-:]*".r) ^^ { s =>
+    if (s == "nil") NilAtom()
+    else if (s == "t") TruthAtom()
+    else SymbolAtom(s)
+  }
+  lazy val keyword = regex(":[a-zA-Z][a-zA-Z0-9-:]*".r) ^^ KeywordAtom
+  lazy val number = regex("-?[0-9]+".r) ^^ { s => IntAtom(s.toInt) }
+  lazy val list = literal("(") ~> rep(expr) <~ literal(")") ^^ SExpList.apply
+  lazy val expr: Parser[SExp] = list | keyword | string | number | sym
+
+  def read(r: input.Reader[Char]): SExp = {
+    val result: ParseResult[SExp] = expr(r)
+
+    result match {
+      case Success(value, next) => value
+      case Failure(errMsg, next) =>
+        println(errMsg)
+        NilAtom()
+      case Error(errMsg, next) =>
+        println(errMsg)
+        NilAtom()
+    }
+  }
+
+  def read(s: String): SExp = {
+    read(new input.CharSequenceReader(s))
+  }
+
+}

--- a/src/test/scala/org/ensime/test/ClassFileIndexSpec.scala
+++ b/src/test/scala/org/ensime/test/ClassFileIndexSpec.scala
@@ -4,7 +4,7 @@ import org.scalatest.FunSpec
 import org.scalatest.Matchers
 import org.ensime.config.ProjectConfig
 import org.ensime.indexer.ClassFileIndex
-import org.ensime.util.SExp
+import org.ensime.util.SExpParser
 import scala.tools.nsc.{ Global, Settings }
 import scala.tools.nsc.io.{ Jar, File, Directory, Path, PlainFile }
 import scala.tools.nsc.reporters.ConsoleReporter
@@ -13,7 +13,7 @@ import TestUtil._
 class ClassFileIndexSpec extends FunSpec with Matchers {
 
   def config(s: String): ProjectConfig = {
-    ProjectConfig.fromSExp(SExp.read(s)) match {
+    ProjectConfig.fromSExp(SExpParser.read(s)) match {
       case Right(c) => c
       case Left(t) => throw t
     }

--- a/src/test/scala/org/ensime/test/ProjectConfigSpec.scala
+++ b/src/test/scala/org/ensime/test/ProjectConfigSpec.scala
@@ -3,15 +3,14 @@ package org.ensime.test
 import org.scalatest.FunSpec
 import org.scalatest.Matchers
 import org.ensime.config.ProjectConfig
-import org.ensime.util.SExp
-import org.ensime.util.CanonFile
+import org.ensime.util.{ SExpParser, SExp, CanonFile }
 
 import TestUtil._
 
 class ProjectConfigSpec extends FunSpec with Matchers {
 
   def parse(s: String): ProjectConfig = {
-    ProjectConfig.fromSExp(SExp.read(s)) match {
+    ProjectConfig.fromSExp(SExpParser.read(s)) match {
       case Right(c) => c
       case Left(t) => throw t
     }
@@ -71,6 +70,7 @@ class ProjectConfigSpec extends FunSpec with Matchers {
           |  :active-subproject "B"
           |)""".stripMargin)
         assert(conf.name.get == "Proj B")
+
         assert(conf.sourceRoots.toSet.contains(root1))
         assert(conf.sourceRoots.toSet.contains(root2))
       }
@@ -84,9 +84,9 @@ class ProjectConfigSpec extends FunSpec with Matchers {
         val target = CanonFile(createUniqueDirectory(dir))
         val conf = parse(s"""
           |(
-          |     :name "Outer"
-          |     :target "$target"
-          |     :source-roots ("$root0")
+          |  :name "Outer"
+          |  :target "$target"
+          |  :source-roots ("$root0")
           |  :subprojects (
           |     (
           |     :name "Proj A"

--- a/src/test/scala/org/ensime/test/SExpSpec.scala
+++ b/src/test/scala/org/ensime/test/SExpSpec.scala
@@ -1,17 +1,38 @@
 package org.ensime.test
 import org.scalatest.FunSpec
 import org.scalatest.Matchers
-import org.ensime.util.SExp
+import org.ensime.util.{ StringAtom, SExpParser, BooleanAtom }
 
 class SExpSpec extends FunSpec with Matchers {
 
   describe("SExpSpec") {
-    def check(s: String, r: String) {
-      val res = SExp.read(s).toString
-      assert(res == r, "expected " + r + " got " + res)
+    def check(input: String, expected: String) {
+      val result = SExpParser.read(input).toString
+      assert(result == expected, "expected " + expected + " got " + result)
+      // throw it through again - everything should round trip perfectly
+      val result2 = SExpParser.read(result).toString
+      assert(result == result2, "round trip failed  " + result + " got " + result2)
+    }
+
+    it("should unapply BooleanAtom correctly") {
+      SExpParser.read("t") match {
+        case BooleanAtom(v) => assert(v, "result value should be true")
+        case _ => fail("unapply failed")
+      }
+
+      SExpParser.read("nil") match {
+        case BooleanAtom(v) => assert(!v, "result value should be false")
+        case _ => fail("unapply failed")
+      }
+
+      SExpParser.read("""( "abc" )""") match {
+        case BooleanAtom(v) => fail("unapply should not have succeeded")
+        case _ =>
+      }
     }
 
     it("should parse things right") {
+      check("( 123 )", "(123)")
       check("()", "()")
       check("(nil)", "(nil)")
       check("(t)", "(t)")
@@ -21,18 +42,29 @@ class SExpSpec extends FunSpec with Matchers {
       check("(a b c () t())", "(a b c () t ())")
       check("(a b c\n() nil(nil\n t))", "(a b c () nil (nil t))")
       check("(nildude)", "(nildude)")
-      check("\"a st\\\\ri\\\"n\\g\"", "a st\\ri\"n\\g")
-      check("(\"string  1\"      \"string  2\")", "(string  1 string  2)")
-      assert(SExp.read("t\n").toScala == true, "t should be true!")
-      assert(SExp.read("t\n\t").toScala == true, "t should be true!")
-      assert(SExp.read("t\n\t").toScala == true, "t should be true!")
-      assert(SExp.read("t ").toScala == true, "t should be true!")
-      assert(SExp.read("t").toScala == true, "t should be true!")
-      assert(SExp.read("nil\n").toScala == false, "nil should be false!")
-      assert(SExp.read("nil\n\t").toScala == false, "nil should be false!")
-      assert(SExp.read("nil\n\t").toScala == false, "nil should be false!")
-      assert(SExp.read("nil ").toScala == false, "nil should be false!")
-      assert(SExp.read("nil").toScala == false, "nil should be false!")
+      check("""("\n")""", """("\n")""")
+      check("""("\t")""", """("\t")""")
+      check("""("\r")""", """("\r")""")
+      check("\"a st\\\\ri\\\"n\\\\g\"", "\"a st\\\\ri\\\"n\\\\g\"")
+      check("""("string  1"      "string  2")""", """("string  1" "string  2")""")
+      assert(SExpParser.read("123").toScala == 123, "Int representation should be int")
+      assert(SExpParser.read("t\n").toScala == true, "t should be true!")
+      assert(SExpParser.read("t").asInstanceOf[BooleanAtom].toBool, "t should be true!")
+      assert(SExpParser.read("t\n\t").toScala == true, "t should be true!")
+      assert(SExpParser.read("t\n\t").toScala == true, "t should be true!")
+      assert(SExpParser.read("t ").toScala == true, "t should be true!")
+      assert(SExpParser.read("nil").toScala == false, "nil should be false!")
+      assert(!SExpParser.read("nil").asInstanceOf[BooleanAtom].toBool, "t should be false!")
+      assert(SExpParser.read("nil").toScala == false, "nil should be false!")
+      assert(SExpParser.read("nil ").toScala == false, "nil should be false!")
+      assert(SExpParser.read("nil\n").toScala == false, "nil should be false!")
+      assert(SExpParser.read("nil\n\t").toScala == false, "nil should be false!")
+      assert(SExpParser.read("nil\n\t").toScala == false, "nil should be false!")
+
+      assert(SExpParser.read("""(1 "a" )""").toScala == List(1, "a"), "toScala on list should toScala children")
+
+      assert(SExpParser.read("\"\\na\"").asInstanceOf[StringAtom].toScala == "\na", "scala value of String should be raw string")
+
     }
 
     it("should parse long strings") {
@@ -42,7 +74,7 @@ class SExpSpec extends FunSpec with Matchers {
       }
       val long = l.mkString
       val sexp = "\"" + long + "\""
-      val expected = long
+      val expected = "\"" + long + "\""
       check(sexp, expected)
     }
   }

--- a/src/test/scala/org/ensime/test/intg/BasicWorkflow.scala
+++ b/src/test/scala/org/ensime/test/intg/BasicWorkflow.scala
@@ -29,7 +29,7 @@ class BasicWorkflow extends FunSpec with Matchers {
         // expected form(:ok (:name "scala.Int" :local-name "Int" :type (:name "Int" :type-id 1 :full-name "scala.Int" :decl-as class) :owner-type-id 2))
         // n.b. this code is ugly - but will become neater after protocol refactor
         // id changes between platforms/invocations so we need to extract it and use it
-        val inspectResp = interactor.sendRPCExp(20 seconds, SExp.read(s"""(swank:symbol-at-point $fooFile 128)"""))
+        val inspectResp = interactor.sendRPCExp(20 seconds, SExpParser.read(s"""(swank:symbol-at-point $fooFile 128)"""))
         val intTypeId = inspectResp match {
           case SExpList(KeywordAtom(":ok") :: (res: SExpList) :: Nil) =>
             res.toKeywordMap(KeywordAtom(":type")).asInstanceOf[SExpList].toKeywordMap(KeywordAtom(":type-id")).asInstanceOf[IntAtom].value
@@ -40,7 +40,7 @@ class BasicWorkflow extends FunSpec with Matchers {
         //use the type ID to get the type information
         // compared with a baseline with the type ids removed (
         //        // type info for secondary buffer
-        val typeInfoResp = interactor.sendRPCExp(30 seconds, SExp.read(s"""(swank:inspect-type-by-id 1)"""))
+        val typeInfoResp = interactor.sendRPCExp(30 seconds, SExpParser.read(s"""(swank:inspect-type-by-id 1)"""))
 
         typeInfoResp match {
           case SExpList(KeywordAtom(":ok") :: (typeInfo: SExpList) :: Nil) =>

--- a/src/test/scala/org/ensime/test/intg/IntgUtil.scala
+++ b/src/test/scala/org/ensime/test/intg/IntgUtil.scala
@@ -63,7 +63,7 @@ object IntgUtil extends Assertions {
           val rpcId = nextRPCid
           nextRPCid += 1
           val msg = s"""(:swank-rpc ${req.toWireString} $rpcId)"""
-          project ! IncomingMessageEvent(SExp.read(msg))
+          project ! IncomingMessageEvent(SExpParser.read(msg))
           rpcExpectations += (rpcId -> sender())
         // this is the message from the server
         case OutgoingMessageEvent(obj) =>
@@ -106,8 +106,8 @@ object IntgUtil extends Assertions {
     }
 
     def sendRPCString(dur: FiniteDuration, msg: String): String = {
-      val sexpReq = SExp.read(msg)
-      sendRPCExp(dur, sexpReq).toReadableString()
+      val sexpReq = SExpParser.read(msg)
+      sendRPCExp(dur, sexpReq).toString
     }
 
     def expectRPC(dur: FiniteDuration, toSend: String, expected: String) {
@@ -121,7 +121,7 @@ object IntgUtil extends Assertions {
 
     def expectAsync(dur: FiniteDuration, expected: String) {
 
-      val expectedSExp = SExp.read(expected)
+      val expectedSExp = SExpParser.read(expected)
 
       val askRes = Patterns.ask(actor, AsyncRequest(expectedSExp), dur)
       try {
@@ -157,12 +157,14 @@ object IntgUtil extends Assertions {
       val destFile = Path(projectBase) / relativeSrc
       destFile.parent.createDirectory()
       val writer = destFile.bufferedWriter()
+      val source = Source.fromFile(srcFile.path)
       try {
-        Source.fromFile(srcFile.path).getLines.foreach(line => {
+        source.getLines().foreach(line => {
           writer.write(line)
           writer.write("\n")
         })
       } finally {
+        source.close()
         writer.close()
       }
     }


### PR DESCRIPTION
A bunch of minor stuff around SExp
1. Make the default rendering roundtripable (i.e. parse and sexp, to string, parse that should give same result)
2. Move the parser logic into a separate file
3. Improve the tests and fix a bug in the string escaping logic.
