### PR TITLE
Presentation compiler no longer loads all project sources by default

### DIFF
--- a/src/main/scala/org/ensime/config/EnsimeConfig.scala
+++ b/src/main/scala/org/ensime/config/EnsimeConfig.scala
@@ -27,8 +27,12 @@ case class EnsimeConfig(
     if file.isFile & file.getName.endsWith(".scala")
   } yield file
 
-  def classpath: Set[File] = modules.values.toSet.flatMap {
+  def runtimeClasspath: Set[File] = modules.values.toSet.flatMap {
     m: EnsimeModule => m.compileJars ++ m.testJars ++ m.debugJars :+ m.target :+ m.testTarget
+  }
+
+  def compileClasspath: Set[File] = modules.values.toSet.flatMap {
+    m: EnsimeModule => m.compileJars ++ m.testJars :+ m.target :+ m.testTarget
   }
 
   val javaLib = file(Properties.jdkHome) / "jre/lib/rt.jar"

--- a/src/main/scala/org/ensime/protocol/RPCTarget.scala
+++ b/src/main/scala/org/ensime/protocol/RPCTarget.scala
@@ -37,6 +37,7 @@ trait RPCTarget {
   def rpcPatchSource(f: String, edits: List[PatchOp], callId: Int)
   def rpcTypecheckFiles(fs: List[SourceFileInfo], callId: Int)
   def rpcRemoveFile(f: String, callId: Int)
+  def rpcUnloadAll(callId: Int)
   def rpcTypecheckAll(callId: Int)
   def rpcCompletionsAtPoint(f: String, point: Int, maxResults: Int, caseSens: Boolean, reload: Boolean, callId: Int)
   def rpcPackageMemberCompletion(path: String, prefix: String, callId: Int)

--- a/src/main/scala/org/ensime/protocol/SwankProtocol.scala
+++ b/src/main/scala/org/ensime/protocol/SwankProtocol.scala
@@ -722,6 +722,24 @@ class SwankProtocol extends Protocol {
 
       /**
        * Doc RPC:
+       *   swank:unload-all
+       * Summary:
+       *   Remove all sources from the presentation compiler. Reset the project's symbols
+       *    to the ones defiled in .class files.
+       * Arguments:
+       *   None
+       * Return:
+       *   None
+       * Example call:
+       *   (:swank-rpc (swank:unload-all) 42)
+       * Example return:
+       *   (:return (:ok t) 42)
+       */
+      case ("swank:unload-all", Nil) =>
+        rpcTarget.rpcUnloadAll(callId)
+
+      /**
+       * Doc RPC:
        *   swank:typecheck-all
        * Summary:
        *   Request immediate load and typecheck of all known sources.

--- a/src/main/scala/org/ensime/server/DebugManager.scala
+++ b/src/main/scala/org/ensime/server/DebugManager.scala
@@ -152,7 +152,7 @@ class DebugManager(
   }
 
   def vmOptions(): List[String] = List("-classpath",
-    config.classpath.mkString("\"", File.pathSeparator, "\"")
+    config.runtimeClasspath.mkString("\"", File.pathSeparator, "\"")
   )
 
   private var maybeVM: Option[VM] = None

--- a/src/main/scala/org/ensime/server/ProjectRPCTarget.scala
+++ b/src/main/scala/org/ensime/server/ProjectRPCTarget.scala
@@ -48,7 +48,7 @@ trait ProjectRPCTarget extends RPCTarget { self: Project =>
   }
 
   override def rpcReplConfig(callId: Int) {
-    sendRPCReturn(toWF(new ReplConfig(config.classpath)), callId)
+    sendRPCReturn(toWF(new ReplConfig(config.runtimeClasspath)), callId)
   }
 
   override def rpcSymbolDesignations(f: String, start: Int, end: Int, requestedTypes: List[Symbol], callId: Int) {
@@ -145,6 +145,10 @@ trait ProjectRPCTarget extends RPCTarget { self: Project =>
     val file: File = new File(f)
     getAnalyzer ! RPCRequestEvent(RemoveFileReq(file), callId)
     sendRPCAckOK(callId)
+  }
+
+  override def rpcUnloadAll(callId: Int) {
+    getAnalyzer ! RPCRequestEvent(UnloadAllReq, callId)
   }
 
   override def rpcTypecheckAll(callId: Int) {

--- a/src/test/scala/org/ensime/test/intg/BasicWorkflow.scala
+++ b/src/test/scala/org/ensime/test/intg/BasicWorkflow.scala
@@ -95,7 +95,7 @@ class BasicWorkflow extends FunSpec with Matchers {
 
         // C-c C-v p Inspect source of current package
         interactor.expectRPC(30 seconds, s"""(swank:inspect-package-by-path "org.example")""",
-          s"""(:ok (:name "example" :info-type package :full-name "org.example" :members ((:name "Foo$$" :type-id 131 :full-name "org.example.Foo$$" :decl-as object :pos (:file $fooFile :offset 28 :line 3)))))""")
+          s"""(:ok (:name "example" :info-type package :full-name "org.example" :members ((:name "Foo" :type-id 131 :full-name "org.example.Foo" :decl-as class :pos (:file $fooFile :offset 0 :line 0)) (:name "Foo$$" :type-id 132 :full-name "org.example.Foo$$" :decl-as object :pos (:file $fooFile :offset 28 :line 3)))))""")
       }
     }
   }


### PR DESCRIPTION
This change isn't large but puts us 90% of the way towards fixing #362. It needs an ensime-emacs change as well: ensime/ensime-emacs#39.  @fommil, it would be great if you could try it out. I didn't try to apply this change to 2.9, let me know if it needs fixes.

BTW I had to fix the classpath problem mentioned in #610, it just won't work without it.

The server's default behavior is now _not_ to load all source files on startup. Indexing isn't affected, but the scala-refactoring features that depend on all files are.

A new RPC call, :unload-all, removes all sources from the presentation compiler, then makes the PC reload the target's .class files. This is basically the opposite of :typecheck-all.

A separate mechanism is triggered when .class files are modified: it invalidates the classpath then reloads source files that the PC knows about. This has the effect of updating the PC's state when the project is recompiled.
