### PR TITLE
Added source-mode config parameter

### DIFF
--- a/src/main/scala/org/ensime/util/SExp.scala
+++ b/src/main/scala/org/ensime/util/SExp.scala
@@ -37,6 +37,14 @@ class SExpMapExplorer(list: SExpList) extends SExpListExplorer(list) {
     case None => None
   }
 
+  def getBoolean(name: String): Boolean = getBooleanOpt(name).getOrElse(throw matchError("required key " + name + " not found"))
+
+  def getBooleanOpt(name: String): Option[Boolean] = map.get(KeywordAtom(name)) match {
+    case Some(BooleanAtom(s)) => Some(s)
+    case Some(_) => throw matchError("Key " + name + " does not refer to a string element")
+    case None => None
+  }
+
   def getStringListOpt(name: String): Option[List[String]] = getStringListOpt(KeywordAtom(name))
   def getStringListOpt(name: KeywordAtom): Option[List[String]] = {
     map.get(name) match {


### PR DESCRIPTION
Fix #624

The `:source-mode` config parameter prevents the target from being added to the classpath. It also changes the Analyzer behavior to load all source files whenever a new presentation compiler is created.
