### PR TITLE
Type inspector shows classes with no visible members

### DIFF
--- a/src/main/scala/org/ensime/protocol/SwankProtocolConversions.scala
+++ b/src/main/scala/org/ensime/protocol/SwankProtocolConversions.scala
@@ -604,7 +604,8 @@ class SwankProtocolConversions extends ProtocolConversions {
       (":companion-id", value.companionId match {
         case Some(id) => id
         case None => 'nil
-      }), (":interfaces", SExp(value.supers.map(toWF))))
+      }),
+      (":interfaces", SExp(value.supers.map(toWF))))
   }
 
   def toWF(value: RefactorFailure): SExp = {

--- a/src/test/resources/logback-test.xml
+++ b/src/test/resources/logback-test.xml
@@ -1,10 +1,12 @@
 <configuration>
 
+  <property name="PATTERN" value="%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n" />
+
   <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
     <!-- encoders are assigned the type
          ch.qos.logback.classic.encoder.PatternLayoutEncoder by default -->
     <encoder>
-      <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+      <pattern>${PATTERN}</pattern>
     </encoder>
   </appender>
 
@@ -19,11 +21,11 @@
       <pattern>${PATTERN}</pattern>
     </encoder>
   </appender>
-  
+
   <!-- <logger name="org.ensime.indexer" level="DEBUG"/> -->
   <logger name="scala.tools" level="WARN"/>
   <logger name="org.ensime.server.RichPresentationCompiler" level="WARN"/>
-  
+
   <root level="DEBUG">
     <appender-ref ref="file"/>
   </root>


### PR DESCRIPTION
Fix #122 .. about time :-)

The actual fix is just in `prepareSortedInterfaceInfo`, the rest of the changes are just mild refactors.
