### PR TITLE
Config option to pass arguments to debugger VM

### DIFF
--- a/src/main/scala/org/ensime/config/EnsimeConfig.scala
+++ b/src/main/scala/org/ensime/config/EnsimeConfig.scala
@@ -17,7 +17,8 @@ case class EnsimeConfig(
     modules: Map[String, EnsimeModule],
     referenceSourceJars: List[File],
     formattingPrefs: FormattingPreferences = FormattingPreferences(),
-    sourceMode: Boolean = false) {
+    sourceMode: Boolean = false,
+    debugVMArgs: List[String] = List.empty) {
   (root :: cacheDir :: referenceSourceJars).foreach { f =>
     require(f.exists, s"$f is required but does not exist")
   }
@@ -185,10 +186,12 @@ object EnsimeConfig extends SLF4JLogging {
     }
 
     val sourceMode = rootMap.getBooleanOpt(":source-mode").getOrElse(false)
+    val debugVMArgs = rootMap.getStringListOpt(":debug-args").getOrElse(Nil)
     EnsimeConfig(
       root.tap(_.mkdirs()).canon, cacheDir.tap(_.mkdirs()).canon,
       name, scalaVersion, compilerArgs, subModules,
-      referenceSourceJars, formattingPrefs, sourceMode
+      referenceSourceJars, formattingPrefs, sourceMode,
+      debugVMArgs
     )
   }
 }

--- a/src/main/scala/org/ensime/server/DebugManager.scala
+++ b/src/main/scala/org/ensime/server/DebugManager.scala
@@ -151,9 +151,10 @@ class DebugManager(
     project ! AsyncEvent(DebugVMDisconnectEvent())
   }
 
-  def vmOptions(): List[String] = List("-classpath",
+  def vmOptions(): List[String] = List(
+    "-classpath",
     config.runtimeClasspath.mkString("\"", File.pathSeparator, "\"")
-  )
+  ) ++ config.debugVMArgs
 
   private var maybeVM: Option[VM] = None
 

--- a/src/test/scala/org/ensime/config/EnsimeConfigSpec.scala
+++ b/src/test/scala/org/ensime/config/EnsimeConfigSpec.scala
@@ -42,6 +42,7 @@ class EnsimeConfigSpec extends FunSpec with Matchers {
  :root-dir $dirStr
  :cache-dir $cacheStr
  :reference-source-roots ()
+ :debug-args ("-Dthis=that")
  :subprojects ((:name "module1"
                 :scala-version "2.10.4"
                 :depends-on-modules ()
@@ -59,6 +60,7 @@ class EnsimeConfigSpec extends FunSpec with Matchers {
           assert(module1.name == "module1")
           assert(module1.dependencies.isEmpty)
           assert(config.sourceMode == false)
+          assert(config.debugVMArgs === List("-Dthis=that"))
         })
       }
     }


### PR DESCRIPTION
Fix #218   .  The debug arguments are stored in .ensime. This means that you must restart ensime every time you want to change them.
