### PR TITLE
use the pres compiler .toString on Type

### DIFF
--- a/src/main/scala/org/ensime/model/Helpers.scala
+++ b/src/main/scala/org/ensime/model/Helpers.scala
@@ -83,25 +83,6 @@ trait Helpers { self: Global =>
     } else { "" })
   }
 
-  /**
-   * Generate qualified name, without args postfix.
-   */
-  def typeFullName(tpe: Type): String = {
-    def nestedClassName(sym: Symbol): String = {
-      outerClass(sym) match {
-        case Some(outerSym) =>
-          nestedClassName(outerSym) + "$" + typeShortName(sym)
-        case None => typeShortName(sym)
-      }
-    }
-    val typeSym = tpe.typeSymbol
-    if (typeSym.isNestedClass) {
-      typeSym.enclosingPackage.fullName + "." + nestedClassName(typeSym)
-    } else {
-      typeSym.enclosingPackage.fullName + "." + typeShortName(typeSym)
-    }
-  }
-
   def typeShortName(tpe: Type): String = {
     if (tpe.typeSymbol != NoSymbol) typeShortName(tpe.typeSymbol)
     else tpe.toString()

--- a/src/main/scala/org/ensime/model/Model.scala
+++ b/src/main/scala/org/ensime/model/Model.scala
@@ -408,7 +408,7 @@ trait ModelBuilders { self: RichPresentationCompiler =>
             typeShortName(tpe),
             cacheType(tpe),
             declaredAs(typeSym),
-            typeFullName(tpe),
+            tpe.toString,
             args,
             members,
             symPos,
@@ -459,7 +459,7 @@ trait ModelBuilders { self: RichPresentationCompiler =>
       }
       val name = if (sym.isClass || sym.isTrait || sym.isModule ||
         sym.isModuleClass || sym.isPackageClass) {
-        typeFullName(tpe)
+        tpe.toString
       } else {
         sym.nameString
       }

--- a/src/test/scala/org/ensime/test/RichPresentationCompilerSpec.scala
+++ b/src/test/scala/org/ensime/test/RichPresentationCompilerSpec.scala
@@ -38,7 +38,7 @@ class RichPresentationCompilerSpec extends FunSpec with Matchers with SLF4JLoggi
         val info = cc.askTypeInfoByName("com.example.A$").get
         assert(info.declaredAs == 'object)
         assert(info.name == "A$")
-        assert(info.fullName == "com.example.A$")
+        assert(info.fullName == "com.example.A.type")
         assert(info.pos.get.line == 2)
       }
     }

--- a/src/test/scala/org/ensime/test/intg/BasicWorkflow.scala
+++ b/src/test/scala/org/ensime/test/intg/BasicWorkflow.scala
@@ -50,7 +50,7 @@ class BasicWorkflow extends FunSpec with Matchers {
             val typeMap = typeInfo.toKeywordMap(KeywordAtom(":type")).asInstanceOf[SExpList].toKeywordMap
 
             assert(typeMap(KeywordAtom(":name")) == StringAtom("Int"))
-            assert(typeMap(KeywordAtom(":full-name")) == StringAtom("scala.Int"))
+            assert(typeMap(KeywordAtom(":full-name")) == StringAtom("Int"))
             assert(typeMap(KeywordAtom(":decl-as")) == SymbolAtom("class"))
             // short cut - decoding the structure is painful right now - lets just look for bits that must be there
             // I (@rorygraves) promise to clean this up with the protocol refactor


### PR DESCRIPTION
This handles complicated types with refinements a lot better, e.g. in shapeless. (thanks to @milessabin for spotting this.)
