### PR TITLE
Change the RPC insterface to be call/response

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -44,7 +44,8 @@ libraryDependencies ++= Seq(
   "ch.qos.logback"             %  "logback-classic"      % "1.1.2",
   "org.slf4j"                  %  "jul-to-slf4j"         % "1.7.7",
   "org.slf4j"                  %  "jcl-over-slf4j"       % "1.7.7",
-  "org.scala-refactoring"      %% "org.scala-refactoring.library" % "0.6.2"
+  "org.scala-refactoring"      %% "org.scala-refactoring.library" % "0.6.2",
+  "com.chuusai"                %% "shapeless"            % "2.0.0"
 )
 
 // WORKAROUND: https://github.com/typelevel/scala/issues/75
@@ -143,7 +144,7 @@ scalariformSettings
 instrumentSettings
 
 // let's bump this every time we get more tests
-ScoverageKeys.minimumCoverage := 61
+ScoverageKeys.minimumCoverage := 64
 
 // might be buggy
 ScoverageKeys.highlighting := true

--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -19,4 +19,16 @@ akka {
       unhandled = on
     }
   }
+  swank-dispatcher {
+    type = Dispatcher
+    executor = "thread-pool-executor"
+    thread-pool-executor {
+      # minimum number of threads to cap factor-based core number to
+      core-pool-size-min = 2
+      # No of core threads ... ceil(available processors * factor)
+      core-pool-size-factor = 2.0
+      # maximum number of threads to cap factor-based number to
+      core-pool-size-max = 10
+    }
+  }
 }

--- a/src/main/scala/org/ensime/indexer/SearchService.scala
+++ b/src/main/scala/org/ensime/indexer/SearchService.scala
@@ -1,5 +1,7 @@
 package org.ensime.indexer
 
+import java.util
+
 import DatabaseService._
 import akka.event.slf4j.SLF4JLogging
 import java.sql.SQLException
@@ -197,7 +199,7 @@ class SearchService(
     override def run(): Unit = {
       while (true) {
         val head = backlog.take() // blocks until something appears
-        val buffer = new ArrayList[(FileObject, List[FqnSymbol])]()
+        val buffer = new util.ArrayList[(FileObject, List[FqnSymbol])]()
         backlog.drainTo(buffer, 999) // 1000 at a time to avoid blow-ups
         val tail = buffer.asScala.toList
 

--- a/src/main/scala/org/ensime/model/Model.scala
+++ b/src/main/scala/org/ensime/model/Model.scala
@@ -1,6 +1,5 @@
 package org.ensime.model
 
-import akka.event.slf4j.SLF4JLogging
 import java.io.File
 import org.apache.commons.vfs2.FileObject
 import scala.collection.mutable
@@ -544,13 +543,6 @@ trait ModelBuilders { self: RichPresentationCompiler =>
       new ArrowTypeInfo("NA", -1, TypeInfo.nullInfo, List.empty)
     }
   }
-
-  object TypeInspectInfo {
-    def nullInfo() = {
-      new TypeInspectInfo(TypeInfo.nullInfo, None, List.empty)
-    }
-  }
-
 }
 
 object LineSourcePosition {
@@ -592,7 +584,7 @@ object OffsetSourcePosition {
 
   def fromPosition(p: Position): Option[OffsetSourcePosition] = p match {
     case NoPosition => None
-    case p =>
-      Some(new OffsetSourcePosition(file(p.source.file.path).canon, p.point))
+    case realPos =>
+      Some(new OffsetSourcePosition(file(realPos.source.file.path).canon, realPos.point))
   }
 }

--- a/src/main/scala/org/ensime/protocol/Protocol.scala
+++ b/src/main/scala/org/ensime/protocol/Protocol.scala
@@ -44,7 +44,7 @@ trait Protocol {
    * Protocols must expose an appropriate class for converting messages to
    * the underlying wire format
    */
-  val conversions: ProtocolConversions
+  protected val conversions: ProtocolConversions
 
   /**
    * Read a message from the socket.

--- a/src/main/scala/org/ensime/protocol/ProtocolConversions.scala
+++ b/src/main/scala/org/ensime/protocol/ProtocolConversions.scala
@@ -59,6 +59,7 @@ trait ProtocolConversions {
   def toWF(value: UndoResult): WireFormat
   // a wire format message representing null
   def wfNull: WireFormat
+  def wfTrue: WireFormat
+  def wfFalse: WireFormat
   def toWF(vmStatus: DebugVmStatus): WireFormat
-  def toWF(method: MethodBytecode): WireFormat
 }

--- a/src/main/scala/org/ensime/protocol/RPCTarget.scala
+++ b/src/main/scala/org/ensime/protocol/RPCTarget.scala
@@ -1,80 +1,65 @@
 package org.ensime.protocol
 
+import org.ensime.config.EnsimeConfig
 import org.ensime.model._
-import org.ensime.server.RefactorDesc
-import org.ensime.util.SExp
+import org.ensime.server._
+import org.ensime.util.{ FileRange, SExp }
+
+import scala.reflect.internal.util.RangePosition
 
 trait RPCTarget {
 
-  def rpcConnectionInfo(callId: Int): Unit
-  def rpcShutdownServer(callId: Int): Unit
-
-  def rcpInitProject(confSExp: SExp, callId: Int): Unit
-  def rpcPeekUndo(callId: Int): Unit
-  def rpcExecUndo(undoId: Int, callId: Int): Unit
-  def rpcReplConfig(callId: Int): Unit
-
-  def rpcSymbolDesignations(f: String, start: Int, end: Int, requestedTypes: List[Symbol], callId: Int): Unit
-  def rpcMethodBytecode(f: String, line: Int, callId: Int)
-  def rpcDebugStartVM(commandLine: String, callId: Int)
-  def rpcDebugAttachVM(hostname: String, port: String, callId: Int)
-  def rpcDebugStopVM(callId: Int)
-  def rpcDebugRun(callId: Int)
-  def rpcDebugContinue(threadId: Long, callId: Int)
-  def rpcDebugBreak(file: String, line: Int, callId: Int)
-  def rpcDebugClearBreak(file: String, line: Int, callId: Int)
-  def rpcDebugClearAllBreaks(callId: Int)
-  def rpcDebugListBreaks(callId: Int)
-  def rpcDebugNext(threadId: Long, callId: Int)
-  def rpcDebugStep(threadId: Long, callId: Int)
-  def rpcDebugStepOut(threadId: Long, callId: Int)
-  def rpcDebugLocateName(threadId: Long, name: String, callId: Int)
-  def rpcDebugValue(loc: DebugLocation, callId: Int)
-  def rpcDebugToString(threadId: Long, loc: DebugLocation, callId: Int)
-  def rpcDebugSetValue(loc: DebugLocation, newValue: String, callId: Int)
-  def rpcDebugBacktrace(threadId: Long, index: Int, count: Int, callId: Int)
-  def rpcDebugActiveVM(callId: Int)
-  def rpcPatchSource(f: String, edits: List[PatchOp], callId: Int)
-  def rpcTypecheckFiles(fs: List[SourceFileInfo], callId: Int)
-  def rpcRemoveFile(f: String, callId: Int)
-  def rpcUnloadAll(callId: Int)
-  def rpcTypecheckAll(callId: Int)
-  def rpcCompletionsAtPoint(f: String, point: Int, maxResults: Int, caseSens: Boolean, reload: Boolean, callId: Int)
-  def rpcPackageMemberCompletion(path: String, prefix: String, callId: Int)
-  def rpcInspectTypeAtPoint(f: String, range: OffsetRange, callId: Int)
-
-  def rpcInspectTypeById(id: Int, callId: Int)
-  def rpcInspectTypeByName(name: String, callId: Int)
-
-  def rpcSymbolAtPoint(f: String, point: Int, callId: Int)
-
-  def rpcMemberByName(typeFullName: String, memberName: String, memberIsType: Boolean, callId: Int)
-
-  def rpcTypeById(id: Int, callId: Int)
-
-  def rpcTypeByName(name: String, callId: Int)
-
-  def rpcTypeByNameAtPoint(name: String, f: String, range: OffsetRange, callId: Int)
-
-  def rpcCallCompletion(id: Int, callId: Int)
-
-  def rpcImportSuggestions(f: String, point: Int, names: List[String], maxResults: Int, callId: Int)
-  def rpcPublicSymbolSearch(names: List[String], maxResults: Int, callId: Int)
-
-  def rpcUsesOfSymAtPoint(f: String, point: Int, callId: Int)
-
-  def rpcTypeAtPoint(f: String, range: OffsetRange, callId: Int)
-
-  def rpcInspectPackageByPath(path: String, callId: Int)
-
-  def rpcPrepareRefactor(procId: Int, refactorDesc: RefactorDesc, interactive: Boolean, callId: Int)
-
-  def rpcExecRefactor(procId: Int, refactorType: Symbol, callId: Int)
-
-  def rpcCancelRefactor(procId: Int, callId: Int)
-
-  def rpcExpandSelection(filename: String, start: Int, stop: Int, callId: Int)
-
-  def rpcFormatFiles(filenames: List[String], callId: Int)
+  def rpcConnectionInfo(): ConnectionInfo
+  def rpcShutdownServer(): Unit
+  def rcpInitProject(confSExp: SExp): EnsimeConfig
+  def rpcNotifyClientConnected(): Unit
+  def rpcPeekUndo(): Either[String, Undo]
+  def rpcExecUndo(undoId: Int): Either[String, UndoResult]
+  def rpcReplConfig(): ReplConfig
+  def rpcSymbolDesignations(f: String, start: Int, end: Int, requestedTypes: List[Symbol]): SymbolDesignations
+  def rpcDebugStartVM(commandLine: String): DebugVmStatus
+  def rpcDebugAttachVM(hostname: String, port: String): DebugVmStatus
+  def rpcDebugStopVM(): Boolean
+  def rpcDebugRun(): Boolean
+  def rpcDebugContinue(threadId: Long): Boolean
+  def rpcDebugBreak(file: String, line: Int): Unit
+  def rpcDebugClearBreak(file: String, line: Int): Unit
+  def rpcDebugClearAllBreaks(): Unit
+  def rpcDebugListBreaks(): BreakpointList
+  def rpcDebugNext(threadId: Long): Boolean
+  def rpcDebugStep(threadId: Long): Boolean
+  def rpcDebugStepOut(threadId: Long): Boolean
+  def rpcDebugLocateName(threadId: Long, name: String): Option[DebugLocation]
+  def rpcDebugValue(loc: DebugLocation): Option[DebugValue]
+  def rpcDebugToString(threadId: Long, loc: DebugLocation): Option[String]
+  def rpcDebugSetValue(loc: DebugLocation, newValue: String): Boolean
+  def rpcDebugBacktrace(threadId: Long, index: Int, count: Int): DebugBacktrace
+  def rpcDebugActiveVM(): Boolean
+  def rpcPatchSource(f: String, edits: List[PatchOp]): Unit
+  def rpcTypecheckFiles(fs: List[SourceFileInfo]): Unit
+  def rpcRemoveFile(f: String): Unit
+  def rpcUnloadAll(): Unit
+  def rpcTypecheckAll(): Unit
+  def rpcCompletionsAtPoint(f: String, point: Int, maxResults: Int, caseSens: Boolean, reload: Boolean): CompletionInfoList
+  def rpcPackageMemberCompletion(path: String, prefix: String): List[CompletionInfo]
+  def rpcInspectTypeAtPoint(f: String, range: OffsetRange): Option[TypeInspectInfo]
+  def rpcInspectTypeById(id: Int): Option[TypeInspectInfo]
+  def rpcInspectTypeByName(name: String): Option[TypeInspectInfo]
+  def rpcSymbolAtPoint(f: String, point: Int): Option[SymbolInfo]
+  def rpcMemberByName(typeFullName: String, memberName: String, memberIsType: Boolean): Option[SymbolInfo]
+  def rpcTypeById(id: Int): Option[TypeInfo]
+  def rpcTypeByName(name: String): Option[TypeInfo]
+  def rpcTypeByNameAtPoint(name: String, f: String, range: OffsetRange): Option[TypeInfo]
+  def rpcCallCompletion(id: Int): Option[CallCompletionInfo]
+  def rpcImportSuggestions(f: String, point: Int, names: List[String], maxResults: Int): ImportSuggestions
+  def rpcPublicSymbolSearch(names: List[String], maxResults: Int): SymbolSearchResults
+  def rpcUsesOfSymAtPoint(f: String, point: Int): List[RangePosition]
+  def rpcTypeAtPoint(f: String, range: OffsetRange): Option[TypeInfo]
+  def rpcInspectPackageByPath(path: String): Option[PackageInfo]
+  def rpcPrepareRefactor(procId: Int, refactorDesc: RefactorDesc): Either[RefactorFailure, RefactorEffect]
+  def rpcExecRefactor(procId: Int, refactorType: Symbol): Either[RefactorFailure, RefactorResult]
+  def rpcCancelRefactor(procId: Int): Unit
+  def rpcExpandSelection(filename: String, start: Int, stop: Int): FileRange
+  def rpcFormatFiles(filenames: List[String]): Unit
 }
 

--- a/src/main/scala/org/ensime/protocol/SwankProtocolConversions.scala
+++ b/src/main/scala/org/ensime/protocol/SwankProtocolConversions.scala
@@ -455,7 +455,7 @@ class SwankProtocolConversions extends ProtocolConversions {
   )
 
   override def toWF(config: ReplConfig): SExp = {
-    SExp.propList((":classpath", strToSExp(config.classpath.mkString("\"", File.pathSeparator, "\""))))
+    SExp.propList((":classpath", strToSExp(config.classpath.mkString(File.pathSeparator))))
   }
 
   override def toWF(value: Boolean): SExp = {
@@ -464,6 +464,10 @@ class SwankProtocolConversions extends ProtocolConversions {
   }
 
   override val wfNull: SExp = NilAtom
+
+  override val wfTrue: SExp = TruthAtom
+
+  override val wfFalse: SExp = NilAtom
 
   override def toWF(value: String): SExp = {
     StringAtom(value)
@@ -709,16 +713,6 @@ class SwankProtocolConversions extends ProtocolConversions {
         key(":error-code"), code,
         key(":details"), details)
     }
-  }
-
-  def toWF(method: MethodBytecode): SExp = {
-    SExp.propList(
-      (":class-name", method.className),
-      (":name", method.methodName),
-      (":signature", method.methodSignature.map(strToSExp).getOrElse('nil)),
-      (":bytecode", SExpList(method.byteCode.map { op =>
-        SExp(op.op, op.description)
-      })))
   }
 
   private def changeToWF(ch: FileEdit): SExp = {

--- a/src/main/scala/org/ensime/server/Indexer.scala
+++ b/src/main/scala/org/ensime/server/Indexer.scala
@@ -6,26 +6,21 @@ import java.net.URI
 import org.apache.commons.vfs2.FileObject
 import org.ensime.config.EnsimeConfig
 import org.ensime.indexer.DatabaseService.FqnSymbol
-import org.ensime.indexer.MemberName
 import org.ensime.indexer.SearchService
 import org.ensime.model._
 import org.ensime.protocol.ProtocolConst._
-import org.ensime.protocol.ProtocolConversions
 import scala.reflect.io.{ AbstractFile, ZipArchive }
 
 // legacy types
-case class TypeCompletionsReq(prefix: String, maxResults: Int)
-case class SourceFileCandidatesReq(enclosingPackage: String, classNamePrefix: String)
-case class AbstractFiles(files: Set[AbstractFile])
+case class TypeCompletionsReq(prefix: String, maxResults: Int) extends RPCRequest
+case class SourceFileCandidatesReq(enclosingPackage: String, classNamePrefix: String) extends RPCRequest
+case class AbstractFiles(files: Set[AbstractFile]) extends RPCRequest
 
 //@deprecated("there is no good reason for this to be an actor, plus it enforces single-threaded badness", "fommil")
 class Indexer(
     config: EnsimeConfig,
     index: SearchService,
-    project: Project,
-    protocol: ProtocolConversions) extends Actor with ActorLogging {
-
-  import protocol._
+    project: Project) extends Actor with ActorLogging {
 
   private def typeResult(hit: FqnSymbol) = TypeSearchResult(
     hit.fqn, hit.fqn.split("\\.").last, hit.declAs,
@@ -65,27 +60,22 @@ class Indexer(
     case TypeCompletionsReq(query: String, maxResults: Int) =>
       sender ! SymbolSearchResults(oldSearchTypes(query, maxResults))
 
-    case RPCRequestEvent(req: Any, callId: Int) =>
+    case req: RPCRequest =>
       try {
         req match {
           case ImportSuggestionsReq(file, point, names, maxResults) =>
             val suggestions = names.map(oldSearchTypes(_, maxResults))
-            project ! RPCResultEvent(toWF(ImportSuggestions(suggestions)), callId)
+            sender ! ImportSuggestions(suggestions)
 
           case PublicSymbolSearchReq(keywords, maxResults) =>
             val suggestions = keywords.flatMap(oldSearchSymbols(_, maxResults))
-            project ! RPCResultEvent(toWF(SymbolSearchResults(suggestions)), callId)
+            sender ! SymbolSearchResults(suggestions)
         }
       } catch {
         case e: Exception =>
           log.error(e, "Error handling RPC: " + req)
-          project.sendRPCError(
-            ErrExceptionInIndexer,
-            "Error occurred in indexer. Check the server log.",
-            callId
-          )
+          sender ! RPCError(ErrExceptionInIndexer, "Error occurred in indexer. Check the server log.")
       }
-
     case other =>
       log.warning("Indexer: WTF, what's " + other)
   }

--- a/src/main/scala/org/ensime/server/ProjectRPCTarget.scala
+++ b/src/main/scala/org/ensime/server/ProjectRPCTarget.scala
@@ -1,258 +1,280 @@
 package org.ensime.server
 
 import java.io.File
+import akka.actor.ActorRef
+import org.ensime.config.EnsimeConfig
 import org.ensime.model._
 import org.ensime.protocol._
 import org.ensime.protocol.ProtocolConst._
 import org.ensime.protocol.{ ConnectionInfo, RPCTarget }
 import org.ensime.util._
 
+import scala.reflect.internal.util.RangePosition
 import scalariform.astselect.AstSelector
 import scalariform.formatter.ScalaFormatter
 import scalariform.parser.ScalaParserException
 import scalariform.utils.Range
 
+import scala.concurrent.Await
+import akka.pattern.ask
+import scala.concurrent.duration._
+import shapeless.syntax.typeable._
+import shapeless.Typeable
+
 trait ProjectRPCTarget extends RPCTarget { self: Project =>
 
-  import protocol._
-  import protocol.conversions._
-
-  override def rpcConnectionInfo(callId: Int) {
-    sendRPCReturn(conversions.toWF(new ConnectionInfo()), callId)
+  val defaultMaxWait: FiniteDuration = 30.seconds
+  def callVoidRPC(target: ActorRef, request: RPCRequest, maxWait: FiniteDuration = defaultMaxWait): Unit = {
+    callRPC[VoidResponse.type](target, request, maxWait)
   }
 
-  override def rpcShutdownServer(callId: Int) {
-    sendRPCReturn(toWF(value = true), callId)
+  def callRPC[R](target: ActorRef, request: RPCRequest, maxWait: FiniteDuration = defaultMaxWait)(implicit typ: Typeable[R]): R = {
+    val future = target.ask(request)(maxWait)
+    val result = Await.result(future, maxWait)
+    result match {
+      case e: RPCError =>
+        throw e
+      case r =>
+        val castRes = r.cast[R]
+        if (castRes.isDefined)
+          castRes.get
+        else {
+          val msg = "Error, incorrect type found in RPC call, expected: " + typ + " got " + r.getClass
+          val ex = RPCError(ProtocolConst.ErrExceptionInRPC, msg)
+          log.error(msg, ex)
+          throw ex
+        }
+    }
+  }
+
+  override def rpcConnectionInfo(): ConnectionInfo = {
+    new ConnectionInfo()
+  }
+
+  override def rpcShutdownServer(): Unit = {
     shutdownServer()
   }
 
-  override def rcpInitProject(confSExp: SExp, callId: Int) {
+  override def rcpInitProject(confSExp: SExp): EnsimeConfig = {
     // bit of a hack - simply return the init string right now until it goes away
-    //    initProject(conf)
-    sendRPCReturn(toWF(self.config), callId)
+    self.config
+  }
+
+  override def rpcNotifyClientConnected(): Unit = {
     actor ! ClientConnectedEvent
   }
 
-  override def rpcPeekUndo(callId: Int) {
-    peekUndo() match {
-      case Right(result) => sendRPCReturn(toWF(result), callId)
-      case Left(msg) => sendRPCError(ErrPeekUndoFailed, msg, callId)
-    }
+  override def rpcPeekUndo(): Either[String, Undo] = {
+    peekUndo()
   }
 
-  override def rpcExecUndo(undoId: Int, callId: Int) {
-    execUndo(undoId) match {
-      case Right(result) => sendRPCReturn(toWF(result), callId)
-      case Left(msg) => sendRPCError(ErrExecUndoFailed, msg, callId)
-    }
+  override def rpcExecUndo(undoId: Int): Either[String, UndoResult] = {
+    execUndo(undoId)
   }
 
-  override def rpcReplConfig(callId: Int) {
-    sendRPCReturn(toWF(new ReplConfig(config.runtimeClasspath)), callId)
+  override def rpcReplConfig(): ReplConfig = {
+    new ReplConfig(config.runtimeClasspath)
   }
 
-  override def rpcSymbolDesignations(f: String, start: Int, end: Int, requestedTypes: List[Symbol], callId: Int) {
+  override def rpcSymbolDesignations(f: String, start: Int, end: Int,
+    requestedTypes: List[Symbol]): SymbolDesignations = {
     val file: File = new File(f)
-    getAnalyzer ! RPCRequestEvent(SymbolDesignationsReq(file, start, end, requestedTypes), callId)
+    callRPC[SymbolDesignations](getAnalyzer, SymbolDesignationsReq(file, start, end, requestedTypes))
   }
 
-  override def rpcMethodBytecode(f: String, line: Int, callId: Int) {
-    getIndexer ! RPCRequestEvent(MethodBytecodeReq(new File(f).getName, line), callId)
+  override def rpcDebugStartVM(commandLine: String): DebugVmStatus = {
+    callRPC[DebugVmStatus](acquireDebugger, DebugStartVMReq(commandLine))
   }
 
-  override def rpcDebugStartVM(commandLine: String, callId: Int) {
-    acquireDebugger ! RPCRequestEvent(DebugStartVMReq(commandLine), callId)
+  override def rpcDebugAttachVM(hostname: String, port: String): DebugVmStatus = {
+    callRPC[DebugVmStatus](acquireDebugger, DebugAttachVMReq(hostname, port))
   }
 
-  override def rpcDebugAttachVM(hostname: String, port: String, callId: Int) {
-    acquireDebugger ! RPCRequestEvent(DebugAttachVMReq(hostname, port), callId)
+  override def rpcDebugStopVM(): Boolean = {
+    callRPC[Boolean](acquireDebugger, DebugStopVMReq)
   }
 
-  override def rpcDebugStopVM(callId: Int) {
-    acquireDebugger ! RPCRequestEvent(DebugStopVMReq, callId)
+  override def rpcDebugRun(): Boolean = {
+    callRPC[Boolean](acquireDebugger, DebugRunReq)
   }
 
-  override def rpcDebugRun(callId: Int) {
-    acquireDebugger ! RPCRequestEvent(DebugRunReq, callId)
+  override def rpcDebugContinue(threadId: Long): Boolean = {
+    callRPC[Boolean](acquireDebugger, DebugContinueReq(threadId))
   }
 
-  override def rpcDebugContinue(threadId: Long, callId: Int) {
-    acquireDebugger ! RPCRequestEvent(DebugContinueReq(threadId), callId)
+  override def rpcDebugBreak(file: String, line: Int): Unit = {
+    callVoidRPC(acquireDebugger, DebugBreakReq(file, line))
   }
 
-  override def rpcDebugBreak(file: String, line: Int, callId: Int) {
-    acquireDebugger ! RPCRequestEvent(DebugBreakReq(file, line), callId)
+  override def rpcDebugClearBreak(file: String, line: Int): Unit = {
+    callVoidRPC(acquireDebugger, DebugClearBreakReq(file, line))
   }
 
-  override def rpcDebugClearBreak(file: String, line: Int, callId: Int) {
-    acquireDebugger ! RPCRequestEvent(DebugClearBreakReq(file, line), callId)
+  override def rpcDebugClearAllBreaks(): Unit = {
+    callVoidRPC(acquireDebugger, DebugClearAllBreaksReq)
   }
 
-  override def rpcDebugClearAllBreaks(callId: Int) {
-    acquireDebugger ! RPCRequestEvent(DebugClearAllBreaksReq, callId)
+  override def rpcDebugListBreaks(): BreakpointList = {
+    callRPC[BreakpointList](acquireDebugger, DebugListBreaksReq)
   }
 
-  override def rpcDebugListBreaks(callId: Int) {
-    acquireDebugger ! RPCRequestEvent(DebugListBreaksReq, callId)
+  override def rpcDebugNext(threadId: Long): Boolean = {
+    callRPC[Boolean](acquireDebugger, DebugNextReq(threadId))
   }
 
-  override def rpcDebugNext(threadId: Long, callId: Int) {
-    acquireDebugger ! RPCRequestEvent(DebugNextReq(threadId), callId)
+  override def rpcDebugStep(threadId: Long): Boolean = {
+    callRPC[Boolean](acquireDebugger, DebugStepReq(threadId))
   }
 
-  override def rpcDebugStep(threadId: Long, callId: Int) {
-    acquireDebugger ! RPCRequestEvent(DebugStepReq(threadId), callId)
+  override def rpcDebugStepOut(threadId: Long): Boolean = {
+    callRPC[Boolean](acquireDebugger, DebugStepOutReq(threadId))
   }
 
-  override def rpcDebugStepOut(threadId: Long, callId: Int) {
-    acquireDebugger ! RPCRequestEvent(DebugStepOutReq(threadId), callId)
+  override def rpcDebugLocateName(threadId: Long, name: String): Option[DebugLocation] = {
+    callRPC[Option[DebugLocation]](acquireDebugger, DebugLocateNameReq(threadId, name))
   }
 
-  override def rpcDebugLocateName(threadId: Long, name: String, callId: Int) {
-    acquireDebugger ! RPCRequestEvent(DebugLocateNameReq(threadId, name), callId)
+  override def rpcDebugValue(loc: DebugLocation): Option[DebugValue] = {
+    callRPC[Option[DebugValue]](acquireDebugger, DebugValueReq(loc))
   }
 
-  override def rpcDebugValue(loc: DebugLocation, callId: Int) {
-    acquireDebugger ! RPCRequestEvent(DebugValueReq(loc), callId)
+  override def rpcDebugToString(threadId: Long, loc: DebugLocation): Option[String] = {
+    callRPC[Option[String]](acquireDebugger, DebugToStringReq(threadId, loc))
   }
 
-  def rpcDebugToString(threadId: Long, loc: DebugLocation, callId: Int) {
-    acquireDebugger ! RPCRequestEvent(DebugToStringReq(threadId, loc), callId)
+  override def rpcDebugSetValue(loc: DebugLocation, newValue: String): Boolean = {
+    callRPC[Boolean](acquireDebugger, DebugSetValueReq(loc, newValue))
   }
 
-  override def rpcDebugSetValue(loc: DebugLocation, newValue: String, callId: Int) {
-    acquireDebugger ! RPCRequestEvent(DebugSetValueReq(loc, newValue), callId)
+  override def rpcDebugBacktrace(threadId: Long, index: Int, count: Int): DebugBacktrace = {
+    callRPC[DebugBacktrace](acquireDebugger, DebugBacktraceReq(threadId, index, count))
   }
 
-  override def rpcDebugBacktrace(threadId: Long, index: Int, count: Int, callId: Int) {
-    acquireDebugger ! RPCRequestEvent(DebugBacktraceReq(threadId, index, count), callId)
+  override def rpcDebugActiveVM(): Boolean = {
+    callRPC[Boolean](acquireDebugger, DebugActiveVMReq)
   }
 
-  override def rpcDebugActiveVM(callId: Int) {
-    acquireDebugger ! RPCRequestEvent(DebugActiveVMReq, callId)
-  }
-
-  override def rpcPatchSource(f: String, edits: List[PatchOp], callId: Int) {
+  override def rpcPatchSource(f: String, edits: List[PatchOp]): Unit = {
     val file: File = new File(f)
-    getAnalyzer ! RPCRequestEvent(PatchSourceReq(file, edits), callId)
+    callVoidRPC(getAnalyzer, PatchSourceReq(file, edits))
   }
 
-  override def rpcTypecheckFiles(fs: List[SourceFileInfo], callId: Int) {
-    getAnalyzer ! RPCRequestEvent(ReloadFilesReq(fs), callId)
+  override def rpcTypecheckFiles(fs: List[SourceFileInfo]): Unit = {
+    callVoidRPC(getAnalyzer, ReloadFilesReq(fs))
   }
 
-  override def rpcRemoveFile(f: String, callId: Int) {
+  override def rpcRemoveFile(f: String): Unit = {
     val file: File = new File(f)
-    getAnalyzer ! RPCRequestEvent(RemoveFileReq(file), callId)
-    sendRPCAckOK(callId)
+    callVoidRPC(getAnalyzer, RemoveFileReq(file))
   }
 
-  override def rpcUnloadAll(callId: Int) {
-    getAnalyzer ! RPCRequestEvent(UnloadAllReq, callId)
+  override def rpcUnloadAll() {
+    callVoidRPC(getAnalyzer, UnloadAllReq)
   }
 
-  override def rpcTypecheckAll(callId: Int) {
-    getAnalyzer ! RPCRequestEvent(ReloadAllReq, callId)
+  override def rpcTypecheckAll(): Unit = {
+    callVoidRPC(getAnalyzer, ReloadAllReq)
   }
 
   override def rpcCompletionsAtPoint(f: String, point: Int, maxResults: Int,
-    caseSens: Boolean, reload: Boolean, callId: Int) {
-    getAnalyzer ! RPCRequestEvent(
-      CompletionsReq(new File(f), point, maxResults, caseSens, reload), callId)
+    caseSens: Boolean, reload: Boolean): CompletionInfoList = {
+
+    callRPC[CompletionInfoList](getAnalyzer,
+      CompletionsReq(new File(f), point, maxResults, caseSens, reload),
+      30.seconds)
   }
 
-  override def rpcPackageMemberCompletion(path: String, prefix: String, callId: Int) {
-    getAnalyzer ! RPCRequestEvent(PackageMemberCompletionReq(path, prefix), callId)
+  override def rpcPackageMemberCompletion(path: String, prefix: String): List[CompletionInfo] = {
+    callRPC[List[CompletionInfo]](getAnalyzer, PackageMemberCompletionReq(path, prefix))
   }
 
-  override def rpcInspectTypeAtPoint(f: String, range: OffsetRange, callId: Int) {
-    getAnalyzer ! RPCRequestEvent(InspectTypeReq(new File(f), range), callId)
+  override def rpcInspectTypeAtPoint(f: String, range: OffsetRange): Option[TypeInspectInfo] = {
+    callRPC[Option[TypeInspectInfo]](getAnalyzer, InspectTypeReq(new File(f), range))
   }
 
-  override def rpcInspectTypeById(id: Int, callId: Int) {
-    getAnalyzer ! RPCRequestEvent(InspectTypeByIdReq(id), callId)
+  override def rpcInspectTypeById(id: Int): Option[TypeInspectInfo] = {
+    callRPC[Option[TypeInspectInfo]](getAnalyzer, InspectTypeByIdReq(id))
   }
 
-  override def rpcInspectTypeByName(name: String, callId: Int) {
-    getAnalyzer ! RPCRequestEvent(InspectTypeByNameReq(name), callId)
+  override def rpcInspectTypeByName(name: String): Option[TypeInspectInfo] = {
+    callRPC[Option[TypeInspectInfo]](getAnalyzer, InspectTypeByNameReq(name))
   }
 
-  override def rpcSymbolAtPoint(f: String, point: Int, callId: Int) {
-    getAnalyzer ! RPCRequestEvent(SymbolAtPointReq(new File(f), point), callId)
+  override def rpcSymbolAtPoint(f: String, point: Int): Option[SymbolInfo] = {
+    callRPC[Option[SymbolInfo]](getAnalyzer, SymbolAtPointReq(new File(f), point))
   }
 
-  override def rpcMemberByName(typeFullName: String, memberName: String, memberIsType: Boolean, callId: Int) {
-    getAnalyzer ! RPCRequestEvent(MemberByNameReq(typeFullName, memberName, memberIsType), callId)
+  override def rpcMemberByName(typeFullName: String, memberName: String, memberIsType: Boolean): Option[SymbolInfo] = {
+    callRPC[Option[SymbolInfo]](getAnalyzer, MemberByNameReq(typeFullName, memberName, memberIsType))
   }
 
-  override def rpcTypeById(id: Int, callId: Int) {
-    getAnalyzer ! RPCRequestEvent(TypeByIdReq(id), callId)
+  override def rpcTypeById(id: Int): Option[TypeInfo] = {
+    callRPC[Option[TypeInfo]](getAnalyzer, TypeByIdReq(id))
   }
 
-  override def rpcTypeByName(name: String, callId: Int) {
-    getAnalyzer ! RPCRequestEvent(TypeByNameReq(name), callId)
+  override def rpcTypeByName(name: String): Option[TypeInfo] = {
+    callRPC[Option[TypeInfo]](getAnalyzer, TypeByNameReq(name))
   }
 
-  override def rpcTypeByNameAtPoint(name: String, f: String, range: OffsetRange, callId: Int) {
-    getAnalyzer ! RPCRequestEvent(TypeByNameAtPointReq(name, new File(f), range), callId)
+  override def rpcTypeByNameAtPoint(name: String, f: String, range: OffsetRange): Option[TypeInfo] = {
+    callRPC[Option[TypeInfo]](getAnalyzer, TypeByNameAtPointReq(name, new File(f), range))
   }
 
-  override def rpcCallCompletion(id: Int, callId: Int) {
-    getAnalyzer ! RPCRequestEvent(CallCompletionReq(id), callId)
+  override def rpcCallCompletion(id: Int): Option[CallCompletionInfo] = {
+    callRPC[Option[CallCompletionInfo]](getAnalyzer, CallCompletionReq(id))
   }
 
-  override def rpcImportSuggestions(f: String, point: Int, names: List[String], maxResults: Int, callId: Int) {
-    getAnalyzer ! RPCRequestEvent(ImportSuggestionsReq(new File(f), point, names, maxResults), callId)
+  override def rpcImportSuggestions(f: String, point: Int, names: List[String], maxResults: Int): ImportSuggestions = {
+    callRPC[ImportSuggestions](getIndexer, ImportSuggestionsReq(new File(f), point, names, maxResults))
   }
 
-  override def rpcPublicSymbolSearch(names: List[String], maxResults: Int, callId: Int) {
-    getAnalyzer ! RPCRequestEvent(PublicSymbolSearchReq(names, maxResults), callId)
+  override def rpcPublicSymbolSearch(names: List[String], maxResults: Int): SymbolSearchResults = {
+    callRPC[SymbolSearchResults](getIndexer, PublicSymbolSearchReq(names, maxResults))
   }
 
-  override def rpcUsesOfSymAtPoint(f: String, point: Int, callId: Int) {
-    getAnalyzer ! RPCRequestEvent(UsesOfSymAtPointReq(new File(f), point), callId)
+  override def rpcUsesOfSymAtPoint(f: String, point: Int): List[RangePosition] = {
+    callRPC[List[RangePosition]](getAnalyzer, UsesOfSymAtPointReq(new File(f), point))
   }
 
-  override def rpcTypeAtPoint(f: String, range: OffsetRange, callId: Int) {
-    getAnalyzer ! RPCRequestEvent(TypeAtPointReq(new File(f), range), callId)
+  override def rpcTypeAtPoint(f: String, range: OffsetRange): Option[TypeInfo] = {
+    callRPC[Option[TypeInfo]](getAnalyzer, TypeAtPointReq(new File(f), range))
   }
 
-  override def rpcInspectPackageByPath(path: String, callId: Int) {
-    getAnalyzer ! RPCRequestEvent(InspectPackageByPathReq(path), callId)
+  override def rpcInspectPackageByPath(path: String): Option[PackageInfo] = {
+    callRPC[Option[PackageInfo]](getAnalyzer, InspectPackageByPathReq(path))
   }
 
-  override def rpcPrepareRefactor(procId: Int, refactorDesc: RefactorDesc, interactive: Boolean, callId: Int) {
-    getAnalyzer ! RPCRequestEvent(RefactorPrepareReq(procId, refactorDesc, interactive), callId)
+  override def rpcPrepareRefactor(procId: Int, refactorDesc: RefactorDesc): Either[RefactorFailure, RefactorEffect] = {
+    callRPC[Either[RefactorFailure, RefactorEffect]](getAnalyzer, RefactorPrepareReq(procId, refactorDesc))
   }
 
-  override def rpcExecRefactor(procId: Int, refactorType: Symbol, callId: Int) {
-    getAnalyzer ! RPCRequestEvent(RefactorExecReq(procId, refactorType), callId)
+  override def rpcExecRefactor(procId: Int, refactorType: Symbol): Either[RefactorFailure, RefactorResult] = {
+    callRPC[Either[RefactorFailure, RefactorResult]](getAnalyzer, RefactorExecReq(procId, refactorType))
   }
 
-  override def rpcCancelRefactor(procId: Int, callId: Int) {
-    getAnalyzer ! RPCRequestEvent(RefactorCancelReq(procId), callId)
+  override def rpcCancelRefactor(procId: Int): Unit = {
+    callVoidRPC(getAnalyzer, RefactorCancelReq(procId))
   }
 
-  override def rpcExpandSelection(filename: String, start: Int, stop: Int, callId: Int) {
+  override def rpcExpandSelection(filename: String, start: Int, stop: Int): FileRange = {
     try {
       FileUtils.readFile(new File(filename)) match {
         case Right(contents) =>
           val selectionRange = Range(start, stop - start)
           AstSelector.expandSelection(contents, selectionRange) match {
-            case Some(range) => sendRPCReturn(
-              toWF(FileRange(filename, range.offset, range.offset + range.length)), callId)
-            case _ => sendRPCReturn(
-              toWF(FileRange(filename, start, stop)), callId)
+            case Some(range) => FileRange(filename, range.offset, range.offset + range.length)
+            case _ =>
+              FileRange(filename, start, stop)
           }
         case Left(e) => throw e
       }
     } catch {
       case e: ScalaParserException =>
-        sendRPCError(ErrFormatFailed, "Could not parse broken syntax: " + e, callId)
+        throw RPCError(ErrFormatFailed, "Could not parse broken syntax: " + e)
     }
   }
 
-  override def rpcFormatFiles(filenames: List[String], callId: Int) {
+  override def rpcFormatFiles(filenames: List[String]): Unit = {
     val files = filenames.map { new File(_) }
     try {
       val changeList = files.map { f =>
@@ -265,13 +287,14 @@ trait ProjectRPCTarget extends RPCTarget { self: Project =>
       }
       addUndo("Formatted source of " + filenames.mkString(", ") + ".", FileUtils.inverseEdits(changeList))
       FileUtils.writeChanges(changeList) match {
-        case Right(_) => sendRPCAckOK(callId)
+        case Right(_) =>
+        // do nothing - returning signals success
         case Left(e) =>
-          sendRPCError(ErrFormatFailed, "Could not write any formatting changes: " + e, callId)
+          throw RPCError(ErrFormatFailed, "Could not write any formatting changes: " + e)
       }
     } catch {
       case e: ScalaParserException =>
-        sendRPCError(ErrFormatFailed, "Cannot format broken syntax: " + e, callId)
+        throw RPCError(ErrFormatFailed, "Cannot format broken syntax: " + e)
     }
   }
 }

--- a/src/main/scala/org/ensime/server/RichPresentationCompiler.scala
+++ b/src/main/scala/org/ensime/server/RichPresentationCompiler.scala
@@ -106,11 +106,11 @@ trait RichCompilerControl extends CompilerControl with RefactoringControl with C
         file <- config.sourceFiles
         source = getSourceFile(file.getAbsolutePath)
       } yield source
-    }.toSet ++ activeUnits.map(_.source)
+    }.toSet ++ activeUnits().map(_.source)
     askReloadFiles(all)
   }
 
-  def loadedFiles: List[SourceFile] = activeUnits.map(_.source)
+  def loadedFiles: List[SourceFile] = activeUnits().map(_.source)
 
   def askReloadExistingFiles() =
     askReloadFiles(loadedFiles)
@@ -190,7 +190,7 @@ class RichPresentationCompiler(
   }
 
   def unloadAllFiles(): Unit = {
-    allSources.foreach(removeUnitOf(_))
+    allSources.foreach(removeUnitOf)
   }
 
   /**

--- a/src/main/scala/org/ensime/server/Server.scala
+++ b/src/main/scala/org/ensime/server/Server.scala
@@ -43,10 +43,7 @@ object Server {
   /**
    * ******************************************************************************
    * Read a new style config from the given files.
-   * @param ensimeFile The base ensime file.
-   * @param rootDir The project root directory
-   * @param cacheDir The
-   * @return
+   * @param ensimeFile The base ensime file.   * @return
    */
   def readEnsimeConfig(ensimeFile: File): EnsimeConfig = {
     val configSrc = Source.fromFile(ensimeFile)
@@ -77,7 +74,7 @@ class Server(config: EnsimeConfig, host: String, requestedPort: Int) {
 
   writePort(config.cacheDir, actualPort)
 
-  val protocol = new SwankProtocol
+  val protocol = new SwankProtocol(actorSystem)
   val project = new Project(config, protocol, actorSystem)
 
   def start() {

--- a/src/main/scala/org/ensime/util/FileEdit.scala
+++ b/src/main/scala/org/ensime/util/FileEdit.scala
@@ -1,0 +1,40 @@
+package org.ensime.util
+
+import java.io.File
+
+trait FileEdit {
+  def file: File
+  def text: String
+  def from: Int
+  def to: Int
+}
+
+case class TextEdit(file: File, from: Int, to: Int, text: String) extends FileEdit
+
+case class NewFile(file: File, text: String) extends FileEdit {
+  def from: Int = 0
+  def to: Int = text.length - 1
+}
+case class DeleteFile(file: File, text: String) extends FileEdit {
+  def from: Int = 0
+  def to: Int = text.length - 1
+}
+
+object FileEdit {
+
+  import scala.tools.refactoring.common.{ TextChange, NewFileChange, Change }
+
+  def fromChange(ch: Change): FileEdit = {
+    ch match {
+      case ch: TextChange => TextEdit(ch.file.file, ch.from, ch.to, ch.text)
+      case ch: NewFileChange => NewFile(ch.file, ch.text)
+    }
+  }
+
+  def applyEdits(ch: List[TextEdit], source: String): String = {
+    (source /: ch.sortBy(-_.to)) { (src, change) =>
+      src.substring(0, change.from) + change.text + src.substring(change.to)
+    }
+  }
+
+}

--- a/src/main/scala/org/ensime/util/FileUtil.scala
+++ b/src/main/scala/org/ensime/util/FileUtil.scala
@@ -3,54 +3,13 @@ package org.ensime.util
 import java.io._
 import java.net.URI
 import java.nio.charset.Charset
-import java.security.MessageDigest
 import org.apache.commons.vfs2.FileObject
 import scala.collection.Seq
 import scala.collection.mutable
-import scala.tools.nsc.io.AbstractFile
-import scala.reflect.io.ZipArchive
 import scala.util.Try
 import scala.sys.process._
 
 import pimpathon.file._
-
-// This routine copied from http://rosettacode.org/wiki/Walk_a_directory/Recursively#Scala
-
-trait FileEdit {
-  def file: File
-  def text: String
-  def from: Int
-  def to: Int
-}
-case class TextEdit(file: File, from: Int, to: Int, text: String) extends FileEdit
-
-case class NewFile(file: File, text: String) extends FileEdit {
-  def from: Int = 0
-  def to: Int = text.length - 1
-}
-case class DeleteFile(file: File, text: String) extends FileEdit {
-  def from: Int = 0
-  def to: Int = text.length - 1
-}
-
-object FileEdit {
-
-  import scala.tools.refactoring.common.{ TextChange, NewFileChange, Change }
-
-  def fromChange(ch: Change): FileEdit = {
-    ch match {
-      case ch: TextChange => TextEdit(ch.file.file, ch.from, ch.to, ch.text)
-      case ch: NewFileChange => NewFile(ch.file, ch.text)
-    }
-  }
-
-  def applyEdits(ch: List[TextEdit], source: String): String = {
-    (source /: ch.sortBy(-_.to)) { (src, change) =>
-      src.substring(0, change.from) + change.text + src.substring(change.to)
-    }
-  }
-
-}
 
 /** A wrapper around file, allowing iteration either on direct children or on directory tree */
 class RichFile(file: File) {
@@ -128,134 +87,10 @@ object FileUtils {
       )
     )
 
-  private def error[T](s: String): T = {
-    throw new IOException(s)
-  }
-
   implicit def toCanonFile(file: File): CanonFile = CanonFile(file)
-
-  import RichFile._
-  def expandRecursively(rootDir: File, fileList: Iterable[File], isValid: (File => Boolean)): Set[CanonFile] = {
-    (for (
-      f <- fileList;
-      files = if (f.isAbsolute) f.andTree else new File(rootDir, f.getPath).andTree;
-      file <- files if isValid(file)
-    ) yield { toCanonFile(file) }).toSet
-  }
-
-  // NOTE: Taken from ZipArchive internals to replace deepIterator that will be removed 2.11
-  private def walkIterator(its: Iterator[AbstractFile]): Iterator[AbstractFile] = {
-    its flatMap { f =>
-      if (f.isDirectory) walkIterator(f.iterator)
-      else Iterator(f)
-    }
-  }
-
-  def expandSourceJars(fileList: Iterable[CanonFile]): Iterable[AbstractFile] = {
-    fileList.flatMap { f =>
-      if (isValidArchive(f)) {
-        walkIterator(ZipArchive.fromFile(f).iterator).filter(f => isValidSourceName(f.name))
-      } else {
-        Seq(AbstractFile.getFile(f))
-      }
-    }
-  }
-
-  def canonicalizeDirs(names: Iterable[String], baseDir: File): Iterable[CanonFile] = {
-    names.map { s => canonicalizeDir(s, baseDir) }.flatten
-  }
-
-  def canonicalizeFiles(names: Iterable[String], baseDir: File): Iterable[CanonFile] = {
-    names.map { s => canonicalizeFile(s, baseDir) }.flatten
-  }
-
-  def canonicalizeFile(s: String, baseDir: File): Option[CanonFile] = {
-    val f = new File(s)
-    if (f.isAbsolute) Some(toCanonFile(f))
-    else Some(toCanonFile(new File(baseDir, s)))
-  }.filter(f => f.exists)
-
-  def canonicalizeDir(s: String, baseDir: File): Option[CanonFile] = {
-    canonicalizeFile(s, baseDir).filter(_.isDirectory)
-  }
-
-  def isValidJar(f: File): Boolean = f.exists && f.getName.endsWith(".jar")
-  def isValidArchive(f: File): Boolean = f.exists && (f.getName.endsWith(".jar") || f.getName.endsWith(".zip"))
-  def isValidClassDir(f: File): Boolean = f.exists && f.isDirectory
-  def isValidSourceName(filename: String) = {
-    filename.endsWith(".scala") || filename.endsWith(".java")
-  }
-
-  def isValidSourceFile(f: File): Boolean = {
-    f.exists && !f.isHidden && isValidSourceName(f.getName)
-  }
-
-  def isValidSourceOrArchive(f: File): Boolean = {
-    isValidSourceFile(f) || isValidArchive(f)
-  }
 
   def isScalaSourceFile(f: File): Boolean = {
     f.exists && f.getName.endsWith(".scala")
-  }
-
-  def createDirectory(dir: File): Unit = {
-    def failBase = "Could not create directory " + dir
-    // Need a retry because mkdirs() has a race condition
-    var tryCount = 0
-    while (!dir.exists && !dir.mkdirs() && tryCount < 100) { tryCount += 1 }
-    if (dir.isDirectory)
-      ()
-    else if (dir.exists) {
-      error(failBase + ": file exists and is not a directory.")
-    } else
-      error(failBase)
-  }
-
-  def listFiles(dir: File): Array[File] = Option(dir.listFiles()).getOrElse(new Array[File](0))
-
-  def delete(files: Iterable[File]): Unit = files.foreach(delete)
-
-  def delete(file: File): Unit = {
-    if (file.isDirectory) {
-      delete(listFiles(file))
-      file.delete
-    } else if (file.exists)
-      file.delete
-  }
-
-  def hexifyBytes(b: Array[Byte]): String = {
-    var result = ""
-    var i: Int = 0
-    while (i < b.length) {
-      result += Integer.toString((b(i) & 0xff) + 0x100, 16).substring(1)
-      i += 1
-    }
-    result
-  }
-
-  def md5(f: File): String = {
-    val buffer = new Array[Byte](1024)
-    val hash = MessageDigest.getInstance("MD5")
-    for (f <- f.andTree) {
-      try {
-        hash.update(f.getAbsolutePath.getBytes)
-        if (!f.isDirectory) {
-          val fis = new FileInputStream(f)
-          var numRead = 0
-          do {
-            numRead = fis.read(buffer)
-            if (numRead > 0) {
-              hash.update(buffer, 0, numRead)
-            }
-          } while (numRead != -1)
-          fis.close()
-        }
-      } catch {
-        case e: IOException =>
-          e.printStackTrace()
-      }
-    }
-    hexifyBytes(hash.digest())
   }
 
   def readFile(file: File): Either[IOException, String] = {

--- a/src/test/resources/logback-test.xml
+++ b/src/test/resources/logback-test.xml
@@ -4,7 +4,16 @@
     <resetJUL>true</resetJUL>
   </contextListener>
 
-  <appender name="file" class="ch.qos.logback.core.FileAppender">
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <!-- encoders are assigned the type
+             ch.qos.logback.classic.encoder.PatternLayoutEncoder by default -->
+        <encoder>
+            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+
+    <appender name="file" class="ch.qos.logback.core.FileAppender">
     <file>test-output.log</file>
     <append>false</append>
     <encoder>

--- a/src/test/scala/org/ensime/test/SwankProtocolConversionsSpec.scala
+++ b/src/test/scala/org/ensime/test/SwankProtocolConversionsSpec.scala
@@ -1,6 +1,5 @@
 package org.ensime.test
 
-import org.ensime.config._
 import org.ensime.model._
 import org.ensime.protocol._
 import org.ensime.server._
@@ -8,272 +7,201 @@ import org.scalatest.FunSpec
 import org.scalatest.Matchers
 import org.ensime.util._
 
-import scala.reflect.internal.util._
-import scala.tools.nsc.io.{ Path, PlainFile }
-import scala.reflect.internal.util.{ RangePosition, OffsetPosition, BatchSourceFile }
-
-import pimpathon.file._
-import org.ensime.util.RichFile._
-
-object SwankProtocolConversionsSpec {
-
-  // some useful example components
-  val packageInfo = new PackageInfo("name", "fullName", List())
-  val typeInfo = new TypeInfo("type1", 7, 'type1, "FOO.type1", List(), List(), None, Some(8))
-  val paramSectionInfo = new ParamSectionInfo(List(("ABC", typeInfo)), false)
-  val interfaceInfo = new InterfaceInfo(typeInfo, Some("DEF"))
-
-  val entityInfo: TypeInfo = new ArrowTypeInfo("Arrow1", 8, typeInfo, List(paramSectionInfo))
-
-  val completionInfo = new CompletionInfo("name",
-    new CompletionSignature(List(List(("abc", "def"), ("hij", "lmn"))), "ABC"), 88, false, 90, Some("BAZ"))
-
-  val completionInfo2 = new CompletionInfo("name2",
-    new CompletionSignature(List(List(("abc", "def"))), "ABC"), 90, true, 91, None)
-
-  val methodSearchRes = MethodSearchResult("abc", "a", 'abcd, Some(LineSourcePosition(file("abd"), 10)), "ownerStr")
-  val typeSearchRes = TypeSearchResult("abc", "a", 'abcd, Some(LineSourcePosition(file("abd"), 10)))
-
-  val note1 = new Note("file1", "note1", 2, 23, 33, 19, 8)
-  val note2 = new Note("file1", "note2", 1, 23, 33, 19, 8)
-
-  val abd = CanonFile("abd")
-  val abd_str = TestUtil.fileToWireString(abd)
-  val file1 = CanonFile("/abc/def")
-  val file1_str = TestUtil.fileToWireString(file1)
-  val file2 = CanonFile("/test/test/")
-  val file2_str = TestUtil.fileToWireString(file2)
-  val file3 = CanonFile("/foo/abc")
-  val file3_str = TestUtil.fileToWireString(file3)
-  val file4 = CanonFile("/foo/def")
-  val file4_str = TestUtil.fileToWireString(file4)
-  val file5 = CanonFile("/foo/hij")
-  val file5_str = TestUtil.fileToWireString(file5)
-
-  val sourcePos1 = new LineSourcePosition(file1, 57)
-  val sourcePos2 = new LineSourcePosition(file1, 59)
-  val sourcePos3 = new EmptySourcePosition()
-  val sourcePos4 = new OffsetSourcePosition(file1, 456)
-
-  val breakPoint1 = new Breakpoint(sourcePos1)
-  val breakPoint2 = new Breakpoint(sourcePos2)
-
-  val debugStackLocal1 = DebugStackLocal(3, "name1", "type1", "summary1")
-  val debugStackLocal2 = DebugStackLocal(4, "name2", "type2", "summary2")
-
-  val debugStackFrame = DebugStackFrame(7, List(debugStackLocal1, debugStackLocal2), 4, "class1", "method1", sourcePos1, 7)
-
-  val debugClassField = DebugClassField(19, "nameStr", "typeNameStr", "summaryStr")
-
-  val batchSourceFile = new BatchSourceFile(new PlainFile(Path("/abc")), "blah\nblah\nblah\n")
-  val batchSourceFile_str = TestUtil.stringToWireString(batchSourceFile.path)
-
-}
+import scala.reflect.internal.util.RangePosition
 
 class SwankProtocolConversionsSpec extends FunSpec with Matchers {
 
-  import SwankProtocolConversionsSpec._
+  import SwankTestData._
 
   describe("SwankProtocolConversionsSpec") {
+    TestUtil.withActorSystem { as =>
 
-    val protocol = new SwankProtocol
-    import protocol.conversions._
-    it("should encode all message types correctly") {
-      assert(toWF(SendBackgroundMessageEvent(1, Some("ABCDEF"))).toWireString === """(:background-message 1 "ABCDEF")""")
-      assert(toWF(SendBackgroundMessageEvent(1, None)).toWireString === "(:background-message 1 nil)")
-      assert(toWF(AnalyzerReadyEvent).toWireString === "(:compiler-ready)")
-      assert(toWF(FullTypeCheckCompleteEvent).toWireString === "(:full-typecheck-finished)")
-      assert(toWF(IndexerReadyEvent).toWireString === "(:indexer-ready)")
+      val protocol = new SwankProtocol(as)
+      import protocol.conversions._
+      it("should encode all message types correctly") {
+        assert(toWF(SendBackgroundMessageEvent(1, Some("ABCDEF"))).toWireString === """(:background-message 1 "ABCDEF")""")
+        assert(toWF(SendBackgroundMessageEvent(1, None)).toWireString === "(:background-message 1 nil)")
+        assert(toWF(AnalyzerReadyEvent).toWireString === "(:compiler-ready)")
+        assert(toWF(FullTypeCheckCompleteEvent).toWireString === "(:full-typecheck-finished)")
+        assert(toWF(IndexerReadyEvent).toWireString === "(:indexer-ready)")
 
-      assert(toWF(NewJavaNotesEvent(NoteList(full = false,
-        List(new Note("foo.scala", "testMsg", 1, 50, 55, 77, 5))))).toWireString === """(:java-notes (:is-full nil :notes ((:severity warn :msg "testMsg" :beg 50 :end 55 :line 77 :col 5 :file "foo.scala"))))""")
-      assert(toWF(NewScalaNotesEvent(NoteList(full = false,
-        List(new Note("foo.scala", "testMsg", 1, 50, 55, 77, 5))))).toWireString === """(:scala-notes (:is-full nil :notes ((:severity warn :msg "testMsg" :beg 50 :end 55 :line 77 :col 5 :file "foo.scala"))))""")
+        assert(toWF(NewJavaNotesEvent(NoteList(full = false,
+          List(new Note("foo.scala", "testMsg", 1, 50, 55, 77, 5))))).toWireString === """(:java-notes (:is-full nil :notes ((:severity warn :msg "testMsg" :beg 50 :end 55 :line 77 :col 5 :file "foo.scala"))))""")
+        assert(toWF(NewScalaNotesEvent(NoteList(full = false,
+          List(new Note("foo.scala", "testMsg", 1, 50, 55, 77, 5))))).toWireString === """(:scala-notes (:is-full nil :notes ((:severity warn :msg "testMsg" :beg 50 :end 55 :line 77 :col 5 :file "foo.scala"))))""")
 
-      assert(toWF(ClearAllScalaNotesEvent).toWireString === "(:clear-all-scala-notes)")
-      assert(toWF(ClearAllJavaNotesEvent).toWireString === "(:clear-all-java-notes)")
+        assert(toWF(ClearAllScalaNotesEvent).toWireString === "(:clear-all-scala-notes)")
+        assert(toWF(ClearAllJavaNotesEvent).toWireString === "(:clear-all-java-notes)")
 
-      // toWF(evt: DebugEvent): WireFormat
-      assert(toWF(DebugOutputEvent("XXX")).toWireString === """(:debug-event (:type output :body "XXX"))""")
-      assert(toWF(DebugStepEvent(207L, "threadNameStr", sourcePos1)).toWireString ===
-        """(:debug-event (:type step :thread-id "207" :thread-name "threadNameStr" :file """ + file1_str + """ :line 57))""")
-      assert(toWF(DebugBreakEvent(209L, "threadNameStr", sourcePos1)).toWireString ===
-        """(:debug-event (:type breakpoint :thread-id "209" :thread-name "threadNameStr" :file """ + file1_str + """ :line 57))""")
-      assert(toWF(DebugVMDeathEvent()).toWireString === """(:debug-event (:type death))""")
-      assert(toWF(DebugVMStartEvent()).toWireString === """(:debug-event (:type start))""")
-      assert(toWF(DebugVMDisconnectEvent()).toWireString === """(:debug-event (:type disconnect))""")
+        // toWF(evt: DebugEvent): WireFormat
+        assert(toWF(DebugOutputEvent("XXX")).toWireString === """(:debug-event (:type output :body "XXX"))""")
+        assert(toWF(DebugStepEvent(207L, "threadNameStr", sourcePos1)).toWireString ===
+          """(:debug-event (:type step :thread-id "207" :thread-name "threadNameStr" :file """ + file1_str + """ :line 57))""")
+        assert(toWF(DebugBreakEvent(209L, "threadNameStr", sourcePos1)).toWireString ===
+          """(:debug-event (:type breakpoint :thread-id "209" :thread-name "threadNameStr" :file """ + file1_str + """ :line 57))""")
+        assert(toWF(DebugVMDeathEvent()).toWireString === """(:debug-event (:type death))""")
+        assert(toWF(DebugVMStartEvent()).toWireString === """(:debug-event (:type start))""")
+        assert(toWF(DebugVMDisconnectEvent()).toWireString === """(:debug-event (:type disconnect))""")
 
-      assert(toWF(DebugExceptionEvent(33L, 209L, "threadNameStr", Some(sourcePos1))).toWireString ===
-        """(:debug-event (:type exception :exception "33" :thread-id "209" :thread-name "threadNameStr" :file """ + file1_str + """ :line 57))""")
+        assert(toWF(DebugExceptionEvent(33L, 209L, "threadNameStr", Some(sourcePos1))).toWireString ===
+          """(:debug-event (:type exception :exception "33" :thread-id "209" :thread-name "threadNameStr" :file """ + file1_str + """ :line 57))""")
 
-      assert(toWF(DebugExceptionEvent(33L, 209L, "threadNameStr", None)).toWireString ===
-        """(:debug-event (:type exception :exception "33" :thread-id "209" :thread-name "threadNameStr" :file nil :line nil))""")
+        assert(toWF(DebugExceptionEvent(33L, 209L, "threadNameStr", None)).toWireString ===
+          """(:debug-event (:type exception :exception "33" :thread-id "209" :thread-name "threadNameStr" :file nil :line nil))""")
 
-      assert(toWF(DebugThreadStartEvent(907L)).toWireString === """(:debug-event (:type threadStart :thread-id "907"))""")
-      assert(toWF(DebugThreadDeathEvent(907L)).toWireString === """(:debug-event (:type threadDeath :thread-id "907"))""")
+        assert(toWF(DebugThreadStartEvent(907L)).toWireString === """(:debug-event (:type threadStart :thread-id "907"))""")
+        assert(toWF(DebugThreadDeathEvent(907L)).toWireString === """(:debug-event (:type threadDeath :thread-id "907"))""")
 
-      // toWF(obj: DebugLocation)
-      assert(toWF(DebugObjectReference(57L).asInstanceOf[DebugLocation]).toWireString ===
-        """(:type reference :object-id "57")""")
-      assert(toWF(DebugArrayElement(58L, 2).asInstanceOf[DebugLocation]).toWireString ===
-        """(:type element :object-id "58" :index 2)""")
-      assert(toWF(DebugObjectField(58L, "fieldName").asInstanceOf[DebugLocation]).toWireString ===
-        """(:type field :object-id "58" :field "fieldName")""")
-      assert(toWF(DebugStackSlot(27L, 12, 23).asInstanceOf[DebugLocation]).toWireString ===
-        """(:type slot :thread-id "27" :frame 12 :offset 23)""")
+        // toWF(obj: DebugLocation)
+        assert(toWF(DebugObjectReference(57L).asInstanceOf[DebugLocation]).toWireString ===
+          """(:type reference :object-id "57")""")
+        assert(toWF(DebugArrayElement(58L, 2).asInstanceOf[DebugLocation]).toWireString ===
+          """(:type element :object-id "58" :index 2)""")
+        assert(toWF(DebugObjectField(58L, "fieldName").asInstanceOf[DebugLocation]).toWireString ===
+          """(:type field :object-id "58" :field "fieldName")""")
+        assert(toWF(DebugStackSlot(27L, 12, 23).asInstanceOf[DebugLocation]).toWireString ===
+          """(:type slot :thread-id "27" :frame 12 :offset 23)""")
 
-      // toWF(obj: DebugValue)
+        // toWF(obj: DebugValue)
 
-      // toWF(evt: DebugPrimitiveValue)
-      assert(toWF(DebugPrimitiveValue("summaryStr", "typeNameStr").asInstanceOf[DebugValue]).toWireString ===
-        """(:val-type prim :summary "summaryStr" :type-name "typeNameStr")""")
+        // toWF(evt: DebugPrimitiveValue)
+        assert(toWF(DebugPrimitiveValue("summaryStr", "typeNameStr").asInstanceOf[DebugValue]).toWireString ===
+          """(:val-type prim :summary "summaryStr" :type-name "typeNameStr")""")
 
-      // toWF(evt: DebugClassField)
-      assert(toWF(debugClassField).toWireString === """(:index 19 :name "nameStr" :summary "summaryStr" :type-name "typeNameStr")""")
+        // toWF(evt: DebugClassField)
+        assert(toWF(debugClassField).toWireString === """(:index 19 :name "nameStr" :summary "summaryStr" :type-name "typeNameStr")""")
 
-      // toWF(obj: DebugStringInstance)
-      assert(toWF(DebugStringInstance("summaryStr", List(debugClassField), "typeNameStr", 5L).asInstanceOf[DebugValue]).toWireString ===
-        """(:val-type str :summary "summaryStr" :fields ((:index 19 :name "nameStr" :summary "summaryStr" :type-name "typeNameStr")) :type-name "typeNameStr" :object-id "5")""")
+        // toWF(obj: DebugStringInstance)
+        assert(toWF(DebugStringInstance("summaryStr", List(debugClassField), "typeNameStr", 5L).asInstanceOf[DebugValue]).toWireString ===
+          """(:val-type str :summary "summaryStr" :fields ((:index 19 :name "nameStr" :summary "summaryStr" :type-name "typeNameStr")) :type-name "typeNameStr" :object-id "5")""")
 
-      // toWF(evt: DebugObjectInstance)
-      assert(toWF(DebugObjectInstance("summaryStr", List(debugClassField), "typeNameStr", 5L).asInstanceOf[DebugValue]).toWireString ===
-        """(:val-type obj :fields ((:index 19 :name "nameStr" :summary "summaryStr" :type-name "typeNameStr")) :type-name "typeNameStr" :object-id "5")""")
+        // toWF(evt: DebugObjectInstance)
+        assert(toWF(DebugObjectInstance("summaryStr", List(debugClassField), "typeNameStr", 5L).asInstanceOf[DebugValue]).toWireString ===
+          """(:val-type obj :fields ((:index 19 :name "nameStr" :summary "summaryStr" :type-name "typeNameStr")) :type-name "typeNameStr" :object-id "5")""")
 
-      // toWF(evt: DebugNullValue)
-      assert(toWF(DebugNullValue("typeNameStr").asInstanceOf[DebugValue]).toWireString ===
-        """(:val-type null :type-name "typeNameStr")""")
+        // toWF(evt: DebugNullValue)
+        assert(toWF(DebugNullValue("typeNameStr").asInstanceOf[DebugValue]).toWireString ===
+          """(:val-type null :type-name "typeNameStr")""")
 
-      // toWF(evt: DebugArrayInstance)
-      assert(toWF(DebugArrayInstance(3, "typeName", "elementType", 5L).asInstanceOf[DebugValue]).toWireString ===
-        """(:val-type arr :length 3 :type-name "typeName" :element-type-name "elementType" :object-id "5")""")
+        // toWF(evt: DebugArrayInstance)
+        assert(toWF(DebugArrayInstance(3, "typeName", "elementType", 5L).asInstanceOf[DebugValue]).toWireString ===
+          """(:val-type arr :length 3 :type-name "typeName" :element-type-name "elementType" :object-id "5")""")
 
-      // toWF(evt: DebugStackLocal)
-      assert(toWF(debugStackLocal1).toWireString === """(:index 3 :name "name1" :summary "summary1" :type-name "type1")""")
+        // toWF(evt: DebugStackLocal)
+        assert(toWF(debugStackLocal1).toWireString === """(:index 3 :name "name1" :summary "summary1" :type-name "type1")""")
 
-      // toWF(evt: DebugStackFrame)
-      assert(toWF(debugStackFrame).toWireString === """(:index 7 :locals ((:index 3 :name "name1" :summary "summary1" :type-name "type1") (:index 4 :name "name2" :summary "summary2" :type-name "type2")) :num-args 4 :class-name "class1" :method-name "method1" :pc-location (:file """ + file1_str + """ :line 57) :this-object-id "7")""")
+        // toWF(evt: DebugStackFrame)
+        assert(toWF(debugStackFrame).toWireString === """(:index 7 :locals ((:index 3 :name "name1" :summary "summary1" :type-name "type1") (:index 4 :name "name2" :summary "summary2" :type-name "type2")) :num-args 4 :class-name "class1" :method-name "method1" :pc-location (:file """ + file1_str + """ :line 57) :this-object-id "7")""")
 
-      // toWF(evt: DebugBacktrace)
-      assert(toWF(DebugBacktrace(List(debugStackFrame), 17, "thread1")).toWireString === """(:frames ((:index 7 :locals ((:index 3 :name "name1" :summary "summary1" :type-name "type1") (:index 4 :name "name2" :summary "summary2" :type-name "type2")) :num-args 4 :class-name "class1" :method-name "method1" :pc-location (:file """ + file1_str + """ :line 57) :this-object-id "7")) :thread-id "17" :thread-name "thread1")""")
+        // toWF(evt: DebugBacktrace)
+        assert(toWF(DebugBacktrace(List(debugStackFrame), 17, "thread1")).toWireString === """(:frames ((:index 7 :locals ((:index 3 :name "name1" :summary "summary1" :type-name "type1") (:index 4 :name "name2" :summary "summary2" :type-name "type2")) :num-args 4 :class-name "class1" :method-name "method1" :pc-location (:file """ + file1_str + """ :line 57) :this-object-id "7")) :thread-id "17" :thread-name "thread1")""")
 
-      // toWF(pos: LineSourcePosition)
-      assert(toWF(sourcePos1).toWireString === """(:file """ + file1_str + """ :line 57)""")
-      // toWF(pos: EmptySourcePosition)
-      assert(toWF(sourcePos3).toWireString === "t")
-      // toWF(pos: OffsetSourcePosition)
-      assert(toWF(sourcePos4).toWireString === """(:file """ + file1_str + """ :offset 456)""")
+        // toWF(pos: LineSourcePosition)
+        assert(toWF(sourcePos1).toWireString === """(:file """ + file1_str + """ :line 57)""")
+        // toWF(pos: EmptySourcePosition)
+        assert(toWF(sourcePos3).toWireString === "t")
+        // toWF(pos: OffsetSourcePosition)
+        assert(toWF(sourcePos4).toWireString === """(:file """ + file1_str + """ :offset 456)""")
 
-      // toWF(bp: Breakpoint)
-      assert(toWF(breakPoint1).toWireString === """(:file """ + file1_str + """ :line 57)""")
+        // toWF(bp: Breakpoint)
+        assert(toWF(breakPoint1).toWireString === """(:file """ + file1_str + """ :line 57)""")
 
-      // toWF(config: BreakpointList)
-      assert(toWF(BreakpointList(List(breakPoint1), List(breakPoint2))).toWireString === """(:active ((:file """ + file1_str + """ :line 57)) :pending ((:file """ + file1_str + """ :line 59)))""")
+        // toWF(config: BreakpointList)
+        assert(toWF(BreakpointList(List(breakPoint1), List(breakPoint2))).toWireString === """(:active ((:file """ + file1_str + """ :line 57)) :pending ((:file """ + file1_str + """ :line 59)))""")
 
-      // toWF(config: ProjectConfig)
-      //assert(toWF(ProjectConfig()).toWireString === """(:project-name nil :source-roots ())""")
-      //assert(toWF(ProjectConfig(name = Some("Project1"), sourceRoots = List(file2))).toWireString === """(:project-name "Project1" :source-roots (""" + file2_str + """))""")
+        // toWF(config: ProjectConfig)
+        //assert(toWF(ProjectConfig()).toWireString === """(:project-name nil :source-roots ())""")
+        //assert(toWF(ProjectConfig(name = Some("Project1"), sourceRoots = List(file2))).toWireString === """(:project-name "Project1" :source-roots (""" + file2_str + """))""")
 
-      // toWF(config: ReplConfig)
-      //assert(toWF(new ReplConfig("classpath;classpath")).toWireString === """(:classpath "classpath;classpath")""")
+        // toWF(config: ReplConfig)
+        assert(toWF(new ReplConfig(Set(file1))).toWireString === s"""(:classpath $file1_str)""")
 
-      // toWF(value: Boolean)
-      assert(toWF(value = true).toWireString === """t""")
-      assert(toWF(value = false).toWireString === """nil""")
+        // toWF(value: Boolean)
+        assert(wfTrue.toWireString === """t""")
+        assert(wfFalse.toWireString === """nil""")
 
-      // toWF(value: String)
-      assert(toWF("ABC").toWireString === """"ABC"""")
+        // toWF(value: String)
+        assert(toWF("ABC").toWireString === """"ABC"""")
 
-      // toWF(value: Note)
-      assert(toWF(note1).toWireString === """(:severity error :msg "note1" :beg 23 :end 33 :line 19 :col 8 :file "file1")""")
+        // toWF(value: Note)
+        assert(toWF(note1).toWireString === note1Str)
+        //  toWF(notelist: NoteList)
+        assert(toWF(noteList).toWireString === noteListStr)
 
-      //  toWF(notelist: NoteList)
-      assert(toWF(new NoteList(true, List(note1, note2))).toWireString === """(:is-full t :notes ((:severity error :msg "note1" :beg 23 :end 33 :line 19 :col 8 :file "file1") (:severity warn :msg "note2" :beg 23 :end 33 :line 19 :col 8 :file "file1")))""")
+        // toWF(values: Iterable[WireFormat])
+        assert(toWF(List(wfTrue, wfFalse, toWF("ABC"))).toWireString === """(t nil "ABC")""")
 
-      // toWF(values: Iterable[WireFormat])
-      assert(toWF(List(toWF(value = true), toWF(value = false), toWF("ABC"))).toWireString === """(t nil "ABC")""")
+        // toWF(value: CompletionInfo)
+        assert(toWF(completionInfo).toWireString === """(:name "name" :type-sig (((("abc" "def") ("hij" "lmn"))) "ABC") :type-id 88 :to-insert "BAZ")""")
 
-      // toWF(value: CompletionInfo)
-      assert(toWF(completionInfo).toWireString === """(:name "name" :type-sig (((("abc" "def") ("hij" "lmn"))) "ABC") :type-id 88 :to-insert "BAZ")""")
+        // toWF(value: CompletionInfo)
+        assert(toWF(completionInfo2).toWireString === """(:name "name2" :type-sig (((("abc" "def"))) "ABC") :type-id 90 :is-callable t)""")
 
-      // toWF(value: CompletionInfo)
-      assert(toWF(completionInfo2).toWireString === """(:name "name2" :type-sig (((("abc" "def"))) "ABC") :type-id 90 :is-callable t)""")
+        // toWF(value: CompletionInfoList)
+        assert(toWF(CompletionInfoList("fooBar", List(completionInfo))).toWireString === """(:prefix "fooBar" :completions ((:name "name" :type-sig (((("abc" "def") ("hij" "lmn"))) "ABC") :type-id 88 :to-insert "BAZ")))""")
+        // toWF(value: PackageMemberInfoLight)
+        assert(toWF(new PackageMemberInfoLight("packageName")).toWireString === """(:name "packageName")""")
+        // toWF(value: SymbolInfo)
+        assert(toWF(new SymbolInfo("name", "localName", None, typeInfo, false, Some(2))).toWireString === """(:name "name" :local-name "localName" :type (:name "type1" :type-id 7 :full-name "FOO.type1" :decl-as type1 :outer-type-id 8) :owner-type-id 2)""")
 
-      // toWF(value: CompletionInfoList)
-      assert(toWF(CompletionInfoList("fooBar", List(completionInfo))).toWireString === """(:prefix "fooBar" :completions ((:name "name" :type-sig (((("abc" "def") ("hij" "lmn"))) "ABC") :type-id 88 :to-insert "BAZ")))""")
-      // toWF(value: PackageMemberInfoLight)
-      assert(toWF(new PackageMemberInfoLight("packageName")).toWireString === """(:name "packageName")""")
-      // toWF(value: SymbolInfo)
-      assert(toWF(new SymbolInfo("name", "localName", None, typeInfo, false, Some(2))).toWireString === """(:name "name" :local-name "localName" :type (:name "type1" :type-id 7 :full-name "FOO.type1" :decl-as type1 :outer-type-id 8) :owner-type-id 2)""")
+        // toWF(value: NamedTypeMemberInfo)
+        assert(toWF(new NamedTypeMemberInfo("typeX", typeInfo, None, 'abcd)).toWireString === """(:name "typeX" :type (:name "type1" :type-id 7 :full-name "FOO.type1" :decl-as type1 :outer-type-id 8) :decl-as abcd)""")
 
-      // toWF(value: NamedTypeMemberInfo)
-      assert(toWF(new NamedTypeMemberInfo("typeX", typeInfo, None, 'abcd)).toWireString === """(:name "typeX" :type (:name "type1" :type-id 7 :full-name "FOO.type1" :decl-as type1 :outer-type-id 8) :decl-as abcd)""")
+        // toWF(value: EntityInfo)
+        assert(toWF(entityInfo).toWireString === entityInfoStr)
 
-      // toWF(value: EntityInfo)
-      assert(toWF(entityInfo).toWireString === """(:name "Arrow1" :type-id 8 :arrow-type t :result-type (:name "type1" :type-id 7 :full-name "FOO.type1" :decl-as type1 :outer-type-id 8) :param-sections ((:params (("ABC" (:name "type1" :type-id 7 :full-name "FOO.type1" :decl-as type1 :outer-type-id 8))))))""")
+        // toWF(value: TypeInfo)
+        assert(toWF(typeInfo).toWireString === """(:name "type1" :type-id 7 :full-name "FOO.type1" :decl-as type1 :outer-type-id 8)""")
 
-      // toWF(value: TypeInfo)
-      assert(toWF(typeInfo).toWireString === """(:name "type1" :type-id 7 :full-name "FOO.type1" :decl-as type1 :outer-type-id 8)""")
+        // toWF(value: PackageInfo)
+        assert(toWF(packageInfo).toWireString === """(:name "name" :info-type package :full-name "fullName")""")
 
-      // toWF(value: PackageInfo)
-      assert(toWF(packageInfo).toWireString === """(:name "name" :info-type package :full-name "fullName")""")
+        // toWF(value: CallCompletionInfo)
+        assert(toWF(new CallCompletionInfo(typeInfo, List(paramSectionInfo))).toWireString === """(:result-type (:name "type1" :type-id 7 :full-name "FOO.type1" :decl-as type1 :outer-type-id 8) :param-sections ((:params (("ABC" (:name "type1" :type-id 7 :full-name "FOO.type1" :decl-as type1 :outer-type-id 8))))))""")
 
-      // toWF(value: CallCompletionInfo)
-      assert(toWF(new CallCompletionInfo(typeInfo, List(paramSectionInfo))).toWireString === """(:result-type (:name "type1" :type-id 7 :full-name "FOO.type1" :decl-as type1 :outer-type-id 8) :param-sections ((:params (("ABC" (:name "type1" :type-id 7 :full-name "FOO.type1" :decl-as type1 :outer-type-id 8))))))""")
+        // toWF(value: InterfaceInfo)
+        assert(toWF(interfaceInfo).toWireString === """(:type (:name "type1" :type-id 7 :full-name "FOO.type1" :decl-as type1 :outer-type-id 8) :via-view "DEF")""")
+        // toWF(value: TypeInspectInfo)
+        assert(toWF(new TypeInspectInfo(typeInfo, Some(1), List(interfaceInfo))).toWireString === """(:type (:name "type1" :type-id 7 :full-name "FOO.type1" :decl-as type1 :outer-type-id 8) :info-type typeInspect :companion-id 1 :interfaces ((:type (:name "type1" :type-id 7 :full-name "FOO.type1" :decl-as type1 :outer-type-id 8) :via-view "DEF")))""")
 
-      // toWF(value: InterfaceInfo)
-      assert(toWF(interfaceInfo).toWireString === """(:type (:name "type1" :type-id 7 :full-name "FOO.type1" :decl-as type1 :outer-type-id 8) :via-view "DEF")""")
-      // toWF(value: TypeInspectInfo)
-      assert(toWF(new TypeInspectInfo(typeInfo, Some(1), List(interfaceInfo))).toWireString === """(:type (:name "type1" :type-id 7 :full-name "FOO.type1" :decl-as type1 :outer-type-id 8) :info-type typeInspect :companion-id 1 :interfaces ((:type (:name "type1" :type-id 7 :full-name "FOO.type1" :decl-as type1 :outer-type-id 8) :via-view "DEF")))""")
+        // toWF(value: SymbolSearchResults)
+        assert(toWF(new SymbolSearchResults(List(methodSearchRes, typeSearchRes))).toWireString === s"""((:name "abc" :local-name "a" :decl-as abcd :pos (:file $abd_str :line 10) :owner-name "ownerStr") (:name "abc" :local-name "a" :decl-as abcd :pos (:file $abd_str :line 10)))""")
 
-      // toWF(value: SymbolSearchResults)
-      assert(toWF(new SymbolSearchResults(List(methodSearchRes, typeSearchRes))).toWireString === s"""((:name "abc" :local-name "a" :decl-as abcd :pos (:file $abd_str :line 10) :owner-name "ownerStr") (:name "abc" :local-name "a" :decl-as abcd :pos (:file $abd_str :line 10)))""")
+        // toWF(value: ImportSuggestions)
+        assert(toWF(new ImportSuggestions(List(List(methodSearchRes, typeSearchRes)))).toWireString ===
+          s"""(((:name "abc" :local-name "a" :decl-as abcd :pos (:file $abd_str :line 10) :owner-name "ownerStr") (:name "abc" :local-name "a" :decl-as abcd :pos (:file $abd_str :line 10))))""")
 
-      // toWF(value: ImportSuggestions)
-      assert(toWF(new ImportSuggestions(List(List(methodSearchRes, typeSearchRes)))).toWireString ===
-        s"""(((:name "abc" :local-name "a" :decl-as abcd :pos (:file $abd_str :line 10) :owner-name "ownerStr") (:name "abc" :local-name "a" :decl-as abcd :pos (:file $abd_str :line 10))))""")
+        // toWF(value: SymbolSearchResult)
+        assert(toWF(methodSearchRes).toWireString === s"""(:name "abc" :local-name "a" :decl-as abcd :pos (:file $abd_str :line 10) :owner-name "ownerStr")""")
+        assert(toWF(typeSearchRes).toWireString === s"""(:name "abc" :local-name "a" :decl-as abcd :pos (:file $abd_str :line 10))""")
 
-      // toWF(value: SymbolSearchResult)
-      assert(toWF(methodSearchRes).toWireString === s"""(:name "abc" :local-name "a" :decl-as abcd :pos (:file $abd_str :line 10) :owner-name "ownerStr")""")
-      assert(toWF(typeSearchRes).toWireString === s"""(:name "abc" :local-name "a" :decl-as abcd :pos (:file $abd_str :line 10))""")
+        assert(toWF(new RangePosition(batchSourceFile, 70, 75, 90)).toWireString === """(:file """ + batchSourceFile_str + """ :offset 75 :start 70 :end 90)""")
 
-      assert(toWF(new RangePosition(batchSourceFile, 70, 75, 90)).toWireString === """(:file """ + batchSourceFile_str + """ :offset 75 :start 70 :end 90)""")
+        assert(toWF(FileRange("/abc", 7, 9)).toWireString === """(:file "/abc" :start 7 :end 9)""")
 
-      assert(toWF(FileRange("/abc", 7, 9)).toWireString === """(:file "/abc" :start 7 :end 9)""")
+        assert(toWF(SymbolDesignations("/abc", List(
+          SymbolDesignation(7, 9, 'abc),
+          SymbolDesignation(11, 22, 'def)
+        ))).toWireString === """(:file "/abc" :syms ((abc 7 9) (def 11 22)))""")
 
-      assert(toWF(SymbolDesignations("/abc", List(
-        SymbolDesignation(7, 9, 'abc),
-        SymbolDesignation(11, 22, 'def)
-      ))).toWireString === """(:file "/abc" :syms ((abc 7 9) (def 11 22)))""")
+        assert(toWF(RefactorFailure(7, "message")).toWireString === """(:procedure-id 7 :status failure :reason "message")""")
 
-      assert(toWF(RefactorFailure(7, "message")).toWireString === """(:procedure-id 7 :status failure :reason "message")""")
+        assert(toWF(new RefactorEffect(9, 'add, List(TextEdit(file3, 5, 7, "aaa")))).toWireString === """(:procedure-id 9 :refactor-type add :status success :changes ((:file """ + file3_str + """ :text "aaa" :from 5 :to 7)))""")
 
-      assert(toWF(new RefactorEffect {
-        val procedureId = 9
-        val refactorType = 'add
-        val changes = List(TextEdit(file3, 5, 7, "aaa"))
-      }).toWireString === """(:procedure-id 9 :refactor-type add :status success :changes ((:file """ + file3_str + """ :text "aaa" :from 5 :to 7)))""")
+        assert(toWF(new RefactorResult(7, 'abc, List(file3, file1))).toWireString === """(:procedure-id 7 :refactor-type abc :status success :touched-files (""" + file3_str + " " + file1_str + """))""")
 
-      assert(toWF(new RefactorResult {
-        val refactorType = 'abc
-        val procedureId = 7
-        val touched = List(file3, file1)
-      }).toWireString === """(:procedure-id 7 :refactor-type abc :status success :touched-files (""" + file3_str + " " + file1_str + """))""")
+        assert(toWF(Undo(3, "Undoing stuff", List(
+          TextEdit(file3, 5, 7, "aaa"),
+          NewFile(file4, "xxxxx"),
+          DeleteFile(file5, "zzzz")
+        ))).toWireString === """(:id 3 :changes ((:file """ + file3_str + """ :text "aaa" :from 5 :to 7) (:file """ + file4_str + """ :text "xxxxx" :from 0 :to 4) (:file """ + file5_str + """ :text "zzzz" :from 0 :to 3)) :summary "Undoing stuff")""")
 
-      assert(toWF(Undo(3, "Undoing stuff", List(
-        TextEdit(file3, 5, 7, "aaa"),
-        NewFile(file4, "xxxxx"),
-        DeleteFile(file5, "zzzz")
-      ))).toWireString === """(:id 3 :changes ((:file """ + file3_str + """ :text "aaa" :from 5 :to 7) (:file """ + file4_str + """ :text "xxxxx" :from 0 :to 4) (:file """ + file5_str + """ :text "zzzz" :from 0 :to 3)) :summary "Undoing stuff")""")
+        assert(toWF(UndoResult(7, List(file3, file4))).toWireString === """(:id 7 :touched-files (""" + file3_str + """ """ + file4_str + """))""")
 
-      assert(toWF(UndoResult(7, List(file3, file4))).toWireString === """(:id 7 :touched-files (""" + file3_str + """ """ + file4_str + """))""")
-
-      assert(wfNull.toWireString === """nil""")
-      assert(toWF(DebugVmSuccess).toWireString === """(:status "success")""")
-      assert(toWF(DebugVmError(303, "xxxx")).toWireString === """(:status "error" :error-code 303 :details "xxxx")""")
-
-      // toWF(method: MethodBytecode)
-      assert(toWF(MethodBytecode("className1", "methodName1",
-        Some("MethodSig"), List(Op("op", "desc")), 7, 11)).toWireString === """(:class-name "className1" :name "methodName1" :signature "MethodSig" :bytecode (("op" "desc")))""")
+        assert(wfNull.toWireString === """nil""")
+        assert(toWF(DebugVmSuccess).toWireString === """(:status "success")""")
+        assert(toWF(DebugVmError(303, "xxxx")).toWireString === """(:status "error" :error-code 303 :details "xxxx")""")
+      }
     }
   }
 }

--- a/src/test/scala/org/ensime/test/SwankProtocolSpec.scala
+++ b/src/test/scala/org/ensime/test/SwankProtocolSpec.scala
@@ -1,82 +1,43 @@
 package org.ensime.test
 
 import java.io.{ InputStreamReader, ByteArrayInputStream, ByteArrayOutputStream, File }
+import java.util.concurrent.{ TimeUnit, CountDownLatch }
 import java.util.concurrent.atomic.AtomicInteger
 
-import akka.actor.TypedActor.MethodCall
-import akka.actor.{ ActorSystem, TypedActor, TypedProps }
-import akka.testkit.TestProbe
 import org.ensime.model._
-import org.ensime.protocol.{ RPCTarget, SwankProtocol }
+import org.ensime.protocol.{ ReplConfig, ConnectionInfo, RPCTarget, SwankProtocol }
 import org.ensime.server._
 import org.ensime.util._
 import org.scalamock.scalatest.MockFactory
 import org.scalatest.{ BeforeAndAfterAll, FunSpec, ShouldMatchers }
+import pimpathon.file._
 
-import scala.reflect.internal.util.{ RangePosition, BatchSourceFile }
-import scala.reflect.io.ZipArchive
-import scala.tools.nsc.io.{ PlainFile, VirtualFile }
+import scala.reflect.internal.util.{ BatchSourceFile, RangePosition }
+import scala.reflect.io.{ PlainFile, ZipArchive }
+import scala.tools.nsc.io._
 
 class SwankProtocolSpec extends FunSpec with ShouldMatchers with BeforeAndAfterAll with MockFactory {
+
+  import SwankTestData._
 
   class MockZipEntry(entry: String, archive: ZipArchive) extends VirtualFile(entry, entry) {
     override def underlyingSource: Option[ZipArchive] = Some(archive)
   }
 
-  def withTestConfig(f: (SwankProtocol, TestProbe, TestProbe) => Unit) {
-
-    implicit val actorSystem = ActorSystem.create()
-    try {
-      val typedSystem = TypedActor(actorSystem)
-
-      val rpcTargetProbe = TestProbe()
-      val outputProbe = TestProbe()
-      val rpcProxy = typedSystem.typedActorOf(TypedProps[RPCTarget], rpcTargetProbe.ref)
-
-      val protocol = new SwankProtocol()
-      protocol.setRPCTarget(rpcProxy)
-      protocol.setOutputActor(outputProbe.ref)
-
-      f(protocol, rpcTargetProbe, outputProbe)
-
-    } finally {
-      actorSystem.shutdown()
-    }
-  }
-
-  def testRPCMethod(msg: String, methodName: String, args: Any*) {
-    withTestConfig { (protocol, rpcProbe, outputProbe) =>
-      val encodedMsg = SExpParser.read(msg)
-      protocol.handleIncomingMessage(encodedMsg)
-
-      val rpcCall = rpcProbe.expectMsgType[MethodCall]
-      assert(rpcCall.method.getName == methodName)
-      val actualParams = rpcCall.parameters.toList
-      val expectedParams = args.toList
-      assert(expectedParams == actualParams)
-
-      outputProbe.expectNoMsg()
-    }
-  }
-
   describe("SwankProtocol") {
-    it("processes remove-file request") {
-      testRPCMethod("""(:swank-rpc (swank:remove-file "Analyzer.scala") 42)""",
-        "rpcRemoveFile",
-        "Analyzer.scala", 42)
-    }
-
     it("can encode and decode sexp to wire") {
-      val msg = SExpParser.read("""(:XXXX "abc") """)
-      val protocol = new SwankProtocol()
+      TestUtil.withActorSystem { actorSystem =>
+        val msg = SExpParser.read("""(:XXXX "abc") """)
+        val protocol = new SwankProtocol(actorSystem)
 
-      val os = new ByteArrayOutputStream()
-      protocol.writeMessage(msg, os)
+        val os = new ByteArrayOutputStream()
+        protocol.writeMessage(msg, os)
 
-      val reader = new InputStreamReader(new ByteArrayInputStream(os.toByteArray))
-      val incomingMsg = protocol.readMessage(reader).asInstanceOf[SExp]
+        val reader = new InputStreamReader(new ByteArrayInputStream(os.toByteArray))
+        val incomingMsg = protocol.readMessage(reader).asInstanceOf[SExp]
 
-      assert(msg == incomingMsg)
+        assert(msg == incomingMsg)
+      }
     }
 
     trait MsgHandler {
@@ -84,458 +45,603 @@ class SwankProtocolSpec extends FunSpec with ShouldMatchers with BeforeAndAfterA
     }
 
     val nextId = new AtomicInteger(1)
-    def test(msg: String)(expectation: (RPCTarget, MsgHandler, Int) => Unit): Unit = {
+    def testWithResponse(msg: String)(expectation: (RPCTarget, MsgHandler, Int) => Unit): Unit = {
+      TestUtil.withActorSystem { actorSystem =>
+        val t = mock[RPCTarget]
+        val out = mock[MsgHandler]
 
-      val t = mock[RPCTarget]
-      val out = mock[MsgHandler]
-
-      val prot = new SwankProtocol() {
-        override def sendMessage(o: WireFormat) {
-          out.send(o.toString)
+        val latch = new CountDownLatch(1)
+        val prot = new SwankProtocol(actorSystem) {
+          override def sendMessage(o: WireFormat) {
+            out.send(o.toString)
+            latch.countDown()
+          }
         }
+        prot.setRPCTarget(t)
+
+        val rpcId = nextId.getAndIncrement
+        expectation(t, out, rpcId)
+
+        val sexp = SExpParser.read("(:swank-rpc " + msg + " " + rpcId + ")")
+        assert(sexp != NilAtom)
+
+        prot.handleIncomingMessage(sexp)
+
+        if (!latch.await(1000, TimeUnit.MILLISECONDS))
+          fail("Waited too long for expectation")
       }
-      prot.setRPCTarget(t)
-
-      val rpcId = nextId.getAndIncrement
-      expectation(t, out, rpcId)
-
-      val sexp = SExpParser.read(s"(:swank-rpc $msg $rpcId)")
-      assert(sexp != NilAtom)
-
-      prot.handleIncomingMessage(sexp)
     }
 
-    it("should understand swank:peek-undo") {
-      test("""(swank:peek-undo)""") { (t, m, id) =>
-        (t.rpcPeekUndo _).expects(id)
+    it("should understand swank:peek-undo - success") {
+      val file3 = CanonFile("/foo/abc")
+      val file3_str = TestUtil.fileToWireString(file3)
+
+      testWithResponse("""(swank:peek-undo)""") { (t, m, id) =>
+        (t.rpcPeekUndo _).expects().returns(Right(Undo(3, "Undoing stuff", List(TextEdit(file3, 5, 7, "aaa")))))
+        (m.send _).expects("""(:return (:ok (:id 3 :changes ((:file """ + file3_str + """ :text "aaa" :from 5 :to 7)) :summary "Undoing stuff")) """ + id + ")")
+      }
+    }
+
+    it("should understand swank:peek-undo - fail") {
+      testWithResponse("""(swank:peek-undo)""") { (t, m, id) =>
+        (t.rpcPeekUndo _).expects().returns(Left("ErrorError"))
+        (m.send _).expects(s"""(:return (:abort 206 "ErrorError") $id)""")
       }
     }
 
     it("should understand swank:exec-undo") {
-      test("""(swank:exec-undo 1)""") { (t, m, id) =>
-        (t.rpcExecUndo _).expects(1, id)
+      testWithResponse("""(swank:exec-undo 1)""") { (t, m, id) =>
+        (t.rpcExecUndo _).expects(1).returns(Right(undoResult))
+        (m.send _).expects(s"""(:return (:ok $undoResultStr) $id)""")
+
       }
     }
 
     it("should understand connection-info request") {
-      test("(swank:connection-info)") { (t, m, id) =>
-        (t.rpcConnectionInfo _).expects(id)
+      testWithResponse("(swank:connection-info)") { (t, m, id) =>
+        (t.rpcConnectionInfo _).expects().returns(new ConnectionInfo())
+        (m.send _).expects(s"""(:return (:ok (:pid nil :implementation (:name "ENSIME-ReferenceServer") :version "0.8.9")) $id)""")
       }
     }
 
-    it("should understand swank:init-project") {
-      val configFragment = """(:use-sbt t :compiler-args ("-Ywarn-dead-code" "-Ywarn-catches" "-Xstrict-warnings") :root-dir "/Users/aemon/projects/ensime/")"""
-      test(s"""(swank:init-project $configFragment)""") { (t, m, id) =>
-        (t.rcpInitProject _).expects(SExpParser.read(configFragment), id)
-      }
-    }
+    //    it("should understand swank:init-project") {
+    //      val configFragment = """(:use-sbt t :compiler-args ("-Ywarn-dead-code" "-Ywarn-catches" "-Xstrict-warnings") :root-dir "/Users/aemon/projects/ensime/")"""
+    //      testWithResponse(s"""(swank:init-project $configFragment)""") { (t, id) =>
+    //        (t.rcpInitProject _).expects(SExpParser.read(configFragment)).returns(EnsimeConfig(...))
+    //        (m.send _).expects(s"""(:return (:ok $ensimeConfigStr) $id)""")
+    //      }
+    //    }
 
     it("should understand swank:repl-config") {
-      test("(swank:repl-config)") { (t, m, id) =>
-        (t.rpcReplConfig _).expects(id)
+      testWithResponse("(swank:repl-config)") { (t, m, id) =>
+        (t.rpcReplConfig _).expects().returns(replConfig)
+        (m.send _).expects(s"""(:return (:ok $replConfigStr) $id)""")
       }
     }
 
     it("should understand swank:remove-file") {
-      test("""(swank:remove-file "Analyzer.scala")""") { (t, m, id) =>
-        (t.rpcRemoveFile _).expects("Analyzer.scala", id)
+      testWithResponse("""(swank:remove-file "Analyzer.scala")""") { (t, m, id) =>
+        (t.rpcRemoveFile _).expects("Analyzer.scala")
+        (m.send _).expects(s"""(:return (:ok t) $id)""")
       }
     }
 
-    val analyzerFile = new File("Analyzer.scala")
-    val fooFile = new File("Foo.scala")
-
     it("should understand swank:swank:typecheck-file") {
-      test("""(swank:typecheck-file "Analyzer.scala")""") { (t, m, id) =>
-        (t.rpcTypecheckFiles _).expects(List(SourceFileInfo(analyzerFile)), id)
+      testWithResponse("""(swank:typecheck-file "Analyzer.scala")""") { (t, m, id) =>
+        (t.rpcTypecheckFiles _).expects(List(SourceFileInfo(analyzerFile)))
+        (m.send _).expects(s"""(:return (:ok t) $id)""")
       }
     }
 
     it("should understand swank:swank:typecheck-file with content") {
-      test("""(swank:typecheck-file "Analyzer.scala" "contents\\n\\ncontents")""") { (t, m, id) =>
-        (t.rpcTypecheckFiles _).expects(List(SourceFileInfo(analyzerFile, Some("contents\\n\\ncontents"))), id)
+      testWithResponse("""(swank:typecheck-file "Analyzer.scala" "contents\\n\\ncontents")""") { (t, m, id) =>
+        (t.rpcTypecheckFiles _).expects(List(SourceFileInfo(analyzerFile, Some("contents\\n\\ncontents"))))
+        (m.send _).expects(s"""(:return (:ok t) $id)""")
       }
     }
 
     it("should understand swank:typecheck-files") {
-      test("""(swank:typecheck-files ("Analyzer.scala" "Foo.scala"))""") { (t, m, id) =>
-        (t.rpcTypecheckFiles _).expects(List(SourceFileInfo(analyzerFile), SourceFileInfo(fooFile)), id)
+      testWithResponse("""(swank:typecheck-files ("Analyzer.scala" "Foo.scala"))""") { (t, m, id) =>
+        (t.rpcTypecheckFiles _).expects(List(SourceFileInfo(analyzerFile), SourceFileInfo(fooFile)))
+        (m.send _).expects(s"""(:return (:ok t) $id)""")
       }
     }
 
     it("should understand swank:atch-source") {
-      test("""(swank:patch-source "Analyzer.scala" (("+" 6461 "Inc") ("-" 7127 7128) ("*" 7200 7300 "Bob")))""") { (t, m, id) =>
-        (t.rpcPatchSource _).expects("Analyzer.scala", List(PatchInsert(6461, "Inc"), PatchDelete(7127, 7128), PatchReplace(7200, 7300, "Bob")), id)
+      testWithResponse("""(swank:patch-source "Analyzer.scala" (("+" 6461 "Inc") ("-" 7127 7128) ("*" 7200 7300 "Bob")))""") { (t, m, id) =>
+        (t.rpcPatchSource _).expects("Analyzer.scala", List(PatchInsert(6461, "Inc"), PatchDelete(7127, 7128), PatchReplace(7200, 7300, "Bob")))
+        (m.send _).expects(s"""(:return (:ok t) $id)""")
       }
     }
 
     it("should understand swank:typecheck-all") {
-      test("""(swank:typecheck-all)""") { (t, m, id) =>
-        (t.rpcTypecheckAll _).expects(id)
+      testWithResponse("""(swank:typecheck-all)""") { (t, m, id) =>
+        (t.rpcTypecheckAll _).expects()
+        (m.send _).expects(s"""(:return (:ok t) $id)""")
+      }
+    }
+
+    it("should understand swank:unload-all") {
+      testWithResponse("""(swank:unload-all)""") { (t, m, id) =>
+        (t.rpcUnloadAll _).expects()
+        (m.send _).expects(s"""(:return (:ok t) $id)""")
       }
     }
 
     it("should understand swank:format-source") {
-      test("""(swank:format-source ("/ensime/src/Test.scala"))""") { (t, m, id) =>
-        (t.rpcFormatFiles _).expects(List("/ensime/src/Test.scala"), id)
+      testWithResponse("""(swank:format-source ("/ensime/src/Test.scala"))""") { (t, m, id) =>
+        (t.rpcFormatFiles _).expects(List("/ensime/src/Test.scala"))
+        (m.send _).expects(s"""(:return (:ok t) $id)""")
       }
     }
 
+    // TODO add test for exception handling in above
+
     it("should understand swank:public-symbol-search") {
-      test("""(swank:public-symbol-search ("java" "io" "File") 50)""") { (t, m, id) =>
-        (t.rpcPublicSymbolSearch _).expects(List("java", "io", "File"), 50, id)
+      testWithResponse("""(swank:public-symbol-search ("java" "io" "File") 50)""") { (t, m, id) =>
+        (t.rpcPublicSymbolSearch _).expects(List("java", "io", "File"), 50).returns(symbolSearchResults)
+        (m.send _).expects(s"""(:return (:ok $symbolSearchResultsStr) $id)""")
       }
     }
 
     it("should understand swank:import-suggestions") {
-      test("""(swank:import-suggestions "/ensime/src/main/scala/org/ensime/server/Analyzer.scala" 2300 ("Actor") 10)""") { (t, m, id) =>
-        (t.rpcImportSuggestions _).expects("/ensime/src/main/scala/org/ensime/server/Analyzer.scala", 2300, List("Actor"), 10, id)
+      testWithResponse("""(swank:import-suggestions "/ensime/src/main/scala/org/ensime/server/Analyzer.scala" 2300 ("Actor") 10)""") { (t, m, id) =>
+        (t.rpcImportSuggestions _).expects("/ensime/src/main/scala/org/ensime/server/Analyzer.scala", 2300,
+          List("Actor"), 10).returns(importSuggestions)
+        (m.send _).expects(s"""(:return (:ok $importSuggestionsStr) $id)""")
       }
     }
 
     it("should understand swank:completions") {
-      test(
+      testWithResponse(
         """(swank:completions
-          | "/ensime/src/main/scala/org/ensime/protocol/SwankProtocol.scala"
-          | 22626 0 t t)""".stripMargin) { (t, m, id) =>
-          (t.rpcCompletionsAtPoint _).expects("/ensime/src/main/scala/org/ensime/protocol/SwankProtocol.scala", 22626, 0, true, true, id)
+              | "/ensime/src/main/scala/org/ensime/protocol/SwankProtocol.scala"
+              | 22626 0 t t)""".stripMargin) { (t, m, id) =>
+          (t.rpcCompletionsAtPoint _).expects(
+            "/ensime/src/main/scala/org/ensime/protocol/SwankProtocol.scala", 22626, 0, true, true).returns(completionInfoCList)
+          (m.send _).expects(s"""(:return (:ok $completionInfoCListStr) $id)""")
         }
     }
 
     it("should understand swank:package-member-completion") {
-      test("""(swank:package-member-completion "org.ensime.server" "Server")""") { (t, m, id) =>
-        (t.rpcPackageMemberCompletion _).expects("org.ensime.server", "Server", id)
+      testWithResponse("""(swank:package-member-completion "org.ensime.server" "Server")""") { (t, m, id) =>
+        (t.rpcPackageMemberCompletion _).expects("org.ensime.server", "Server").returns(completionInfoList)
+        (m.send _).expects(s"""(:return (:ok $completionInfoListStr) $id)""")
       }
     }
 
     it("should understand swank:call-completion") {
-      test("""(swank:call-completion 1)""") { (t, m, id) =>
-        (t.rpcCallCompletion _).expects(1, id)
+      testWithResponse("""(swank:call-completion 1)""") { (t, m, id) =>
+        (t.rpcCallCompletion _).expects(1).returns(Some(callCompletionInfo))
+        (m.send _).expects(s"""(:return (:ok $callCompletionInfoStr) $id)""")
       }
     }
 
     it("should understand swank:uses-of-symbol-at-point") {
-      test("""(swank:uses-of-symbol-at-point "Test.scala" 11334)""") { (t, m, id) =>
-        (t.rpcUsesOfSymAtPoint _).expects("Test.scala", 11334, id)
+      testWithResponse("""(swank:uses-of-symbol-at-point "Test.scala" 11334)""") { (t, m, id) =>
+        (t.rpcUsesOfSymAtPoint _).expects("Test.scala", 11334).returns(List(rangePos1, rangePos2))
+        (m.send _).expects(s"""(:return (:ok ($rangePos1Str $rangePos2Str)) $id)""")
       }
     }
 
     it("should understand swank:member-by-name") {
-      test("""(swank:member-by-name "org.example.A" "x" t)""") { (t, m, id) =>
-        (t.rpcMemberByName _).expects("org.example.A", "x", true, id)
+      testWithResponse("""(swank:member-by-name "org.example.A" "x" t)""") { (t, m, id) =>
+        (t.rpcMemberByName _).expects("org.example.A", "x", true).returns(Some(symbolInfo))
+        (m.send _).expects(s"""(:return (:ok $symbolInfoStr) $id)""")
       }
     }
 
     it("should understand swank:type-by-id") {
-      test("""(swank:type-by-id 1381)""") { (t, m, id) =>
-        (t.rpcTypeById _).expects(1381, id)
+      testWithResponse("""(swank:type-by-id 7)""") { (t, m, id) =>
+        (t.rpcTypeById _).expects(7).returns(Some(typeInfo))
+        (m.send _).expects(s"""(:return (:ok $typeInfoStr) $id)""")
       }
     }
 
     it("should understand swank:type-by-name") {
-      test("""(swank:type-by-name "java.lang.String")""") { (t, m, id) =>
-        (t.rpcTypeByName _).expects("java.lang.String", id)
+      testWithResponse("""(swank:type-by-name "java.lang.String")""") { (t, m, id) =>
+        (t.rpcTypeByName _).expects("java.lang.String").returns(Some(typeInfo))
+        (m.send _).expects(s"""(:return (:ok $typeInfoStr) $id)""")
       }
     }
 
     it("should understand swank:type-by-name-at-point at point") {
-      test("""(swank:type-by-name-at-point "String" "SwankProtocol.scala" 31680)""") { (t, m, id) =>
-        (t.rpcTypeByNameAtPoint _).expects("String", "SwankProtocol.scala", OffsetRange(31680), id)
+      testWithResponse("""(swank:type-by-name-at-point "String" "SwankProtocol.scala" 31680)""") { (t, m, id) =>
+        (t.rpcTypeByNameAtPoint _).expects("String", "SwankProtocol.scala", OffsetRange(31680)).returns(Some(typeInfo))
+        (m.send _).expects(s"""(:return (:ok $typeInfoStr) $id)""")
       }
     }
 
     it("should understand swank:type-by-name-at-point at range") {
-      test("""(swank:type-by-name-at-point "String" "SwankProtocol.scala" (31680 31691))""") { (t, m, id) =>
-        (t.rpcTypeByNameAtPoint _).expects("String", "SwankProtocol.scala", OffsetRange(31680, 31691), id)
+      testWithResponse("""(swank:type-by-name-at-point "String" "SwankProtocol.scala" (31680 31691))""") { (t, m, id) =>
+        (t.rpcTypeByNameAtPoint _).expects("String", "SwankProtocol.scala", OffsetRange(31680, 31691)).returns(Some(typeInfo))
+        (m.send _).expects(s"""(:return (:ok $typeInfoStr) $id)""")
       }
     }
 
     it("should understand swank:type-at-point at point") {
-      test("""(swank:type-at-point "SwankProtocol.scala" 31680)""") { (t, m, id) =>
-        (t.rpcTypeAtPoint _).expects("SwankProtocol.scala", OffsetRange(31680), id)
+      testWithResponse("""(swank:type-at-point "SwankProtocol.scala" 31680)""") { (t, m, id) =>
+        (t.rpcTypeAtPoint _).expects("SwankProtocol.scala", OffsetRange(31680)).returns(Some(typeInfo))
+        (m.send _).expects(s"""(:return (:ok $typeInfoStr) $id)""")
       }
     }
 
     it("should understand swank:type-at-point at range") {
-      test("""(swank:type-at-point "SwankProtocol.scala" (31680 31691))""") { (t, m, id) =>
-        (t.rpcTypeAtPoint _).expects("SwankProtocol.scala", OffsetRange(31680, 31691), id)
+      testWithResponse("""(swank:type-at-point "SwankProtocol.scala" (31680 31691))""") { (t, m, id) =>
+        (t.rpcTypeAtPoint _).expects("SwankProtocol.scala", OffsetRange(31680, 31691)).returns(Some(typeInfo))
+        (m.send _).expects(s"""(:return (:ok $typeInfoStr) $id)""")
       }
     }
 
     it("should understand swank:inspect-type-at-point at point") {
-      test("""(swank:inspect-type-at-point "SwankProtocol.scala" 32736)""") { (t, m, id) =>
-        (t.rpcInspectTypeAtPoint _).expects("SwankProtocol.scala", OffsetRange(32736), id)
+      testWithResponse("""(swank:inspect-type-at-point "SwankProtocol.scala" 32736)""") { (t, m, id) =>
+        (t.rpcInspectTypeAtPoint _).expects("SwankProtocol.scala", OffsetRange(32736)).returns(Some(typeInspectInfo))
+        (m.send _).expects(s"""(:return (:ok $typeInspectInfoStr) $id)""")
       }
     }
 
     it("should understand swank:inspect-type-at-point at range") {
-      test("""(swank:inspect-type-at-point "SwankProtocol.scala" (32736 32740))""") { (t, m, id) =>
-        (t.rpcInspectTypeAtPoint _).expects("SwankProtocol.scala", OffsetRange(32736, 32740), id)
+      testWithResponse("""(swank:inspect-type-at-point "SwankProtocol.scala" (32736 32740))""") { (t, m, id) =>
+        (t.rpcInspectTypeAtPoint _).expects("SwankProtocol.scala", OffsetRange(32736, 32740)).returns(Some(typeInspectInfo))
+        (m.send _).expects(s"""(:return (:ok $typeInspectInfoStr) $id)""")
       }
     }
 
     it("should understand swank:inspect-type-by-id") {
-      test("""(swank:inspect-type-by-id 232)""") { (t, m, id) =>
-        (t.rpcInspectTypeById _).expects(232, id)
+      testWithResponse("""(swank:inspect-type-by-id 232)""") { (t, m, id) =>
+        (t.rpcInspectTypeById _).expects(232).returning(Some(typeInspectInfo))
+        (m.send _).expects(s"""(:return (:ok $typeInspectInfoStr) $id)""")
       }
     }
 
     it("should understand swank:inspect-type-by-name") {
-      test("""(swank:inspect-type-by-name "abc.d")""") { (t, m, id) =>
-        (t.rpcInspectTypeByName _).expects("abc.d", id)
+      testWithResponse("""(swank:inspect-type-by-name "abc.d")""") { (t, m, id) =>
+        (t.rpcInspectTypeByName _).expects("abc.d").returning(Some(typeInspectInfo))
+        (m.send _).expects(s"""(:return (:ok $typeInspectInfoStr) $id)""")
       }
     }
 
     it("should understand symbol-at-point") {
-      test("""(swank:symbol-at-point "SwankProtocol.scala" 36483)""") { (t, m, id) =>
-        (t.rpcSymbolAtPoint _).expects("SwankProtocol.scala", 36483, id)
+      testWithResponse("""(swank:symbol-at-point "SwankProtocol.scala" 36483)""") { (t, m, id) =>
+        (t.rpcSymbolAtPoint _).expects("SwankProtocol.scala", 36483).returns(Some(symbolInfo))
+        (m.send _).expects(s"""(:return (:ok $symbolInfoStr) $id)""")
       }
     }
 
     it("should understand swank:inspect-package-by-path") {
-      test("""(swank:inspect-package-by-path "org.ensime.util")""") { (t, m, id) =>
-        (t.rpcInspectPackageByPath _).expects("org.ensime.util", id)
+      testWithResponse("""(swank:inspect-package-by-path "org.ensime.util")""") { (t, m, id) =>
+        (t.rpcInspectPackageByPath _).expects("org.ensime.util").returns(Some(packageInfo))
+        (m.send _).expects(s"""(:return (:ok $packageInfoStr) $id)""")
       }
     }
 
-    it("should understand swank:prepare-refactor - inline local") {
-      test("""(swank:prepare-refactor 5 inlineLocal (file "SwankProtocol.scala" start 100 end 200) t)""") { (t, m, id) =>
-        (t.rpcPrepareRefactor _).expects(5, InlineLocalRefactorDesc("SwankProtocol.scala", 100, 200), true, id)
+    it("should understand swank:prepare-refactor - inline local - prepare failure") {
+      testWithResponse("""(swank:prepare-refactor 7 inlineLocal (file "SwankProtocol.scala" start 100 end 200) t)""") { (t, m, id) =>
+
+        //        Either[RefactorFailure, RefactorEffect]
+        (t.rpcPrepareRefactor _).expects(7, InlineLocalRefactorDesc("SwankProtocol.scala", 100, 200)).returns(
+          Left(refactorFailure))
+        (m.send _).expects(s"""(:return (:ok $refactorFailureStr) $id)""")
       }
+    }
+    it("should understand swank:prepare-refactor - inline local - prepare - interactive") {
+      testWithResponse("""(swank:prepare-refactor 7 inlineLocal (file "SwankProtocol.scala" start 100 end 200) t)""") { (t, m, id) =>
+        (t.rpcPrepareRefactor _).expects(7, InlineLocalRefactorDesc("SwankProtocol.scala", 100, 200)).returns(
+          Right(refactorRenameEffect))
+        (m.send _).expects(s"""(:return (:ok $refactorRanameEffectStr) $id)""")
+      }
+    }
+
+    it("should understand swank:prepare-refactor - inline local - non-interactive - failure") {
+      testWithResponse("""(swank:prepare-refactor 7 inlineLocal (file "SwankProtocol.scala" start 100 end 200) nil)""") { (t, m, id) =>
+
+        (t.rpcPrepareRefactor _).expects(7, InlineLocalRefactorDesc("SwankProtocol.scala", 100, 200)).returns(Right(refactorRenameEffect))
+        (t.rpcExecRefactor _).expects(7, Symbols.InlineLocal).returns(Left(refactorFailure))
+
+        (m.send _).expects(s"""(:return (:ok $refactorFailureStr) $id)""")
+      }
+    }
+
+    def testRefactorMethod(msg: String, desc: RefactorDesc) {
+
+      val refactorEffect = new RefactorEffect(7, desc.refactorType, List(TextEdit(file3, 5, 7, "aaa")))
+      val refactorResult = new RefactorResult(7, desc.refactorType, List(file3, file1))
+      val refactorResultStr = """(:procedure-id 7 :refactor-type """ + desc.refactorType.name + """ :status success :touched-files (""" + file3_str + " " + file1_str + """))"""
+
+      testWithResponse("""(swank:prepare-refactor 7""" + msg + " nil)") { (t, m, id) =>
+        (t.rpcPrepareRefactor _).expects(7, desc).returns(Right(refactorEffect))
+        (t.rpcExecRefactor _).expects(7, desc.refactorType).returns(Right(refactorResult))
+        (m.send _).expects(s"""(:return (:ok $refactorResultStr) $id)""")
+      }
+    }
+
+    it("should understand swank:prepare-refactor - inline local - non-interactive") {
+      testRefactorMethod("""inlineLocal (file "SwankProtocol.scala" start 100 end 200)""",
+        InlineLocalRefactorDesc("SwankProtocol.scala", 100, 200))
     }
 
     it("should understand swank:prepare-refactor - rename") {
-      test("""(swank:prepare-refactor 6 rename (file "SwankProtocol.scala" start 39504 end 39508 newName "dude") t)""") { (t, m, id) =>
-        (t.rpcPrepareRefactor _).expects(6, RenameRefactorDesc("dude", "SwankProtocol.scala", 39504, 39508), true, id)
-      }
+      testRefactorMethod("""rename (file "SwankProtocol.scala" start 39504 end 39508 newName "dude")""",
+        RenameRefactorDesc("dude", "SwankProtocol.scala", 39504, 39508))
     }
 
     it("should understand swank:prepare-refactor - extractMethod") {
-      test("""(swank:prepare-refactor 6 extractMethod (methodName "foo" file "SwankProtocol.scala" start 39504 end 39508) t)""") { (t, m, id) =>
-        (t.rpcPrepareRefactor _).expects(6, ExtractMethodRefactorDesc("foo", "SwankProtocol.scala", 39504, 39508), true, id)
-      }
+      testRefactorMethod("""extractMethod (methodName "foo" file "SwankProtocol.scala" start 39504 end 39508)""",
+        ExtractMethodRefactorDesc("foo", "SwankProtocol.scala", 39504, 39508))
     }
 
     it("should understand swank:prepare-refactor - extractLocal") {
-      test("""(swank:prepare-refactor 6 extractLocal (name "foo" file "SwankProtocol.scala" start 39504 end 39508) t)""") { (t, m, id) =>
-        (t.rpcPrepareRefactor _).expects(6, ExtractLocalRefactorDesc("foo", "SwankProtocol.scala", 39504, 39508), true, id)
-      }
+      testRefactorMethod("""extractLocal (name "foo" file "SwankProtocol.scala" start 39504 end 39508)""",
+        ExtractLocalRefactorDesc("foo", "SwankProtocol.scala", 39504, 39508))
     }
 
     it("should understand swank:prepare-refactor - organiseImports") {
-      test("""(swank:prepare-refactor 6 organiseImports (file "SwankProtocol.scala") t)""") { (t, m, id) =>
-        (t.rpcPrepareRefactor _).expects(6, OrganiseImportsRefactorDesc("SwankProtocol.scala"), true, id)
-      }
+      testRefactorMethod("""organiseImports (file "SwankProtocol.scala")""",
+        OrganiseImportsRefactorDesc("SwankProtocol.scala"))
     }
 
     it("should not fail on swank:prepareRefactor from bug 573") {
-      test("""(swank:prepare-refactor 2 organizeImports (file "/home/fommil/Projects/ensime-server/src/main/scala/org/ensime/indexer/DatabaseService.scala") t)""") { (t, m, id) =>
-        (t.rpcPrepareRefactor _).expects(2, OrganiseImportsRefactorDesc("/home/fommil/Projects/ensime-server/src/main/scala/org/ensime/indexer/DatabaseService.scala"), true, id)
-      }
+      testRefactorMethod("""organizeImports (file "/home/fommil/Projects/ensime-server/src/main/scala/org/ensime/indexer/DatabaseService.scala")""",
+        OrganiseImportsRefactorDesc("/home/fommil/Projects/ensime-server/src/main/scala/org/ensime/indexer/DatabaseService.scala"))
     }
 
     it("should understand swank:prepare-refactor - addImport") {
-      test("""(swank:prepare-refactor 6 addImport (qualifiedName "com.bar.Foo" file "SwankProtocol.scala" start 39504 end 39508) t)""") { (t, m, id) =>
-        (t.rpcPrepareRefactor _).expects(6, AddImportRefactorDesc("com.bar.Foo", "SwankProtocol.scala", 39504, 39508), true, id)
+      testRefactorMethod("""addImport (qualifiedName "com.bar.Foo" file "SwankProtocol.scala" start 39504 end 39508)""",
+        AddImportRefactorDesc("com.bar.Foo", "SwankProtocol.scala", 39504, 39508))
+    }
+
+    it("should understand swank:exec-refactor - refactor failure") {
+      testWithResponse("""(swank:exec-refactor 7 rename)""") { (t, m, id) =>
+        (t.rpcExecRefactor _).expects(7, Symbol("rename")).returns(Left(refactorFailure))
+        (m.send _).expects(s"""(:return (:ok $refactorFailureStr) $id)""")
       }
     }
 
-    it("should understand swank:exec-refactor") {
-      test("""(swank:exec-refactor 7 rename)""") { (t, m, id) =>
-        (t.rpcExecRefactor _).expects(7, Symbol("rename"), id)
+    it("should understand swank:exec-refactor - refactor result") {
+      testWithResponse("""(swank:exec-refactor 7 rename)""") { (t, m, id) =>
+        (t.rpcExecRefactor _).expects(7, Symbol("rename")).returns(Right(refactorResult))
+        (m.send _).expects(s"""(:return (:ok $refactorResultStr) $id)""")
       }
     }
 
     it("should understand swank:cancel-refactor") {
-      test("""(swank:cancel-refactor 1)""") { (t, m, id) =>
-        (t.rpcCancelRefactor _).expects(1, id)
+      testWithResponse("""(swank:cancel-refactor 1)""") { (t, m, id) =>
+        (t.rpcCancelRefactor _).expects(1)
+        (m.send _).expects(s"""(:return (:ok t) $id)""")
       }
     }
 
     it("should understand swank:symbol-designations") {
-      test("""(swank:symbol-designations "SwankProtocol.scala" 0 46857 (var val varField valField))""") { (t, m, id) =>
-        (t.rpcSymbolDesignations _).expects("SwankProtocol.scala", 0, 46857,
-          List(Symbol("var"), Symbol("val"), Symbol("varField"), Symbol("valField")), id)
+      testWithResponse("""(swank:symbol-designations "SwankProtocol.scala" 0 46857 (var val varField valField))""") {
+        (t, m, id) =>
+          (t.rpcSymbolDesignations _).expects("SwankProtocol.scala", 0, 46857,
+            List(Symbol("var"), Symbol("val"), Symbol("varField"), Symbol("valField"))).returns(symbolDesignations)
+          (m.send _).expects(s"""(:return (:ok $symbolDesignationsStr) $id)""")
       }
     }
 
     it("should understand swank:expand-selection") {
-      test("""(swank:expand-selection "Model.scala" 4648 4721)""") { (t, m, id) =>
-        (t.rpcExpandSelection _).expects("Model.scala", 4648, 4721, id)
+      testWithResponse("""(swank:expand-selection "Model.scala" 4648 4721)""") { (t, m, id) =>
+        (t.rpcExpandSelection _).expects("Model.scala", 4648, 4721).returns(fileRange)
+        (m.send _).expects(s"""(:return (:ok $fileRangeStr) $id)""")
       }
     }
 
-    it("should understand swank:method-bytecode") {
-      test("""(swank:method-bytecode "hello.scala" 12)""") { (t, m, id) =>
-        (t.rpcMethodBytecode _).expects("hello.scala", 12, id)
+    it("should understand swank:debug-active-vm - good") {
+      testWithResponse("""(swank:debug-active-vm)""") { (t, m, id) =>
+        (t.rpcDebugActiveVM _).expects().returns(true)
+        (m.send _).expects(s"""(:return (:ok t) $id)""")
       }
     }
 
-    it("should understand swank:debug-active-vm") {
-      test("""(swank:debug-active-vm)""") { (t, m, id) =>
-        (t.rpcDebugActiveVM _).expects(id)
+    it("should understand swank:debug-active-vm - bad") {
+      testWithResponse("""(swank:debug-active-vm)""") { (t, m, id) =>
+        (t.rpcDebugActiveVM _).expects().returns(false)
+        (m.send _).expects(s"""(:return (:ok nil) $id)""")
       }
     }
 
-    it("should understand swank:debug-start") {
-      test("""(swank:debug-start "org.hello.HelloWorld arg")""") { (t, m, id) =>
-        (t.rpcDebugStartVM _).expects("org.hello.HelloWorld arg", id)
+    it("should understand swank:debug-start - success") {
+      testWithResponse("""(swank:debug-start "org.hello.HelloWorld arg")""") { (t, m, id) =>
+        (t.rpcDebugStartVM _).expects("org.hello.HelloWorld arg").returns(DebugVmSuccess)
+        (m.send _).expects(s"""(:return (:ok (:status "success")) $id)""")
       }
     }
 
-    it("should understand swank:debug-attach") {
-      test("""(swank:debug-attach "localhost" "9000")""") { (t, m, id) =>
-        (t.rpcDebugAttachVM _).expects("localhost", "9000", id)
+    it("should understand swank:debug-start - failure") {
+      testWithResponse("""(swank:debug-start "org.hello.HelloWorld arg")""") { (t, m, id) =>
+        (t.rpcDebugStartVM _).expects("org.hello.HelloWorld arg").returns(DebugVmError(303, "xxxx"))
+        (m.send _).expects(s"""(:return (:ok (:status "error" :error-code 303 :details "xxxx")) $id)""")
       }
     }
 
-    it("should understand swank:debug-stop") {
-      test("""(swank:debug-stop)""") { (t, m, id) =>
-        (t.rpcDebugStopVM _).expects(id)
+    it("should understand swank:debug-attach - success") {
+      testWithResponse("""(swank:debug-attach "localhost" "9000")""") { (t, m, id) =>
+        (t.rpcDebugAttachVM _).expects("localhost", "9000").returns(DebugVmSuccess)
+        (m.send _).expects(s"""(:return (:ok (:status "success")) $id)""")
+      }
+    }
+
+    it("should understand swank:debug-attach - failure") {
+      testWithResponse("""(swank:debug-attach "localhost" "9000")""") { (t, m, id) =>
+        (t.rpcDebugAttachVM _).expects("localhost", "9000").returns(DebugVmError(303, "xxxx"))
+        (m.send _).expects(s"""(:return (:ok (:status "error" :error-code 303 :details "xxxx")) $id)""")
+      }
+    }
+
+    it("should understand swank:debug-stop - good") {
+      testWithResponse("""(swank:debug-stop)""") { (t, m, id) =>
+        (t.rpcDebugStopVM _).expects().returns(true)
+        (m.send _).expects(s"""(:return (:ok t) $id)""")
+      }
+    }
+
+    it("should understand swank:debug-stop - bad") {
+      testWithResponse("""(swank:debug-stop)""") { (t, m, id) =>
+        (t.rpcDebugStopVM _).expects().returns(false)
+        (m.send _).expects(s"""(:return (:ok nil) $id)""")
       }
     }
 
     it("should understand swank:debug-set-break") {
-      test("""(swank:debug-set-break "hello.scala" 12)""") { (t, m, id) =>
-        (t.rpcDebugBreak _).expects("hello.scala", 12, id)
+      testWithResponse("""(swank:debug-set-break "hello.scala" 12)""") { (t, m, id) =>
+        (t.rpcDebugBreak _).expects("hello.scala", 12)
+        (m.send _).expects(s"""(:return (:ok t) $id)""")
       }
     }
 
     it("should understand swank:debug-clear-break") {
-      test("""(swank:debug-clear-break "hello.scala" 12)""") { (t, m, id) =>
-        (t.rpcDebugClearBreak _).expects("hello.scala", 12, id)
+      testWithResponse("""(swank:debug-clear-break "hello.scala" 12)""") { (t, m, id) =>
+        (t.rpcDebugClearBreak _).expects("hello.scala", 12)
+        (m.send _).expects("(:return (:ok t) " + id + ")")
       }
     }
 
     it("should understand swank:debug-clear-all-breaks") {
-      test("""(swank:debug-clear-all-breaks)""") { (t, m, id) =>
-        (t.rpcDebugClearAllBreaks _).expects(id)
+      testWithResponse("""(swank:debug-clear-all-breaks)""") { (t, m, id) =>
+        (t.rpcDebugClearAllBreaks _).expects()
+        (m.send _).expects("(:return (:ok t) " + id + ")")
       }
     }
 
     it("debug-list-breakpoints test") {
-      test("""(swank:debug-list-breakpoints)""") { (t, m, id) =>
-        (t.rpcDebugListBreaks _).expects(id)
+      testWithResponse("""(swank:debug-list-breakpoints)""") { (t, m, id) =>
+        (t.rpcDebugListBreaks _).expects().returns(breakpointList)
+        (m.send _).expects(s"""(:return (:ok $breakpointListStr) $id)""")
       }
     }
 
     it("should understand swank:debug-run") {
-      test("""(swank:debug-run)""") { (t, m, id) =>
-        (t.rpcDebugRun _).expects(id)
+      testWithResponse("""(swank:debug-run)""") { (t, m, id) =>
+        (t.rpcDebugRun _).expects().returns(true)
+        (m.send _).expects(s"""(:return (:ok t) $id)""")
       }
     }
 
     it("should understand swank:debug-continue") {
-      test("""(swank:debug-continue "1")""") { (t, m, id) =>
-        (t.rpcDebugContinue _).expects(1L, id)
+      testWithResponse("""(swank:debug-continue "1")""") { (t, m, id) =>
+        (t.rpcDebugContinue _).expects(1L).returns(true)
+        (m.send _).expects(s"""(:return (:ok t) $id)""")
       }
     }
 
     it("should understand swank:debug-step") {
-      test("""(swank:debug-step "982398123")""") { (t, m, id) =>
-        (t.rpcDebugStep _).expects(982398123L, id)
+      testWithResponse("""(swank:debug-step "982398123")""") { (t, m, id) =>
+        (t.rpcDebugStep _).expects(982398123L).returns(true)
+        (m.send _).expects(s"""(:return (:ok t) $id)""")
       }
     }
 
     it("should understand swank:debug-next") {
-      test("""(swank:debug-next "982398123")""") { (t, m, id) =>
-        (t.rpcDebugNext _).expects(982398123L, id)
+      testWithResponse("""(swank:debug-next "982398123")""") { (t, m, id) =>
+        (t.rpcDebugNext _).expects(982398123L).returns(true)
+        (m.send _).expects(s"""(:return (:ok t) $id)""")
       }
     }
 
     it("should understand swank:debug-step-out") {
-      test("""(swank:debug-step-out "982398123")""") { (t, m, id) =>
-        (t.rpcDebugStepOut _).expects(982398123L, id)
+      testWithResponse("""(swank:debug-step-out "982398123")""") { (t, m, id) =>
+        (t.rpcDebugStepOut _).expects(982398123L).returns(true)
+        (m.send _).expects(s"""(:return (:ok t) $id)""")
       }
     }
 
     it("should understand swank:debug-locate-name") {
-      test("""(swank:debug-locate-name "7" "apple")""") { (t, m, id) =>
-        (t.rpcDebugLocateName _).expects(7L, "apple", id)
+      testWithResponse("""(swank:debug-locate-name "7" "apple")""") { (t, m, id) =>
+        (t.rpcDebugLocateName _).expects(7L, "apple").returns(Some(debugLocObjectRef))
+        (m.send _).expects("(:return (:ok " + debugLocObjectRefStr + ") " + id + ")")
       }
     }
 
     it("should understand swank:debug-value - array") {
-      test("""(swank:debug-value (:type element :object-id "23" :index 2))""") { (t, m, id) =>
-        (t.rpcDebugValue _).expects(DebugArrayElement(23L, 2), id)
+      testWithResponse("""(swank:debug-value (:type element :object-id "23" :index 2))""") { (t, m, id) =>
+        (t.rpcDebugValue _).expects(DebugArrayElement(23L, 2)).returns(Some(debugNullValue))
+        (m.send _).expects("(:return (:ok " + debugNullValueStr + ") " + id + ")")
       }
     }
 
     it("should understand swank:debug-value - object") {
-      test("""(swank:debug-value (:type reference :object-id "23"))""") { (t, m, id) =>
-        (t.rpcDebugValue _).expects(DebugObjectReference(23L), id)
+      testWithResponse("""(swank:debug-value (:type reference :object-id "23"))""") { (t, m, id) =>
+        (t.rpcDebugValue _).expects(DebugObjectReference(23L)).returns(Some(debugArrayInstValue))
+        (m.send _).expects("(:return (:ok " + debugArrayInstValueStr + ") " + id + ")")
       }
     }
 
     it("should understand swank:debug-value - object field") {
-      test("""(swank:debug-value (:type field :object-id "23" :field "fred"))""") { (t, m, id) =>
-        (t.rpcDebugValue _).expects(DebugObjectField(23L, "fred"), id)
+      testWithResponse("""(swank:debug-value (:type field :object-id "23" :field "fred"))""") { (t, m, id) =>
+        (t.rpcDebugValue _).expects(DebugObjectField(23L, "fred")).returns(Some(debugPrimitiveValue))
+        (m.send _).expects("(:return (:ok " + debugPrimitiveValueStr + ") " + id + ")")
       }
     }
 
     it("should understand swank:debug-value - stack slot") {
-      test("""(swank:debug-value (:type slot :thread-id "23" :frame 7 :offset 25))""") { (t, m, id) =>
-        (t.rpcDebugValue _).expects(DebugStackSlot(23L, 7, 25), id)
+      testWithResponse("""(swank:debug-value (:type slot :thread-id "23" :frame 7 :offset 25))""") { (t, m, id) =>
+        (t.rpcDebugValue _).expects(DebugStackSlot(23L, 7, 25)).returns(Some(debugStringValue))
+        (m.send _).expects("(:return (:ok " + debugStringValueStr + ") " + id + ")")
       }
     }
 
     it("should understand swank:debug-to-string - array element") {
-      test("""(swank:debug-to-string "2" (:type element :object-id "23" :index 2))""") { (t, m, id) =>
-        (t.rpcDebugToString _).expects(2L, DebugArrayElement(23L, 2), id)
+      testWithResponse("""(swank:debug-to-string "2" (:type element :object-id "23" :index 2))""") { (t, m, id) =>
+        (t.rpcDebugToString _).expects(2L, DebugArrayElement(23L, 2)).returns(Some("null"))
+        (m.send _).expects("(:return (:ok \"null\") " + id + ")")
       }
     }
 
     it("should understand swank:debug-set-value - array element") {
-      test("""(swank:debug-set-value (:type element :object-id "23" :index 2) "1")""") { (t, m, id) =>
-        (t.rpcDebugSetValue _).expects(DebugArrayElement(23L, 2), "1", id)
+      testWithResponse("""(swank:debug-set-value (:type element :object-id "23" :index 2) "1")""") { (t, m, id) =>
+        (t.rpcDebugSetValue _).expects(DebugArrayElement(23L, 2), "1").returns(true)
+        (m.send _).expects("(:return (:ok t) " + id + ")")
       }
     }
 
     it("should understand swank:debug-backtrace") {
-      test("""(swank:debug-backtrace "23" 0 2)""") { (t, m, id) =>
-        (t.rpcDebugBacktrace _).expects(23L, 0, 2, id)
+      testWithResponse("""(swank:debug-backtrace "23" 0 2)""") { (t, m, id) =>
+        (t.rpcDebugBacktrace _).expects(23L, 0, 2).returns(debugBacktrace)
+        (m.send _).expects("(:return (:ok " + debugBacktraceStr + ") " + id + ")")
       }
     }
 
     it("should understand swank:shutdown-server") {
-      test("(swank:shutdown-server)") { (t, m, id) =>
-        (t.rpcShutdownServer _).expects(id)
+      testWithResponse("(swank:shutdown-server)") { (t, m, id) =>
+        (t.rpcShutdownServer _).expects()
+        (m.send _).expects("(:return (:ok t) " + id + ")")
       }
     }
 
     it("should rejected an invalid range expression") {
-      test("""(swank:type-by-name-at-point "String" "SwankProtocol.scala" (broken range expression))""") { (t, m, id) =>
+      testWithResponse("""(swank:type-by-name-at-point "String" "SwankProtocol.scala" (broken range expression))""") { (t, m, id) =>
         (m.send _).expects(s"""(:return (:abort 202 "Malformed swank:type-by-name-at-point call: (swank:type-by-name-at-point \\"String\\" \\"SwankProtocol.scala\\" (broken range expression))") $id)""")
       }
     }
 
     it("should rejected an invalid patch expression") {
-      test("""(swank:patch-source "Analyzer.scala" (("+" 6461 "Inc") ("???" 7127 7128)))""") { (t, m, id) =>
+      testWithResponse("""(swank:patch-source "Analyzer.scala" (("+" 6461 "Inc") ("???" 7127 7128)))""") { (t, m, id) =>
         (m.send _).expects(s"""(:return (:abort 202 "Malformed swank:patch-source call: (swank:patch-source \\"Analyzer.scala\\" ((\\"+\\" 6461 \\"Inc\\") (\\"???\\" 7127 7128)))") $id)""")
       }
     }
 
     it("should rejected an invalid symbol list expression") {
-      test("""(swank:symbol-designations "SwankProtocol.scala" 0 46857 (var "fred"))""") { (t, m, id) =>
+      testWithResponse("""(swank:symbol-designations "SwankProtocol.scala" 0 46857 (var "fred"))""") { (t, m, id) =>
         (m.send _).expects(s"""(:return (:abort 202 "Malformed swank:symbol-designations call: (swank:symbol-designations \\"SwankProtocol.scala\\" 0 46857 (var \\"fred\\"))") $id)""")
       }
     }
 
     it("should rejected an invalid debug location expression") {
-      test("""(swank:debug-value (:type unknown :object-id "23" :index 2))""") { (t, m, id) =>
+      testWithResponse("""(swank:debug-value (:type unknown :object-id "23" :index 2))""") { (t, m, id) =>
         (m.send _).expects(s"""(:return (:abort 202 "Malformed swank:debug-value call: (swank:debug-value (:type unknown :object-id \\"23\\" :index 2))") $id)""")
       }
     }
 
     it("should return error for rpc calls that throw an exception") {
-      test("(swank:shutdown-server)") { (t, m, id) =>
-        (t.rpcShutdownServer _).expects(id).throws(new RuntimeException("Bang"))
+      testWithResponse("(swank:shutdown-server)") { (t, m, id) =>
+        (t.rpcShutdownServer _).expects().throws(new RuntimeException("Bang"))
         (m.send _).expects(s"""(:return (:abort 201 \"Bang\") $id)""")
       }
     }
 
     it("should return error for unknown refactor") {
-      test("""(swank:prepare-refactor 9 unknownRefactor (file "SwankProtocol.scala") t)""") { (t, m, id) =>
+      testWithResponse("""(swank:prepare-refactor 9 unknownRefactor (file "SwankProtocol.scala") t)""") { (t, m, id) =>
         (m.send _).expects(s"""(:return (:abort 202 "Malformed prepare-refactor - Incorrect arguments or unknown refactor type: unknownRefactor: (swank:prepare-refactor 9 unknownRefactor (file \\"SwankProtocol.scala\\") t)") $id)""")
       }
     }

--- a/src/test/scala/org/ensime/test/SwankTestData.scala
+++ b/src/test/scala/org/ensime/test/SwankTestData.scala
@@ -1,0 +1,154 @@
+package org.ensime.test
+
+import java.io.File
+
+import org.ensime.model._
+import org.ensime.protocol.ReplConfig
+import org.ensime.server.{ UndoResult, RefactorResult, RefactorEffect, RefactorFailure }
+import org.ensime.util._
+import pimpathon.file._
+
+import scala.reflect.internal.util.{ RangePosition, BatchSourceFile }
+import scala.reflect.io.PlainFile
+import scala.tools.nsc.io._
+
+object SwankTestData {
+
+  val typeInfo = new TypeInfo("type1", 7, 'type1, "FOO.type1", List(), List(), None, Some(8))
+  val typeInfoStr = """(:name "type1" :type-id 7 :full-name "FOO.type1" :decl-as type1 :outer-type-id 8)"""
+
+  val interfaceInfo = new InterfaceInfo(typeInfo, Some("DEF"))
+  val typeInspectInfo = new TypeInspectInfo(typeInfo, Some(1), List(interfaceInfo))
+  val typeInspectInfoStr = """(:type """ + typeInfoStr + """ :info-type typeInspect :companion-id 1 :interfaces ((:type """ + typeInfoStr + """ :via-view "DEF")))"""
+
+  val paramSectionInfo = new ParamSectionInfo(List(("ABC", typeInfo)), false)
+  val callCompletionInfo = new CallCompletionInfo(typeInfo, List(paramSectionInfo))
+  val callCompletionInfoStr = """(:result-type """ + typeInfoStr + """ :param-sections ((:params (("ABC" """ + typeInfoStr + """)))))"""
+
+  val symbolDesignations = SymbolDesignations("/abc",
+    List(SymbolDesignation(7, 9, 'abc),
+      SymbolDesignation(11, 22, 'def)))
+  val symbolDesignationsStr = """(:file "/abc" :syms ((abc 7 9) (def 11 22)))"""
+
+  val symbolInfo = new SymbolInfo("name", "localName", None, typeInfo, false, Some(2))
+  val symbolInfoStr = """(:name "name" :local-name "localName" :type """ + typeInfoStr + """ :owner-type-id 2)"""
+
+  val batchSourceFile = new BatchSourceFile(new PlainFile(Path("/abc")), "blah\nblah\nblah\n")
+  val batchSourceFile_str = TestUtil.stringToWireString(batchSourceFile.path)
+
+  val rangePos1 = new RangePosition(batchSourceFile, 70, 75, 90)
+  val rangePos1Str = """(:file """ + batchSourceFile_str + """ :offset 75 :start 70 :end 90)"""
+
+  val rangePos2 = new RangePosition(batchSourceFile, 80, 85, 100)
+  val rangePos2Str = """(:file """ + batchSourceFile_str + """ :offset 85 :start 80 :end 100)"""
+
+  val packageInfo = new PackageInfo("name", "fullName", List())
+  val packageInfoStr = """(:name "name" :info-type package :full-name "fullName")"""
+
+  val completionInfo = new CompletionInfo("name", new CompletionSignature(List(List(("abc", "def"), ("hij", "lmn"))), "ABC"), 88, false, 90, Some("BAZ"))
+  val completionInfoStr = """(:name "name" :type-sig (((("abc" "def") ("hij" "lmn"))) "ABC") :type-id 88 :to-insert "BAZ")"""
+
+  val completionInfo2 = new CompletionInfo("name2", new CompletionSignature(List(List(("abc", "def"))), "ABC"), 90, true, 91, None)
+  val completionInfo2Str = """(:name "name2" :type-sig (((("abc" "def"))) "ABC") :type-id 90 :is-callable t)"""
+
+  val completionInfoList = List(completionInfo, completionInfo2)
+  val completionInfoListStr = "(" + completionInfoStr + " " + completionInfo2Str + ")"
+
+  val refactorFailure = RefactorFailure(7, "message")
+  val refactorFailureStr = """(:procedure-id 7 :status failure :reason "message")"""
+
+  val file1 = CanonFile("/abc/def")
+  val file1_str = TestUtil.fileToWireString(file1)
+  val file2 = CanonFile("/test/test/")
+  val file2_str = TestUtil.fileToWireString(file2)
+  val file3 = CanonFile("/foo/abc")
+  val file3_str = TestUtil.fileToWireString(file3)
+  val file4 = CanonFile("/foo/def")
+  val file4_str = TestUtil.fileToWireString(file4)
+  val file5 = CanonFile("/foo/hij")
+  val file5_str = TestUtil.fileToWireString(file5)
+
+  val refactorEffect = new RefactorEffect(9, 'add, List(TextEdit(file3, 5, 7, "aaa")))
+  val refactorEffectStr = """(:procedure-id 9 :refactor-type add :status success :changes ((:file """ + file3_str + """ :text "aaa" :from 5 :to 7)))"""
+
+  val refactorResult = new RefactorResult(7, 'abc, List(file3, file1))
+  val refactorResultStr = """(:procedure-id 7 :refactor-type abc :status success :touched-files (""" + file3_str + " " + file1_str + """))"""
+
+  val sourcePos1 = new LineSourcePosition(file1, 57)
+  val sourcePos2 = new LineSourcePosition(file1, 59)
+  val sourcePos3 = new EmptySourcePosition()
+  val sourcePos4 = new OffsetSourcePosition(file1, 456)
+
+  val breakPoint1 = new Breakpoint(sourcePos1)
+  val breakPoint2 = new Breakpoint(sourcePos2)
+
+  val breakpointList = BreakpointList(List(breakPoint1), List(breakPoint2))
+  val breakpointListStr = """(:active ((:file """ + file1_str + """ :line 57)) :pending ((:file """ + file1_str + """ :line 59)))"""
+
+  val debugStackLocal1 = DebugStackLocal(3, "name1", "type1", "summary1")
+  val debugStackLocal2 = DebugStackLocal(4, "name2", "type2", "summary2")
+
+  val debugStackFrame = DebugStackFrame(7, List(debugStackLocal1, debugStackLocal2), 4, "class1", "method1", sourcePos1, 7)
+
+  val debugBacktrace = DebugBacktrace(List(debugStackFrame), 17, "thread1")
+  val debugBacktraceStr = """(:frames ((:index 7 :locals ((:index 3 :name "name1" :summary "summary1" :type-name "type1") (:index 4 :name "name2" :summary "summary2" :type-name "type2")) :num-args 4 :class-name "class1" :method-name "method1" :pc-location (:file """ + file1_str + """ :line 57) :this-object-id "7")) :thread-id "17" :thread-name "thread1")"""
+
+  val undoResult = UndoResult(7, List(file3, file4))
+  val undoResultStr = """(:id 7 :touched-files (""" + file3_str + """ """ + file4_str + """))"""
+
+  val replConfig = new ReplConfig(Set(file1))
+  val replConfigStr = """(:classpath """ + file1_str + """)"""
+
+  val analyzerFile = new File("Analyzer.scala")
+  val fooFile = new File("Foo.scala")
+
+  val abd = CanonFile("abd")
+  val abd_str = TestUtil.fileToWireString(abd)
+
+  val methodSearchRes = MethodSearchResult("abc", "a", 'abcd, Some(LineSourcePosition(file("abd"), 10)), "ownerStr")
+  val typeSearchRes = TypeSearchResult("abc", "a", 'abcd, Some(LineSourcePosition(file("abd"), 10)))
+
+  val importSuggestions = new ImportSuggestions(List(List(methodSearchRes, typeSearchRes)))
+  val importSuggestionsStr = """(((:name "abc" :local-name "a" :decl-as abcd :pos (:file """ + abd_str + """ :line 10) :owner-name "ownerStr") (:name "abc" :local-name "a" :decl-as abcd :pos (:file """ + abd_str + """ :line 10))))"""
+
+  val symbolSearchResults = new SymbolSearchResults(List(methodSearchRes, typeSearchRes))
+  val symbolSearchResultsStr = """((:name "abc" :local-name "a" :decl-as abcd :pos (:file """ + abd_str + """ :line 10) :owner-name "ownerStr") (:name "abc" :local-name "a" :decl-as abcd :pos (:file """ + abd_str + """ :line 10)))"""
+
+  val completionInfoCList = CompletionInfoList("fooBar", List(completionInfo))
+  val completionInfoCListStr = """(:prefix "fooBar" :completions (""" + completionInfoStr + """))"""
+
+  val refactorRenameEffect = new RefactorEffect(7, 'rename, List(TextEdit(file3, 5, 7, "aaa")))
+  val refactorRanameEffectStr = """(:procedure-id 7 :refactor-type rename :status success :changes ((:file """ + file3_str + """ :text "aaa" :from 5 :to 7)))"""
+
+  val fileRange = FileRange("/abc", 7, 9)
+  val fileRangeStr = """(:file "/abc" :start 7 :end 9)"""
+
+  val debugLocObjectRef: DebugLocation = DebugObjectReference(57L)
+  val debugLocObjectRefStr = """(:type reference :object-id "57")"""
+
+  val debugNullValue = DebugNullValue("typeNameStr")
+  val debugNullValueStr = """(:val-type null :type-name "typeNameStr")"""
+
+  val debugArrayInstValue = DebugArrayInstance(3, "typeName", "elementType", 5L)
+  val debugArrayInstValueStr = """(:val-type arr :length 3 :type-name "typeName" :element-type-name "elementType" :object-id "5")"""
+
+  val debugPrimitiveValue = DebugPrimitiveValue("summaryStr", "typeNameStr")
+  val debugPrimitiveValueStr = """(:val-type prim :summary "summaryStr" :type-name "typeNameStr")"""
+
+  val debugClassField = DebugClassField(19, "nameStr", "typeNameStr", "summaryStr")
+  val debugClassFieldStr = """(:index 19 :name "nameStr" :summary "summaryStr" :type-name "typeNameStr")"""
+
+  val debugStringValue = DebugStringInstance("summaryStr", List(debugClassField), "typeNameStr", 5L)
+  val debugStringValueStr = """(:val-type str :summary "summaryStr" :fields (""" + debugClassFieldStr + """) :type-name "typeNameStr" :object-id "5")"""
+
+  val note1 = new Note("file1", "note1", 2, 23, 33, 19, 8)
+  val note1Str = """(:severity error :msg "note1" :beg 23 :end 33 :line 19 :col 8 :file "file1")"""
+  val note2 = new Note("file1", "note2", 1, 23, 33, 19, 8)
+  val note2Str = """(:severity warn :msg "note2" :beg 23 :end 33 :line 19 :col 8 :file "file1")"""
+
+  val noteList = new NoteList(true, List(note1, note2))
+  val noteListStr = "(:is-full t :notes (" + note1Str + " " + note2Str + "))"
+
+  val entityInfo: TypeInfo = new ArrowTypeInfo("Arrow1", 8, typeInfo, List(paramSectionInfo))
+  val entityInfoStr = """(:name "Arrow1" :type-id 8 :arrow-type t :result-type (:name "type1" :type-id 7 :full-name "FOO.type1" :decl-as type1 :outer-type-id 8) :param-sections ((:params (("ABC" (:name "type1" :type-id 7 :full-name "FOO.type1" :decl-as type1 :outer-type-id 8))))))"""
+}

--- a/src/test/scala/org/ensime/test/intg/BasicWorkflow.scala
+++ b/src/test/scala/org/ensime/test/intg/BasicWorkflow.scala
@@ -42,6 +42,7 @@ class BasicWorkflow extends FunSpec with Matchers {
             fail("Failed to understand inspect symbol response: " + inspectResp)
         }
 
+        //        interactor.expectRPC(20 seconds, s"""(swank:type-by-id $intTypeId)""", s"""(:ok (:name "Int" :type-id $intTypeId :full-name "scala.Int" :decl-as class))""")
         //use the type ID to get the type information
         // compared with a baseline with the type ids removed (
         //        // type info for secondary buffer

--- a/src/test/scala/org/ensime/test/intg/DebugWorkflow.scala
+++ b/src/test/scala/org/ensime/test/intg/DebugWorkflow.scala
@@ -35,6 +35,8 @@ class DebugWorkflow extends FunSpec with Matchers {
         //  :thread-id "1"
         //  :thread-name "main"))
 
+        //        interactor.expectRPC(20 seconds, s"""(swank:debug-list-breakpoints)""", """(:ok (:file "org/example/Foo.scala" 14))""")
+        //
         interactor.expectRPC(20 seconds, s"""(swank:debug-stop)""", """(:ok t)""")
       }
     }

--- a/src/test/scala/org/ensime/test/intg/IntgUtil.scala
+++ b/src/test/scala/org/ensime/test/intg/IntgUtil.scala
@@ -14,7 +14,6 @@ import org.ensime.server.Server
 import org.ensime.test.TestUtil
 import org.ensime.util._
 import org.scalatest.Assertions
-import org.slf4j.LoggerFactory
 
 import scala.concurrent.Await
 import scala.concurrent.duration._
@@ -175,7 +174,7 @@ object IntgUtil extends Assertions with SLF4JLogging {
 
   /**
    * Run an integration test based on the given project
-   * @param projectSource The directory containing the test project (will not be modified)
+   * @param path The directory containing the test project (will not be modified)
    * @param f The test function to run
    */
   def withTestProject(path: String)(f: (EnsimeConfig, InteractorHelper) => Unit): Unit = {
@@ -222,3 +221,4 @@ object IntgUtil extends Assertions with SLF4JLogging {
     }
   }
 }
+

--- a/src/test/scala/org/ensime/util/FileUtilSpec.scala
+++ b/src/test/scala/org/ensime/util/FileUtilSpec.scala
@@ -1,13 +1,8 @@
 package org.ensime.util
 
 import akka.event.slf4j.SLF4JLogging
-import java.io.{ File }
-import org.slf4j.LoggerFactory
-import scala.tools.nsc.io.Path
-import org.ensime.test.TestUtil
 import org.scalatest.{ Matchers, FunSpec }
 import pimpathon.file._
-import org.ensime.util.RichFile._
 
 class FileUtilSpec extends FunSpec with Matchers with SLF4JLogging {
   describe("FileUtils") {
@@ -24,35 +19,6 @@ class FileUtilSpec extends FunSpec with Matchers with SLF4JLogging {
         readback match {
           case Left(e) => fail(e)
           case Right(readContents) => assert(readContents == contents)
-        }
-      }
-    }
-
-    // bug in upstream pimpathon
-    ignore("should expand recursively with non-readable directories") {
-      withTempDirectory { dirRaw =>
-        val dir = dirRaw.canon
-        val dir1 = new File(dir, "dir1")
-        dir1.mkdir()
-        val dir2 = new File(dir, "dir2")
-        dir2.mkdir()
-
-        val file1 = new File(dir1, "file1.txt")
-        val file2 = new File(dir2, "file2.txt")
-
-        file1.createNewFile()
-        file2.createNewFile()
-
-        val permSet = dir2.setReadable(false)
-        val entries = FileUtils.expandRecursively(dir, List(new File("dir1"), new File("dir2")), f => f.isFile)
-
-        if (permSet) {
-          assert(entries === Set(CanonFile(file1)))
-          dir2.setReadable(true, false)
-        } else {
-          // Windows workaround: setReadable doesn't work so make this test
-          // impotent.
-          assert(entries === Set(CanonFile(file1), CanonFile(file2)))
         }
       }
     }


### PR DESCRIPTION
A large PR - but in may ways pretty simple - RPCTarget now returns the results inline rather than relying on the infrastructure to correctly respond.  This moves nearly all of the protocol handling into the protcol module (there is another PR to fully seperate the core from the protocol.

@fommil / @edani / @aemoncannon / @marcsaegesser  This needs a solid kick around before merging as it could have easily broken something.  It subtly changes the call behaviour as every call now has timeouts (currently all defaulting to 30seconds but configurable on a case by case basis.
