### PR TITLE
Server shouldn't die when source dirs are unreadable

### DIFF
--- a/src/main/scala/org/ensime/util/FileUtil.scala
+++ b/src/main/scala/org/ensime/util/FileUtil.scala
@@ -3,6 +3,7 @@ package org.ensime.util
 import java.io._
 import java.nio.charset.Charset
 import java.security.MessageDigest
+import org.slf4j.LoggerFactory
 import scala.collection.Seq
 import scala.collection.mutable
 import scala.tools.nsc.io.AbstractFile
@@ -48,7 +49,17 @@ object FileEdit {
 class RichFile(file: File) {
 
   def children: Iterable[File] = new Iterable[File] {
-    override def iterator: Iterator[File] = if (file.isDirectory) file.listFiles.iterator else Iterator.empty
+    override def iterator: Iterator[File] = if (file.isDirectory) {
+      val dirContents = file.listFiles
+      if (dirContents == null) {
+        LoggerFactory.getLogger(getClass).warn("Could not read directory " + file)
+        Iterator.empty
+      } else {
+        dirContents.iterator
+      }
+    } else {
+      Iterator.empty
+    }
   }
 
   def andTree: Iterable[File] = Seq(file) ++ children.flatMap(child => new RichFile(child).andTree)

--- a/src/test/scala/org/ensime/util/FileUtilSpec.scala
+++ b/src/test/scala/org/ensime/util/FileUtilSpec.scala
@@ -1,7 +1,9 @@
 package org.ensime.util
 
-import java.io.File
-
+import java.io.{ File }
+import org.slf4j.LoggerFactory
+import scala.tools.nsc.io.Path
+import org.ensime.test.TestUtil
 import org.scalatest.{ Matchers, FunSpec }
 
 object FileUtilSpec {
@@ -38,6 +40,35 @@ class FileUtilSpec extends FunSpec with Matchers {
 
     it("should apply edits to a list of files") {
 
+    }
+
+    val log = LoggerFactory.getLogger(this.getClass)
+
+    it("should expand recursively with non-readable directories") {
+      TestUtil.withTemporaryDirectory { dir =>
+        val dir1 = new File(dir, "dir1")
+        dir1.mkdir()
+        val dir2 = new File(dir, "dir2")
+        dir2.mkdir()
+
+        val file1 = new File(dir1, "file1.txt")
+        val file2 = new File(dir2, "file2.txt")
+
+        file1.createNewFile()
+        file2.createNewFile()
+
+        val permSet = dir2.setReadable(false)
+        val entries = FileUtils.expandRecursively(dir, List(new File("dir1"), new File("dir2")), f => f.isFile)
+
+        if (permSet) {
+          assert(entries === Set(CanonFile(file1)))
+          dir2.setReadable(true, false)
+        } else {
+          // Windows workaround: setReadable doesn't work so make this test
+          // impotent.
+          assert(entries === Set(CanonFile(file1), CanonFile(file2)))
+        }
+      }
     }
   }
 }


### PR DESCRIPTION
Fix #150 ... I'm picking off old bugs until @fommil's indexer refactor is ready.

The new unit test doesn't test much in Windows, but I didn't want to spend the time to make it work.
