### PR TITLE
Restart presentation compiler instead of invalidating classpath

### DIFF
--- a/src/main/scala/org/ensime/protocol/RPCTarget.scala
+++ b/src/main/scala/org/ensime/protocol/RPCTarget.scala
@@ -47,6 +47,8 @@ trait RPCTarget {
 
   def rpcSymbolAtPoint(f: String, point: Int, callId: Int)
 
+  def rpcMemberByName(typeFullName: String, memberName: String, memberIsType: Boolean, callId: Int)
+
   def rpcTypeById(id: Int, callId: Int)
 
   def rpcTypeByName(name: String, callId: Int)

--- a/src/main/scala/org/ensime/protocol/SwankEvent.scala
+++ b/src/main/scala/org/ensime/protocol/SwankEvent.scala
@@ -14,6 +14,7 @@ case class SendBackgroundMessageEvent(code: Int, detail: Option[String]) extends
 case object AnalyzerReadyEvent extends GeneralSwankEvent
 case object FullTypeCheckCompleteEvent extends GeneralSwankEvent
 case object IndexerReadyEvent extends GeneralSwankEvent
+case object CompilerRestartedEvent extends GeneralSwankEvent
 
 case object ClearAllJavaNotesEvent extends GeneralSwankEvent
 case object ClearAllScalaNotesEvent extends GeneralSwankEvent

--- a/src/main/scala/org/ensime/protocol/SwankProtocol.scala
+++ b/src/main/scala/org/ensime/protocol/SwankProtocol.scala
@@ -917,6 +917,27 @@ class SwankProtocol extends Protocol {
 
       /**
        * Doc RPC:
+       *   swank:member-by-name
+       * Summary:
+       *   Request description of a member of a given type
+       * Arguments:
+       *   String: Type full-name as return by swank:typeInfo
+       *   String: Member name
+       *   Boolean: true if the member is a trait or class, flase otherwise
+       * Return:
+       *   A SymbolInfo
+       * Example call:
+       *   (:swank-rpc (swank:member-by-name "com.example.Class", "x", nil) 42)
+       * Example return:
+       *   (:return (:ok (:name "x" :local-name "x" :type (:name "String" :type-id 25
+       *   :full-name "java.lang.String" :decl-as class) :decl-pos
+       *   (:file "SwankProtocol.scala" :offset 36404))) 42)
+       */
+      case ("swank:member-by-name", StringAtom(typeFullName) :: StringAtom(memberName) :: BooleanAtom(memberIsType) :: Nil) =>
+        rpcTarget.rpcMemberByName(typeFullName, memberName, memberIsType, callId)
+
+      /**
+       * Doc RPC:
        *   swank:type-by-id
        * Summary:
        *   Request description of the type with given type id.

--- a/src/main/scala/org/ensime/protocol/SwankProtocolConversions.scala
+++ b/src/main/scala/org/ensime/protocol/SwankProtocolConversions.scala
@@ -189,6 +189,17 @@ class SwankProtocolConversions extends ProtocolConversions {
         SExp(key(":indexer-ready"))
       /**
        * Doc Event:
+       *   :compiler-restarted
+       * Summary:
+       *   Signal that the compiler was restarted. :type-id values received earlier
+       *    are now invalid.
+       * Structure:
+       *   (:compiler-restarted)
+       */
+      case CompilerRestartedEvent =>
+        SExp(key(":compiler-restarted"))
+      /**
+       * Doc Event:
        *   :scala-notes
        * Summary:
        *   Notify client when Scala compiler generates errors,warnings or other notes.

--- a/src/main/scala/org/ensime/server/ProjectRPCTarget.scala
+++ b/src/main/scala/org/ensime/server/ProjectRPCTarget.scala
@@ -177,6 +177,10 @@ trait ProjectRPCTarget extends RPCTarget { self: Project =>
     getAnalyzer ! RPCRequestEvent(SymbolAtPointReq(new File(f), point), callId)
   }
 
+  override def rpcMemberByName(typeFullName: String, memberName: String, memberIsType: Boolean, callId: Int) {
+    getAnalyzer ! RPCRequestEvent(MemberByNameReq(typeFullName, memberName, memberIsType), callId)
+  }
+
   override def rpcTypeById(id: Int, callId: Int) {
     getAnalyzer ! RPCRequestEvent(TypeByIdReq(id), callId)
   }

--- a/src/test/scala/org/ensime/config/EnsimeConfigSpec.scala
+++ b/src/test/scala/org/ensime/config/EnsimeConfigSpec.scala
@@ -30,11 +30,15 @@ class EnsimeConfigSpec extends FunSpec with Matchers {
       withTempDirectory { dir =>
         (dir / ".ensime_cache").mkdirs()
         (dir / "abc").mkdirs()
+
+        val dirStr = TestUtil.fileToWireString(dir)
+        val cacheStr = TestUtil.fileToWireString(dir / ".ensime_cache")
+
         test(dir, s"""
 (:name "project"
  :scala-version "2.10.4"
- :root-dir "$dir"
- :cache-dir "$dir/.ensime_cache"
+ :root-dir $dirStr
+ :cache-dir $cacheStr
  :reference-source-roots ()
  :subprojects ((:name "module1"
                 :scala-version "2.10.4"
@@ -60,11 +64,15 @@ class EnsimeConfigSpec extends FunSpec with Matchers {
       withTempDirectory { dir =>
         (dir / ".ensime_cache").mkdirs()
         (dir / "abc").mkdirs()
+
+        val dirStr = TestUtil.fileToWireString(dir)
+        val cacheStr = TestUtil.fileToWireString(dir / ".ensime_cache")
+
         test(dir, s"""
 (:name "project"
  :scala-version "2.10.4"
- :root-dir "$dir"
- :cache-dir "$dir/.ensime_cache"
+ :root-dir $dirStr
+ :cache-dir $cacheStr
  :subprojects ((:name "module1"
                 :scala-version "2.10.4"
                 :targets ("abc"))))""", { implicit config =>

--- a/src/test/scala/org/ensime/test/RichPresentationCompilerSpec.scala
+++ b/src/test/scala/org/ensime/test/RichPresentationCompilerSpec.scala
@@ -13,33 +13,76 @@ class RichPresentationCompilerSpec extends FunSpec with Matchers with SLF4JLoggi
 
   describe("RichPresentationCompiler") {
 
-    it("can call askTypeInfoByName on a class") {
+    it("should round-trip between typeFullName and askTypeInfoByName") {
       Helpers.withPresCompiler { (dir, cc) =>
         val file = Helpers.srcFile(dir, "abc.scala", Helpers.contents(
           "package com.example",
-          "class A { }"))
+          "object /*1*/A { ",
+          "   val /*1.1*/x: Int = 1",
+          "   class  /*1.2*/X {} ",
+          "   object /*1.3*/X {} ",
+          "}",
+          "class  /*2*/A { ",
+          "   class  /*2.1*/X {} ",
+          "   object /*2.2*/X {} ",
+          "}"
+        ))
         cc.askReloadFile(file)
         cc.askLoadedTyped(file)
-        val info = cc.askTypeInfoByName("com.example.A").get
-        assert(info.declaredAs == 'class)
-        assert(info.name == "A")
-        assert(info.fullName == "com.example.A")
-        assert(info.pos.get.line == 2)
+
+        def roundtrip(label: String, expectedFullName: String) = {
+          val comment = "/*" + label + "*/"
+          val index = file.content.mkString.indexOf(comment)
+          val tpe = cc.askTypeInfoAt(new OffsetPosition(file, index + comment.length)).get
+          val fullName = tpe.fullName
+          assert(fullName === expectedFullName)
+
+          val tpe2 = cc.askTypeInfoByName(fullName).get
+          assert(tpe2.fullName === expectedFullName)
+        }
+
+        roundtrip("1", "com.example.A$")
+        roundtrip("1.1", "scala.Int")
+        roundtrip("1.2", "com.example.A$$X")
+        roundtrip("1.3", "com.example.A$$X$")
+        roundtrip("2", "com.example.A")
+        roundtrip("2.1", "com.example.A$X")
+        roundtrip("2.2", "com.example.A$X$")
       }
     }
 
-    it("can call askTypeInfoByName on an object") {
+    it("should handle askMemberInfoByName") {
       Helpers.withPresCompiler { (dir, cc) =>
         val file = Helpers.srcFile(dir, "abc.scala", Helpers.contents(
           "package com.example",
-          "object A { }"))
+          "object A { ",
+          "   val x: Int = 1",
+          "   class  X {}",
+          "   object X {}",
+          "}",
+          "class A { ",
+          "   class  X {}",
+          "   object X {}",
+          "}"
+        ))
         cc.askReloadFile(file)
         cc.askLoadedTyped(file)
-        val info = cc.askTypeInfoByName("com.example.A$").get
-        assert(info.declaredAs == 'object)
-        assert(info.name == "A$")
-        assert(info.fullName == "com.example.A$")
-        assert(info.pos.get.line == 2)
+
+        def test(typeName: String, memberName: String, isType: Boolean, expectedTypeName: String, expectedDeclAs: Symbol) = {
+          val sym = cc.askMemberInfoByName(typeName, memberName, isType).get
+          assert(sym.localName === memberName)
+          assert(sym.tpe.fullName === expectedTypeName)
+          assert(sym.tpe.declaredAs === expectedDeclAs)
+        }
+
+        test("com.example$", "A", false, "com.example.A$", 'object)
+        test("com.example.A$", "x", false, "scala.Int", 'class)
+        test("com.example.A$", "X", false, "com.example.A$$X$", 'object)
+        test("com.example.A$", "X", true, "com.example.A$$X", 'class)
+
+        test("com.example$", "A", true, "com.example.A", 'class)
+        test("com.example.A", "X", false, "com.example.A$X$", 'object)
+        test("com.example.A", "X", true, "com.example.A$X", 'class)
       }
     }
 

--- a/src/test/scala/org/ensime/test/SwankProtocolSpec.scala
+++ b/src/test/scala/org/ensime/test/SwankProtocolSpec.scala
@@ -220,6 +220,12 @@ class SwankProtocolSpec extends FunSpec with ShouldMatchers with BeforeAndAfterA
       }
     }
 
+    it("should understand swank:member-by-name") {
+      test("""(swank:member-by-name "org.example.A" "x" t)""") { (t, m, id) =>
+        (t.rpcMemberByName _).expects("org.example.A", "x", true, id)
+      }
+    }
+
     it("should understand swank:type-by-id") {
       test("""(swank:type-by-id 1381)""") { (t, m, id) =>
         (t.rpcTypeById _).expects(1381, id)


### PR DESCRIPTION
It would be great if @fommil could try this change on his large work project, to make sure the concept works before I finish this PR.

What's working (at least in scala 2.11):
- restart PC when you type `C-c C-c r` or when compilation happens
- saner handling of continuous compilation (thanks for the hint @fommil)
  Performance is great when working on ENSIME itself

What's missing before it can be merged:
- thorough testing
- rewrite type-id caching  (right now swank:type-by-id won't work across restarts)
- check for any other leaks of Type, Tree or Symbol objects
