### PR TITLE
Add a message tracker to detect unanswered rpc calls

### DIFF
--- a/src/main/scala/org/ensime/protocol/MessageTracker.scala
+++ b/src/main/scala/org/ensime/protocol/MessageTracker.scala
@@ -1,0 +1,67 @@
+package org.ensime.protocol
+
+import java.util.Date
+
+import akka.actor.{ Props, ActorSystem, Actor, ActorLogging }
+import org.ensime.util.SExp
+import scala.concurrent.ExecutionContext
+import scala.concurrent.duration._
+
+object MessageTracker {
+  case class RPCCall(exp: SExp, callId: Int)
+  case class RPCError(msg: String, callId: Int)
+  case class RPCResponse(exp: SExp, callId: Int)
+  case class MessageCheck(callId: Int, sendTime: Long)
+  class MessageTrackingActor(msgTimeout: FiniteDuration) extends Actor with ActorLogging {
+
+    var outstanding: Map[Int, RPCCall] = Map.empty
+
+    override def receive: Receive = {
+      case call @ RPCCall(exp, callId) =>
+        outstanding += (callId -> call)
+        implicit val ex: ExecutionContext = context.dispatcher
+        context.system.scheduler.scheduleOnce(msgTimeout, self, MessageCheck(callId, System.currentTimeMillis()))
+      case RPCError(_, callId) =>
+        if (outstanding.contains(callId)) {
+          log.warning("RPC Error sent for call: " + callId)
+          outstanding -= callId
+        } else
+          log.error("RPC error sent for call: " + callId)
+      case RPCResponse(_, callId) =>
+        if (!outstanding.contains(callId))
+          log.error("Got response for expired (or incorrect) RPC call: " + callId)
+        else {
+          outstanding -= callId
+        }
+      case MessageCheck(callId, sendTime) =>
+        if (outstanding.contains(callId)) {
+          log.error("No response sent from call " + callId + "(" + new Date(sendTime) +
+            ") - call is :" + outstanding(callId).exp)
+          outstanding -= callId
+        }
+    }
+  }
+}
+
+trait MessageTracker {
+  def call(sexp: SExp, callId: Int): Unit
+  def result(exp: SExp, callId: Int): Unit
+  def error(msg: String, callId: Int): Unit
+}
+
+class ReportingMessageTracker(actorSystem: ActorSystem, msgTimeout: FiniteDuration) extends MessageTracker {
+  import MessageTracker._
+  protected val actor = actorSystem.actorOf(Props(new MessageTrackingActor(msgTimeout)))
+
+  def call(sexp: SExp, callId: Int): Unit = {
+    actor ! RPCCall(sexp, callId)
+  }
+
+  def result(exp: SExp, callId: Int): Unit = {
+    actor ! RPCResponse(exp, callId)
+  }
+
+  def error(msg: String, callId: Int): Unit = {
+    actor ! RPCError(msg, callId)
+  }
+}

--- a/src/test/scala/org/ensime/test/NoOpMessageTracker.scala
+++ b/src/test/scala/org/ensime/test/NoOpMessageTracker.scala
@@ -1,0 +1,12 @@
+package org.ensime.test
+
+import org.ensime.protocol.MessageTracker
+import org.ensime.util.SExp
+
+class NoOpMessageTracker extends MessageTracker {
+  override def call(sexp: SExp, callId: Int): Unit = {}
+
+  override def result(exp: SExp, callId: Int): Unit = {}
+
+  override def error(msg: String, callId: Int): Unit = {}
+}

--- a/src/test/scala/org/ensime/test/SwankProtocolConversionsSpec.scala
+++ b/src/test/scala/org/ensime/test/SwankProtocolConversionsSpec.scala
@@ -1,6 +1,5 @@
 package org.ensime.test
 
-import org.ensime.config._
 import org.ensime.model._
 import org.ensime.protocol._
 import org.ensime.server._
@@ -8,12 +7,10 @@ import org.scalatest.FunSpec
 import org.scalatest.Matchers
 import org.ensime.util._
 
-import scala.reflect.internal.util._
 import scala.tools.nsc.io.{ Path, PlainFile }
-import scala.reflect.internal.util.{ RangePosition, OffsetPosition, BatchSourceFile }
+import scala.reflect.internal.util.{ RangePosition, BatchSourceFile }
 
 import pimpathon.file._
-import org.ensime.util.RichFile._
 
 object SwankProtocolConversionsSpec {
 
@@ -73,8 +70,8 @@ class SwankProtocolConversionsSpec extends FunSpec with Matchers {
 
   describe("SwankProtocolConversionsSpec") {
 
-    val protocol = new SwankProtocol
-    import protocol.conversions._
+    val conversions = new SwankProtocolConversions
+    import conversions._
     it("should encode all message types correctly") {
       assert(toWF(SendBackgroundMessageEvent(1, Some("ABCDEF"))).toWireString === """(:background-message 1 "ABCDEF")""")
       assert(toWF(SendBackgroundMessageEvent(1, None)).toWireString === "(:background-message 1 nil)")

--- a/src/test/scala/org/ensime/test/TestUtil.scala
+++ b/src/test/scala/org/ensime/test/TestUtil.scala
@@ -2,14 +2,11 @@ package org.ensime.test
 
 import org.apache.commons.io.FileUtils.copyDirectory
 import java.io.File
-import java.io.IOException
-import org.ensime.util.CanonFile
 import org.scalatest.Tag
 import scala.util.Properties
 import scala.util.Properties._
 import pimpathon.file._
 import org.ensime.config._
-import org.ensime.util.FileUtils._
 import org.ensime.util.RichFile._
 
 object TestUtil {
@@ -24,7 +21,7 @@ object TestUtil {
   val testJars = (parseTestProp("ensime.test.jars") -- compileJars).toList
   val mainSourcePath = "src/main/scala"
   val testSourcePath = "src/test/scala"
-  val compileClassDirs = (parseTestProp("ensime.compile.classDirs")).head
+  val compileClassDirs = parseTestProp("ensime.compile.classDirs").head
   val testClassDirs = parseTestProp("ensime.test.classDirs").head
   val scalaVersion = propOrEmpty("scala.version")
   val sourceJars = parseTestProp("ensime.jars.sources").toList
@@ -51,7 +48,7 @@ object TestUtil {
     classes: Boolean = false,
     testClasses: Boolean = false): EnsimeConfig = {
     val base = tmp.canon
-    require(base.isDirectory())
+    require(base.isDirectory)
 
     val module = {
       val classesDir = base / "target/classes"

--- a/src/test/scala/org/ensime/test/intg/IntgUtil.scala
+++ b/src/test/scala/org/ensime/test/intg/IntgUtil.scala
@@ -11,10 +11,8 @@ import org.apache.commons.io.{ FileUtils => IOFileUtils }
 import org.ensime.config.EnsimeConfig
 import org.ensime.protocol.{ IncomingMessageEvent, OutgoingMessageEvent }
 import org.ensime.server.Server
-import org.ensime.test.TestUtil
 import org.ensime.util._
 import org.scalatest.Assertions
-import org.slf4j.LoggerFactory
 
 import scala.concurrent.Await
 import scala.concurrent.duration._


### PR DESCRIPTION
Not sure if we want to actually pull this into the mainline (or pull it until the protocol refactor is finished).
This class monitors the rpc requests and responses and logs if a message does not get a reply within a reasonable amount of time (configured in constructor).
