### PR TITLE
Fix type completion problem caused by incorrect position type.

### DIFF
--- a/src/main/scala/org/ensime/server/Completion.scala
+++ b/src/main/scala/org/ensime/server/Completion.scala
@@ -263,7 +263,7 @@ trait CompletionControl {
           " ()")
 
         // Move point back to target of method selection.
-        val newP = p.withSource(src).withPoint(p.point - prefix.length - dot.length)
+        val newP = p.withSource(src).withShift(-(prefix.length + dot.length))
 
         Some(MemberContext(newP, prefix, constructing))
       case None => None

--- a/src/test/scala/org/ensime/test/RichPresentationCompilerSpec.scala
+++ b/src/test/scala/org/ensime/test/RichPresentationCompilerSpec.scala
@@ -1,5 +1,6 @@
 package org.ensime.test
 
+import scala.reflect.internal.util.OffsetPosition
 import org.scalatest.FunSpec
 import org.scalatest.Matchers
 import org.ensime.test.util.Helpers
@@ -33,6 +34,53 @@ class RichPresentationCompilerSpec extends FunSpec with Matchers {
         assert(info.name == "A$")
         assert(info.fullName == "com.example.A$")
         assert(info.pos.point == 27)
+      }
+    }
+
+    it("can get completions on member with no prefix") {
+      Helpers.withPresCompiler { cc =>
+        val file = Helpers.srcFile("def.scala", Helpers.contents(
+          "package com.example",
+          "object A { def aMethod(a: Int) = a }",
+          "object B { val x = A. "
+        ))
+        val p = new OffsetPosition(file, 78)
+        val infoList = cc.completionsAt(p, 10, false)
+        println(s"${infoList.completions}")
+        assert(infoList.completions.length > 1)
+        assert(infoList.completions.head.name == "aMethod")
+      }
+    }
+
+    it("can get completions on a member with a prefix") {
+      Helpers.withPresCompiler { cc =>
+        val file = Helpers.srcFile("abc.scala", Helpers.contents(
+          "package com.example",
+          "object A { def aMethod(a: Int) = a }",
+          "object B { val x = A.aMeth }"
+        ))
+        val p = new OffsetPosition(file, 83)
+        println("p = " + p)
+        val infoList = cc.completionsAt(p, 10, false)
+        println(s"${infoList.completions}")
+        assert(infoList.completions.length == 1)
+        assert(infoList.completions.head.name == "aMethod")
+      }
+    }
+
+    it("can get completions on an object name") {
+      Helpers.withPresCompiler { cc =>
+        val file = Helpers.srcFile("abc.scala", Helpers.contents(
+          "package com.example",
+          "object Abc { def aMethod(a: Int) = a }",
+          "object B { val x = Ab }"
+        ))
+        val p = new OffsetPosition(file, 80)
+        println("p = " + p)
+        val infoList = cc.completionsAt(p, 10, false)
+        println(s"${infoList.completions}")
+        assert(infoList.completions.length > 1)
+        assert(infoList.completions.head.name == "Abc")
       }
     }
   }


### PR DESCRIPTION
When I made the changes to support 2.11 I replaced with the deprecated `Position.withSource(src, offset)` with a combination of `withSource` and `withPoint`. However, `withPoint` always creates a `RangePosition` even if the original object is an `OffsetPosition`. This confused the presentation compiler and resulted in member completion requests returning 0 matches.

I've also added a few new tests to `RichPresentationCompilerSpec` to cover completions.

Fixes #542.
