### PR TITLE
Cover all of swank code (incoming)

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -84,7 +84,7 @@ ScalastylePlugin.Settings
 instrumentSettings
 
 // let's bump this every time we get more tests
-ScoverageKeys.minimumCoverage := 44
+ScoverageKeys.minimumCoverage := 47
 
 // might be buggy
 ScoverageKeys.highlighting := true

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -7,7 +7,7 @@ libraryDependencies ++= Seq(
   plugin("net.virtual-void" % "sbt-dependency-graph" % "0.7.4"),
   plugin("com.typesafe.sbt" % "sbt-scalariform" % "1.3.0"),
   plugin("org.scalastyle" %% "scalastyle-sbt-plugin" % "0.5.0"),
-  plugin("org.scoverage" %% "sbt-scoverage" % "0.99.5.1"),
+  plugin("org.scoverage" %% "sbt-scoverage" % "0.99.7.1"),
   plugin("com.github.mpeltonen" % "sbt-idea" % "1.6.0"),
   plugin("com.sksamuel.scapegoat" %% "sbt-scapegoat" % "0.90.16")
   // https://github.com/typelevel/wartremover/issues/108

--- a/src/main/scala/org/ensime/model/Model.scala
+++ b/src/main/scala/org/ensime/model/Model.scala
@@ -84,7 +84,7 @@ case class CompletionInfoList(
   prefix: String,
   completions: List[CompletionInfo])
 
-trait PatchOp {
+sealed trait PatchOp {
   val start: Int
 }
 
@@ -106,19 +106,19 @@ case class BreakpointList(active: List[Breakpoint], pending: List[Breakpoint])
 
 case class OffsetRange(from: Int, to: Int)
 
+object OffsetRange {
+  def apply(fromTo: Int): OffsetRange = new OffsetRange(fromTo, fromTo)
+}
+
 sealed trait DebugLocation
 
-case class DebugObjectReference(
-  objectId: Long) extends DebugLocation
+case class DebugObjectReference(objectId: Long) extends DebugLocation
 
-case class DebugStackSlot(
-  threadId: Long, frame: Int, offset: Int) extends DebugLocation
+case class DebugStackSlot(threadId: Long, frame: Int, offset: Int) extends DebugLocation
 
-case class DebugArrayElement(
-  objectId: Long, index: Int) extends DebugLocation
+case class DebugArrayElement(objectId: Long, index: Int) extends DebugLocation
 
-case class DebugObjectField(
-  objectId: Long, name: String) extends DebugLocation
+case class DebugObjectField(objectId: Long, name: String) extends DebugLocation
 
 sealed trait DebugValue {
   def typeName: String

--- a/src/main/scala/org/ensime/protocol/Protocol.scala
+++ b/src/main/scala/org/ensime/protocol/Protocol.scala
@@ -59,9 +59,8 @@ trait Protocol {
    *
    * @param  value  The message to write.
    * @param  writer The stream to which to write the message.
-   * @return        Void
    */
-  def writeMessage(value: WireFormat, writer: OutputStream)
+  def writeMessage(value: WireFormat, writer: OutputStream): Unit
 
   /**
    * Send a message in wire format to the client. Message
@@ -69,9 +68,8 @@ trait Protocol {
    * output socket.
    *
    * @param  o  The message to send.
-   * @return    Void
    */
-  def sendMessage(o: WireFormat) {
+  def sendMessage(o: WireFormat): Unit = {
     peer ! OutgoingMessageEvent(o)
   }
 
@@ -81,19 +79,16 @@ trait Protocol {
    * to the rpcTarget.
    *
    * @param  msg  The message we've received.
-   * @return        Void
    */
-  def handleIncomingMessage(msg: Any)
+  def handleIncomingMessage(msg: Any): Unit
 
   /**
    * Designate an actor that should receive outgoing
    * messages.
-   * TODO: Perhaps a channel would be more efficient?
    *
    * @param  peer  The Actor.
-   * @return        Void
    */
-  def setOutputActor(peer: ActorRef)
+  def setOutputActor(peer: ActorRef): Unit
   protected def peer: ActorRef
 
   /**
@@ -103,7 +98,7 @@ trait Protocol {
    * @param  target The RPCTarget instance.
    * @return        Void
    */
-  def setRPCTarget(target: RPCTarget)
+  def setRPCTarget(target: RPCTarget): Unit
 
   /**
    * Send a simple RPC Return with a 'true' value.
@@ -111,26 +106,23 @@ trait Protocol {
    * other return value is required.
    *
    * @param  callId The id of the RPC call.
-   * @return        Void
    */
-  def sendRPCAckOK(callId: Int)
+  def sendRPCAckOK(callId: Int): Unit
 
   /**
    * Send an RPC Return with the given value.
    *
    * @param  value  The value to return.
    * @param  callId The id of the RPC call.
-   * @return        Void
    */
-  def sendRPCReturn(value: WireFormat, callId: Int)
+  def sendRPCReturn(value: WireFormat, callId: Int): Unit
 
   /**
    * Send an event.
    *
    * @param  value  The event value.
-   * @return        Void
    */
-  def sendEvent(value: WireFormat)
+  def sendEvent(value: WireFormat): Unit
 
   /**
    * Notify the client that the RPC call could not
@@ -139,9 +131,8 @@ trait Protocol {
    * @param  code  Integer code denoting error type.
    * @param  detail  A message describing the error.
    * @param  callId The id of the failed RPC call.
-   * @return        Void
    */
-  def sendRPCError(code: Int, detail: String, callId: Int)
+  def sendRPCError(code: Int, detail: String, callId: Int): Unit
 
   /**
    * Notify the client that a message was received
@@ -149,7 +140,6 @@ trait Protocol {
    *
    * @param  code  Integer code denoting error type.
    * @param  detail  A message describing the problem.
-   * @return        Void
    */
-  def sendProtocolError(code: Int, detail: String)
+  def sendProtocolError(code: Int, detail: String): Unit
 }

--- a/src/main/scala/org/ensime/server/Analyzer.scala
+++ b/src/main/scala/org/ensime/server/Analyzer.scala
@@ -42,8 +42,7 @@ class Analyzer(
   private val reportHandler = new ReportHandler {
     override def messageUser(str: String) {
       project ! AsyncEvent(
-        toWF(SendBackgroundMessageEvent(
-          MsgCompilerUnexpectedError, Some(str))))
+        toWF(SendBackgroundMessageEvent(MsgCompilerUnexpectedError, Some(str))))
     }
     override def clearAllScalaNotes() {
       project ! AsyncEvent(ClearAllScalaNotesEvent)

--- a/src/main/scala/org/ensime/server/Refactoring.scala
+++ b/src/main/scala/org/ensime/server/Refactoring.scala
@@ -217,6 +217,7 @@ trait RefactoringImpl { self: RichPresentationCompiler =>
   protected def performRefactor(
     procId: Int,
     tpe: scala.Symbol,
+    // TODO - the avilable refactors are defined in the protocol - they should be a set of case classes with an extractor not a map
     params: immutable.Map[scala.Symbol, Any]): Either[RefactorFailure, RefactorEffect] = {
 
     def badArgs = Left(RefactorFailure(procId, "Incorrect arguments passed to " +

--- a/src/main/scala/org/ensime/util/Symbols.scala
+++ b/src/main/scala/org/ensime/util/Symbols.scala
@@ -5,7 +5,6 @@ package org.ensime.util
 */
 
 object Symbols {
-  import scala.tools.nsc.symtab.Flags._
   val Method = 'method
   val Trait = 'trait
   val Interface = 'interface
@@ -28,6 +27,5 @@ object Symbols {
   val Start = 'start
   val End = 'end
   val MethodName = 'methodName
-
 }
 

--- a/src/test/scala/org/ensime/test/SwankProtocolSpec.scala
+++ b/src/test/scala/org/ensime/test/SwankProtocolSpec.scala
@@ -6,10 +6,10 @@ import java.util.concurrent.atomic.AtomicInteger
 import akka.actor.TypedActor.MethodCall
 import akka.actor.{ ActorSystem, TypedActor, TypedProps }
 import akka.testkit.TestProbe
-import org.ensime.model.SourceFileInfo
+import org.ensime.model._
 import org.ensime.protocol.{ SExpConversion, SwankProtocol }
 import org.ensime.server.RPCTarget
-import org.ensime.util.{ SExp, SExpParser, WireFormat }
+import org.ensime.util._
 import org.scalamock.scalatest.MockFactory
 import org.scalatest.{ BeforeAndAfterAll, FunSpec, ShouldMatchers }
 
@@ -122,31 +122,44 @@ class SwankProtocolSpec extends FunSpec with ShouldMatchers with BeforeAndAfterA
       trait MsgHandler {
         def send(o: WireFormat)
       }
-      val t = mock[RPCTarget]
-      val out = mock[MsgHandler]
-
-      val prot = new SwankProtocol() {
-        override def sendMessage(o: WireFormat) {
-          out.send(o)
-        }
-      }
-      prot.setRPCTarget(t)
 
       val nextId = new AtomicInteger(1)
       def test(msg: String)(expectation: (RPCTarget, MsgHandler, Int) => Unit): Unit = {
 
+        val t = mock[RPCTarget]
+        val out = mock[MsgHandler]
+
+        val prot = new SwankProtocol() {
+          override def sendMessage(o: WireFormat) {
+            out.send(o)
+          }
+        }
+        prot.setRPCTarget(t)
+
         val rpcId = nextId.getAndIncrement
         expectation(t, out, rpcId)
 
-        prot.handleIncomingMessage(SExpParser.read(s"(:swank-rpc $msg $rpcId)"))
+        val sexp = SExpParser.read(s"(:swank-rpc $msg $rpcId)")
+        assert(sexp != NilAtom)
+
+        prot.handleIncomingMessage(sexp)
       }
 
       test("(swank:connection-info)") { (t, m, id) =>
         (t.rpcConnectionInfo _).expects(id)
       }
 
-      test("(swank:shutdown-server)") { (t, m, id) =>
-        (t.rpcShutdownServer _).expects(id)
+      val configFragment = """(:use-sbt t :compiler-args ("-Ywarn-dead-code" "-Ywarn-catches" "-Xstrict-warnings") :root-dir "/Users/aemon/projects/ensime/")"""
+      test(s"""(swank:init-project $configFragment)""") { (t, m, id) =>
+        (t.rcpInitProject _).expects(SExpParser.read(configFragment), id)
+      }
+
+      test("""(swank:peek-undo)""") { (t, m, id) =>
+        (t.rpcPeekUndo _).expects(id)
+      }
+
+      test("""(swank:exec-undo 1)""") { (t, m, id) =>
+        (t.rpcExecUndo _).expects(1, id)
       }
 
       test("(swank:repl-config)") { (t, m, id) =>
@@ -158,15 +171,225 @@ class SwankProtocolSpec extends FunSpec with ShouldMatchers with BeforeAndAfterA
       }
 
       val analyzerFile = new File("Analyzer.scala")
+      val fooFile = new File("Foo.scala")
+
       test("""(swank:typecheck-file "Analyzer.scala")""") { (t, m, id) =>
         (t.rpcTypecheckFiles _).expects(List(SourceFileInfo(analyzerFile)), id)
       }
 
       test("""(swank:typecheck-file "Analyzer.scala" "contents\\n\\ncontents")""") { (t, m, id) =>
-
         (t.rpcTypecheckFiles _).expects(List(SourceFileInfo(analyzerFile, Some("contents\\n\\ncontents"))), id)
       }
 
+      test("""(swank:typecheck-files ("Analyzer.scala" "Foo.scala"))""") { (t, m, id) =>
+        (t.rpcTypecheckFiles _).expects(List(SourceFileInfo(analyzerFile), SourceFileInfo(fooFile)), id)
+      }
+
+      test("""(swank:patch-source "Analyzer.scala" (("+" 6461 "Inc") ("-" 7127 7128) ("*" 7200 7300 "Bob")))""") { (t, m, id) =>
+        (t.rpcPatchSource _).expects("Analyzer.scala", List(PatchInsert(6461, "Inc"), PatchDelete(7127, 7128), PatchReplace(7200, 7300, "Bob")), id)
+      }
+
+      test("""(swank:typecheck-all)""") { (t, m, id) =>
+        (t.rpcTypecheckAll _).expects(id)
+      }
+
+      test("""(swank:format-source ("/ensime/src/Test.scala"))""") { (t, m, id) =>
+        (t.rpcFormatFiles _).expects(List("/ensime/src/Test.scala"), id)
+      }
+
+      test("""(swank:public-symbol-search ("java" "io" "File") 50)""") { (t, m, id) =>
+        (t.rpcPublicSymbolSearch _).expects(List("java", "io", "File"), 50, id)
+      }
+
+      test("""(swank:import-suggestions "/ensime/src/main/scala/org/ensime/server/Analyzer.scala" 2300 ("Actor") 10)""") { (t, m, id) =>
+        (t.rpcImportSuggestions _).expects("/ensime/src/main/scala/org/ensime/server/Analyzer.scala", 2300, List("Actor"), 10, id)
+      }
+
+      test("""(swank:completions
+             | "/ensime/src/main/scala/org/ensime/protocol/SwankProtocol.scala"
+             | 22626 0 t t)""".stripMargin) { (t, m, id) =>
+        (t.rpcCompletionsAtPoint _).expects("/ensime/src/main/scala/org/ensime/protocol/SwankProtocol.scala", 22626, 0, true, true, id)
+      }
+
+      test("""(swank:package-member-completion "org.ensime.server" "Server")""") { (t, m, id) =>
+        (t.rpcPackageMemberCompletion _).expects("org.ensime.server", "Server", id)
+      }
+
+      test("""(swank:call-completion 1)""") { (t, m, id) =>
+        (t.rpcCallCompletion _).expects(1, id)
+      }
+
+      test("""(swank:uses-of-symbol-at-point "Test.scala" 11334)""") { (t, m, id) =>
+        (t.rpcUsesOfSymAtPoint _).expects("Test.scala", 11334, id)
+      }
+
+      test("""(swank:type-by-id 1381)""") { (t, m, id) =>
+        (t.rpcTypeById _).expects(1381, id)
+      }
+
+      test("""(swank:type-by-id 1381)""") { (t, m, id) =>
+        (t.rpcTypeById _).expects(1381, id)
+      }
+
+      test("""(swank:type-by-name "java.lang.String")""") { (t, m, id) =>
+        (t.rpcTypeByName _).expects("java.lang.String", id)
+      }
+
+      test("""(swank:type-by-name-at-point "String" "SwankProtocol.scala" 31680)""") { (t, m, id) =>
+        (t.rpcTypeByNameAtPoint _).expects("String", "SwankProtocol.scala", OffsetRange(31680), id)
+      }
+
+      test("""(swank:type-by-name-at-point "String" "SwankProtocol.scala" (31680 31691))""") { (t, m, id) =>
+        (t.rpcTypeByNameAtPoint _).expects("String", "SwankProtocol.scala", OffsetRange(31680, 31691), id)
+      }
+
+      test("""(swank:type-at-point "SwankProtocol.scala" 31680)""") { (t, m, id) =>
+        (t.rpcTypeAtPoint _).expects("SwankProtocol.scala", OffsetRange(31680), id)
+      }
+
+      test("""(swank:type-at-point "SwankProtocol.scala" (31680 31691))""") { (t, m, id) =>
+        (t.rpcTypeAtPoint _).expects("SwankProtocol.scala", OffsetRange(31680, 31691), id)
+      }
+
+      test("""(swank:inspect-type-at-point "SwankProtocol.scala" 32736)""") { (t, m, id) =>
+        (t.rpcInspectTypeAtPoint _).expects("SwankProtocol.scala", OffsetRange(32736), id)
+      }
+
+      test("""(swank:inspect-type-at-point "SwankProtocol.scala" (32736 32740))""") { (t, m, id) =>
+        (t.rpcInspectTypeAtPoint _).expects("SwankProtocol.scala", OffsetRange(32736, 32740), id)
+      }
+
+      test("""(swank:inspect-type-by-id 232)""") { (t, m, id) =>
+        (t.rpcInspectTypeById _).expects(232, id)
+      }
+
+      test("""(swank:symbol-at-point "SwankProtocol.scala" 36483)""") { (t, m, id) =>
+        (t.rpcSymbolAtPoint _).expects("SwankProtocol.scala", 36483, id)
+      }
+
+      test("""(swank:inspect-package-by-path "org.ensime.util")""") { (t, m, id) =>
+        (t.rpcInspectPackageByPath _).expects("org.ensime.util", id)
+      }
+
+      test("""(swank:prepare-refactor 6 rename (file "SwankProtocol.scala" start 39504 end 39508 newName "dude") t)""") { (t, m, id) =>
+        val request: Map[Symbol, Any] =
+          Map(
+            Symbol("file") -> "SwankProtocol.scala",
+            Symbol("start") -> 39504,
+            Symbol("end") -> 39508,
+            Symbol("newName") -> "dude"
+          )
+        (t.rpcPrepareRefactor _).expects(6, Symbol("rename"), request, true, id)
+      }
+
+      test("""(swank:exec-refactor 7 rename)""") { (t, m, id) =>
+        (t.rpcExecRefactor _).expects(7, Symbol("rename"), id)
+      }
+
+      test("""(swank:cancel-refactor 1)""") { (t, m, id) =>
+        (t.rpcCancelRefactor _).expects(1, id)
+      }
+
+      test("""(swank:symbol-designations "SwankProtocol.scala" 0 46857 (var val varField valField))""") { (t, m, id) =>
+        (t.rpcSymbolDesignations _).expects("SwankProtocol.scala", 0, 46857,
+          List(Symbol("var"), Symbol("val"), Symbol("varField"), Symbol("valField")), id)
+      }
+
+      test("""(swank:expand-selection "Model.scala" 4648 4721)""") { (t, m, id) =>
+        (t.rpcExpandSelection _).expects("Model.scala", 4648, 4721, id)
+      }
+
+      test("""(swank:method-bytecode "hello.scala" 12)""") { (t, m, id) =>
+        (t.rpcMethodBytecode _).expects("hello.scala", 12, id)
+      }
+
+      test("""(swank:debug-active-vm)""") { (t, m, id) =>
+        (t.rpcDebugActiveVM _).expects(id)
+      }
+
+      test("""(swank:debug-start "org.hello.HelloWorld arg")""") { (t, m, id) =>
+        (t.rpcDebugStartVM _).expects("org.hello.HelloWorld arg", id)
+      }
+
+      test("""(swank:debug-attach "localhost" "9000")""") { (t, m, id) =>
+        (t.rpcDebugAttachVM _).expects("localhost", "9000", id)
+      }
+
+      test("""(swank:debug-stop)""") { (t, m, id) =>
+        (t.rpcDebugStopVM _).expects(id)
+      }
+
+      test("""(swank:debug-set-break "hello.scala" 12)""") { (t, m, id) =>
+        (t.rpcDebugBreak _).expects("hello.scala", 12, id)
+      }
+
+      test("""(swank:debug-clear-break "hello.scala" 12)""") { (t, m, id) =>
+        (t.rpcDebugClearBreak _).expects("hello.scala", 12, id)
+      }
+
+      test("""(swank:debug-clear-all-breaks)""") { (t, m, id) =>
+        (t.rpcDebugClearAllBreaks _).expects(id)
+      }
+
+      test("""(swank:debug-list-breakpoints)""") { (t, m, id) =>
+        (t.rpcDebugListBreaks _).expects(id)
+      }
+
+      test("""(swank:debug-run)""") { (t, m, id) =>
+        (t.rpcDebugRun _).expects(id)
+      }
+
+      test("""(swank:debug-continue "1")""") { (t, m, id) =>
+        (t.rpcDebugContinue _).expects(1L, id)
+      }
+
+      test("""(swank:debug-step "982398123")""") { (t, m, id) =>
+        (t.rpcDebugStep _).expects(982398123L, id)
+      }
+
+      test("""(swank:debug-next "982398123")""") { (t, m, id) =>
+        (t.rpcDebugNext _).expects(982398123L, id)
+      }
+
+      test("""(swank:debug-step-out "982398123")""") { (t, m, id) =>
+        (t.rpcDebugStepOut _).expects(982398123L, id)
+      }
+
+      test("""(swank:debug-locate-name "7" "apple")""") { (t, m, id) =>
+        (t.rpcDebugLocateName _).expects(7L, "apple", id)
+      }
+
+      test("""(swank:debug-value (:type element :object-id "23" :index 2))""") { (t, m, id) =>
+        (t.rpcDebugValue _).expects(DebugArrayElement(23L, 2), id)
+      }
+
+      test("""(swank:debug-value (:type reference :object-id "23"))""") { (t, m, id) =>
+        (t.rpcDebugValue _).expects(DebugObjectReference(23L), id)
+      }
+
+      test("""(swank:debug-value (:type field :object-id "23" :field "fred"))""") { (t, m, id) =>
+        (t.rpcDebugValue _).expects(DebugObjectField(23L, "fred"), id)
+      }
+
+      test("""(swank:debug-value (:type slot :thread-id "23" :frame 7 :offset 25))""") { (t, m, id) =>
+        (t.rpcDebugValue _).expects(DebugStackSlot(23L, 7, 25), id)
+      }
+
+      test("""(swank:debug-to-string "2" (:type element :object-id "23" :index 2))""") { (t, m, id) =>
+        (t.rpcDebugToString _).expects(2L, DebugArrayElement(23L, 2), id)
+      }
+
+      test("""(swank:debug-set-value (:type element :object-id "23" :index 2) "1")""") { (t, m, id) =>
+        (t.rpcDebugSetValue _).expects(DebugArrayElement(23L, 2), "1", id)
+      }
+
+      test("""(swank:debug-backtrace "23" 0 2)""") { (t, m, id) =>
+        (t.rpcDebugBacktrace _).expects(23L, 0, 2, id)
+      }
+
+      test("(swank:shutdown-server)") { (t, m, id) =>
+        (t.rpcShutdownServer _).expects(id)
+      }
     }
   }
 }


### PR DESCRIPTION
This change is designed to code cover and tighten/simplify the swank protocol. 
There should be no api changes from this change, although the protocol has become less forgiving, for example the previous implementation allowed arbitrary arguments after the matched list (which were ignored), now if the protocol expects three params, it will error if there are 4.

There is no way to test this as it is basically the contract between emacs and ensime.  So please give it a boot around.
