### PR TITLE
Refactor semantic highlight checks ; fix a few problems

### DIFF
--- a/src/main/scala/org/ensime/server/RichPresentationCompiler.scala
+++ b/src/main/scala/org/ensime/server/RichPresentationCompiler.scala
@@ -117,7 +117,9 @@ trait RichCompilerControl extends CompilerControl with RefactoringControl with C
     askOption(usesOfSymbolAtPoint(p).toList).getOrElse(List.empty)
 
   def askSymbolDesignationsInRegion(p: RangePosition, tpes: List[scala.Symbol]): SymbolDesignations =
-    askOption(symbolDesignationsInRegion(p, tpes)).getOrElse(SymbolDesignations("", List.empty))
+    askOption(
+      new SemanticHighlighting(this).symbolDesignationsInRegion(p, tpes)).getOrElse(SymbolDesignations("", List.empty)
+      )
 
   def askClearTypeCache() = clearTypeCache()
 
@@ -143,7 +145,7 @@ class RichPresentationCompiler(
   var indexer: ActorRef,
   val config: ProjectConfig) extends Global(settings, richReporter)
     with NamespaceTraversal with ModelBuilders with RichCompilerControl
-    with RefactoringImpl with IndexerInterface with SemanticHighlighting with Completion with Helpers {
+    with RefactoringImpl with IndexerInterface with Completion with Helpers {
 
   val logger = LoggerFactory.getLogger(this.getClass)
 

--- a/src/test/scala/org/ensime/test/intg/BasicWorkflow.scala
+++ b/src/test/scala/org/ensime/test/intg/BasicWorkflow.scala
@@ -23,7 +23,7 @@ class BasicWorkflow extends FunSpec with Matchers {
 
         // semantic highlighting
         interactor.expectRPC(20 seconds, s"""(swank:symbol-designations $fooFile -1 299 (var val varField valField functionCall operator param class trait object package))""",
-          s"""(:ok (:file $fooFile :syms ((package 12 19) (package 8 11) (trait 40 43) (valField 69 71) (class 100 103) (param 125 126) (class 128 131) (param 133 134) (class 136 142) (operator 156 157) (param 154 155) (functionCall 160 166) (param 158 159) (valField 183 187) (class 193 199) (class 201 204) (valField 214 218) (class 224 227) (functionCall 232 239) (operator 250 251) (valField 256 257) (valField 252 255) (functionCall 261 268) (functionCall 273 283) (valField 269 272))))""")
+          s"""(:ok (:file $fooFile :syms ((package 12 19) (package 8 11) (trait 40 43) (valField 69 70) (class 100 103) (param 125 126) (class 128 131) (param 133 134) (class 136 142) (operator 156 157) (param 154 155) (functionCall 160 166) (param 158 159) (valField 183 186) (class 193 199) (class 201 204) (valField 214 217) (class 224 227) (functionCall 232 239) (operator 250 251) (valField 256 257) (valField 252 255) (functionCall 261 268) (functionCall 273 283) (valField 269 272))))""")
 
         // inspect Int symbol
         // expected form(:ok (:name "scala.Int" :local-name "Int" :type (:name "Int" :type-id 1 :full-name "scala.Int" :decl-as class) :owner-type-id 2))


### PR DESCRIPTION
The main change is to use `namePosition` from scala-refactoring (this is what scala-ide does). This fixes several problems with the wrong text being highlighted.

I also eliminated some code duplication and fixed a couple more known issues.
