### PR TITLE
Make tests quieter

### DIFF
--- a/src/main/scala/org/ensime/server/RichPresentationCompiler.scala
+++ b/src/main/scala/org/ensime/server/RichPresentationCompiler.scala
@@ -155,9 +155,6 @@ class RichPresentationCompiler(
     }
   }
 
-  override val debugIDE: Boolean = true
-  override val verboseIDE: Boolean = true
-
   def activeUnits(): List[CompilationUnit] = {
     val invalidSet = toBeRemoved.synchronized { toBeRemoved.toSet }
     unitOfFile.filter { kv => !invalidSet.contains(kv._1) }.values.toList

--- a/src/test/resources/logback-test.xml
+++ b/src/test/resources/logback-test.xml
@@ -1,0 +1,21 @@
+<configuration>
+
+  <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+    <!-- encoders are assigned the type
+         ch.qos.logback.classic.encoder.PatternLayoutEncoder by default -->
+    <encoder>
+      <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+    </encoder>
+  </appender>
+
+  <contextListener class="ch.qos.logback.classic.jul.LevelChangePropagator">
+    <resetJUL>true</resetJUL>
+  </contextListener>
+  
+  <!-- <logger name="org.ensime.indexer" level="DEBUG"/> -->
+  <logger name="scala.tools" level="WARN"/>
+  
+  <root level="OFF">
+    <appender-ref ref="STDOUT" />
+  </root>
+</configuration>

--- a/src/test/scala/org/ensime/test/RichPresentationCompilerSpec.scala
+++ b/src/test/scala/org/ensime/test/RichPresentationCompilerSpec.scala
@@ -3,9 +3,12 @@ package org.ensime.test
 import scala.reflect.internal.util.OffsetPosition
 import org.scalatest.FunSpec
 import org.scalatest.Matchers
+import org.slf4j.LoggerFactory
 import org.ensime.test.util.Helpers
 
 class RichPresentationCompilerSpec extends FunSpec with Matchers {
+
+  val log = LoggerFactory.getLogger(this.getClass)
 
   describe("RichPresentationCompiler") {
 
@@ -46,7 +49,7 @@ class RichPresentationCompilerSpec extends FunSpec with Matchers {
         ))
         val p = new OffsetPosition(file, 78)
         val infoList = cc.completionsAt(p, 10, false)
-        println(s"${infoList.completions}")
+        log.debug(s"${infoList.completions}")
         assert(infoList.completions.length > 1)
         assert(infoList.completions.head.name == "aMethod")
       }
@@ -60,9 +63,9 @@ class RichPresentationCompilerSpec extends FunSpec with Matchers {
           "object B { val x = A.aMeth }"
         ))
         val p = new OffsetPosition(file, 83)
-        println("p = " + p)
+        log.info("p = " + p)
         val infoList = cc.completionsAt(p, 10, false)
-        println(s"${infoList.completions}")
+        log.info(s"${infoList.completions}")
         assert(infoList.completions.length == 1)
         assert(infoList.completions.head.name == "aMethod")
       }
@@ -76,9 +79,9 @@ class RichPresentationCompilerSpec extends FunSpec with Matchers {
           "object B { val x = Ab }"
         ))
         val p = new OffsetPosition(file, 80)
-        println("p = " + p)
+        log.info("p = " + p)
         val infoList = cc.completionsAt(p, 10, false)
-        println(s"${infoList.completions}")
+        log.info(s"${infoList.completions}")
         assert(infoList.completions.length > 1)
         assert(infoList.completions.head.name == "Abc")
       }

--- a/src/test/scala/org/ensime/test/intg/IntgUtil.scala
+++ b/src/test/scala/org/ensime/test/intg/IntgUtil.scala
@@ -190,7 +190,7 @@ object IntgUtil extends Assertions {
       val cmdLine =
         (if (sys.props("os.name").toLowerCase.contains("windows"))
           List("cmd", "/c")
-        else Nil) ::: List("sbt", "compile", "ensime")
+        else Nil) ::: List("sbt", "--warn", "compile", "ensime")
 
       val buildProcess = scala.sys.process.Process(cmdLine, Some(projectBase))
       buildProcess.!

--- a/src/test/scala/org/ensime/test/util/Helpers.scala
+++ b/src/test/scala/org/ensime/test/util/Helpers.scala
@@ -16,6 +16,14 @@ object Helpers {
     implicit val actorSystem = ActorSystem.create()
     val settings = new Settings(Console.println)
     settings.embeddedDefaults[RichCompilerControl]
+
+    // Uncomment the following to enable pres compiler logging during tests
+    /*
+     settings.YpresentationDebug.value = true
+     settings.YpresentationVerbose.value = true
+     settings.verbose.value = true
+     */
+
     val reporter = new StoreReporter()
     val indexer = TestProbe()
     val parent = TestProbe()


### PR DESCRIPTION
This silences all console output during tests  (easy to turn output back on during development). Makes it much easier to see failures.
