### PR TITLE
S-Express: S-Exp serialisation framework

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -13,16 +13,17 @@ organization := "org.ensime"
 
 name := "ensime"
 
-scalaVersion := "2.11.2"
+scalaVersion := "2.11.4"
 
 version := "0.9.10-SNAPSHOT"
 
 //resolvers += Resolver.sonatypeRepo("snapshots")
 
 libraryDependencies ++= Seq(
-  "com.github.stacycurl"       %% "pimpathon-core"       % "1.0.0",
+  "com.chuusai"                %% "shapeless"            % "2.0.0",
+  "com.github.stacycurl"       %% "pimpathon-core"       % "1.1.0",
   "org.parboiled"              %% "parboiled-scala"      % "1.1.6",
-  "com.h2database"             %  "h2"                   % "1.4.181",
+  "com.h2database"             %  "h2"                   % "1.4.182",
   "com.typesafe.slick"         %% "slick"                % "2.1.0",
   "com.jolbox"                 %  "bonecp"               % "0.8.0.RELEASE",
   "org.apache.commons"         %  "commons-vfs2"         % "2.0" intransitive(),
@@ -40,7 +41,8 @@ libraryDependencies ++= Seq(
   "com.typesafe.akka"          %% "akka-testkit"         % "2.3.6" % "test",
   "commons-io"                 %  "commons-io"           % "2.4"   % "test",
   "org.scalatest"              %% "scalatest"            % "2.2.2" % "test",
-  "org.scalamock"              %% "scalamock-scalatest-support" % "3.1.2" % "test",
+  "org.scalamock"              %% "scalamock-scalatest-support" % "3.1.4" % "test",
+  "org.scalacheck"             %% "scalacheck"           % "1.11.6" % "test",
   "ch.qos.logback"             %  "logback-classic"      % "1.1.2",
   "org.slf4j"                  %  "jul-to-slf4j"         % "1.7.7",
   "org.slf4j"                  %  "jcl-over-slf4j"       % "1.7.7",
@@ -114,12 +116,13 @@ def classDirs(cp: Classpath): String = {
   } yield file.getAbsolutePath
 }.mkString(",")
 
-javaOptions ++= Seq("-XX:MaxPermSize=128m", "-Xmx1g", "-XX:+UseConcMarkSweepGC")
+javaOptions ++= Seq("-XX:MaxPermSize=256m", "-Xmx2g", "-XX:+UseConcMarkSweepGC")
 
 // 0.13.7 introduced awesomely fast resolution caching
 updateOptions := updateOptions.value.withCachedResolution(true)
 
 javaOptions in Test ++= Seq(
+  "-XX:MaxPermSize=256m", "-Xmx4g", "-XX:+UseConcMarkSweepGC",
   "-Densime.compile.jars=" + jars((fullClasspath in Compile).value),
   "-Densime.test.jars=" + jars((fullClasspath in Test).value),
   "-Densime.compile.classDirs=" + classDirs((fullClasspath in Compile).value),
@@ -135,7 +138,7 @@ javaOptions in Test ++= Seq(
 unmanagedSourceDirectories in Test += baseDirectory.value / "src/example-simple"
 
 // full stacktraces in scalatest
-testOptions in Test += Tests.Argument("-oF")
+//testOptions in Test += Tests.Argument("-oF")
 
 graphSettings
 

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,2 +1,2 @@
-sbt.version=0.13.7-RC1
+sbt.version=0.13.7-RC3
 

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -2,7 +2,7 @@ addSbtPlugin("net.virtual-void" % "sbt-dependency-graph" % "0.7.4")
 
 addSbtPlugin("com.typesafe.sbt" % "sbt-scalariform" % "1.3.0")
 
-addSbtPlugin("org.scoverage" %% "sbt-scoverage" % "0.99.7.1")
+addSbtPlugin("org.scoverage" %% "sbt-scoverage" % "0.99.10.2")
 
 // scapegoat can be installed per-user: recommended for dev
 // addSbtPlugin("com.sksamuel.scapegoat" %% "sbt-scapegoat" % "0.94.5")

--- a/src/main/scala/org/ensime/config/ScalariformFormat.scala
+++ b/src/main/scala/org/ensime/config/ScalariformFormat.scala
@@ -1,0 +1,52 @@
+package org.ensime.config
+
+import org.ensime.sexp._
+import org.ensime.sexp.formats._
+import scalariform.formatter.preferences._
+
+trait ScalariformFormat {
+  this: BasicFormats =>
+
+  implicit object FormattingPreferencesFormat extends SexpFormat[FormattingPreferences] {
+
+    private def key(d: PreferenceDescriptor[_]) = SexpSymbol(":" + d.key)
+
+    private def deser(
+      descriptor: PreferenceDescriptor[_],
+      data: Map[SexpSymbol, Sexp]): Option[Any] =
+      data.get(key(descriptor)).map { sexp =>
+        descriptor.preferenceType match {
+          case BooleanPreference => sexp.convertTo[Boolean]
+          case IntegerPreference(_, _) => sexp.convertTo[Int]
+        }
+      }
+
+    def read(s: Sexp): FormattingPreferences = s match {
+      case SexpNil =>
+        FormattingPreferences()
+
+      case SexpData(data) =>
+        val custom = for {
+          descriptor <- AllPreferences.preferences
+          value <- deser(descriptor, data)
+        } yield (descriptor, value)
+        new FormattingPreferences(custom.toMap)
+
+      case x => deserializationError(x)
+    }
+
+    private def ser(
+      descriptor: PreferenceDescriptor[_],
+      value: Any): Sexp = descriptor.preferenceType match {
+      case BooleanPreference => value.asInstanceOf[Boolean].toSexp
+      case IntegerPreference(_, _) => value.asInstanceOf[Int].toSexp
+    }
+
+    def write(f: FormattingPreferences) = {
+      val data = f.preferencesMap.map {
+        case (d, v) => key(d) -> ser(d, v)
+      }
+      SexpData(data.toList)
+    }
+  }
+}

--- a/src/main/scala/org/ensime/indexer/DescriptorParser.scala
+++ b/src/main/scala/org/ensime/indexer/DescriptorParser.scala
@@ -22,42 +22,42 @@ object DescriptorParser extends ParboiledParser[Descriptor] {
     }
   }
 
-  protected def Top: Rule1[Descriptor] = rule("Top") {
+  protected val Top: Rule1[Descriptor] = rule("Top") {
     "(" ~ zeroOrMore(Type) ~ ")" ~ Type
   } ~~> { (params, ret) => Descriptor(params, ret) }
 
-  private def Type: Rule1[DescriptorType] = rule("Type") {
+  private lazy val Type: Rule1[DescriptorType] = rule("Type") {
     (Class | Primitive | Array)
   }
 
-  private def Array: Rule1[DescriptorType] = rule("Array") {
+  private lazy val Array: Rule1[DescriptorType] = rule("Array") {
     ch('[') ~ (Class | Primitive | Array)
   } ~~> { c => ArrayDescriptor(c) }
 
-  private def Class: Rule1[DescriptorType] = rule("Class") {
+  private lazy val Class: Rule1[DescriptorType] = rule("Class") {
     "L" ~ Package ~ Name ~ ";"
   } ~~> { (p, n) => ClassName(p, n) }
 
-  private def Package: Rule1[PackageName] = rule("Package") {
+  private lazy val Package: Rule1[PackageName] = rule("Package") {
     zeroOrMore(oneOrMore("a" - "z" | "A" - "Z" | "_" | "0" - "9").save ~ "/")
   } ~~> { PackageName.apply }
 
-  private def Name: Rule1[String] = rule("Name") {
+  private lazy val Name: Rule1[String] = rule("Name") {
     oneOrMore(noneOf(";/()"))
   } save
 
-  private def Primitive: Rule1[DescriptorType] = rule("Primitive") {
+  private lazy val Primitive: Rule1[DescriptorType] = rule("Primitive") {
     Boolean | Byte | Char | Short | Int | Long | Float | Double | Void
   }
 
-  private def Boolean: Rule1[ClassName] = rule { ch('Z') as PrimitiveBoolean }
-  private def Byte: Rule1[ClassName] = rule { ch('B') as PrimitiveByte }
-  private def Char: Rule1[ClassName] = rule { ch('C') as PrimitiveChar }
-  private def Short: Rule1[ClassName] = rule { ch('S') as PrimitiveShort }
-  private def Int: Rule1[ClassName] = rule { ch('I') as PrimitiveInt }
-  private def Long: Rule1[ClassName] = rule { ch('J') as PrimitiveLong }
-  private def Float: Rule1[ClassName] = rule { ch('F') as PrimitiveFloat }
-  private def Double: Rule1[ClassName] = rule { ch('D') as PrimitiveDouble }
-  private def Void: Rule1[ClassName] = rule { ch('V') as PrimitiveVoid }
+  private lazy val Boolean: Rule1[ClassName] = rule { ch('Z') as PrimitiveBoolean }
+  private lazy val Byte: Rule1[ClassName] = rule { ch('B') as PrimitiveByte }
+  private lazy val Char: Rule1[ClassName] = rule { ch('C') as PrimitiveChar }
+  private lazy val Short: Rule1[ClassName] = rule { ch('S') as PrimitiveShort }
+  private lazy val Int: Rule1[ClassName] = rule { ch('I') as PrimitiveInt }
+  private lazy val Long: Rule1[ClassName] = rule { ch('J') as PrimitiveLong }
+  private lazy val Float: Rule1[ClassName] = rule { ch('F') as PrimitiveFloat }
+  private lazy val Double: Rule1[ClassName] = rule { ch('D') as PrimitiveDouble }
+  private lazy val Void: Rule1[ClassName] = rule { ch('V') as PrimitiveVoid }
 
 }

--- a/src/main/scala/org/ensime/indexer/SearchService.scala
+++ b/src/main/scala/org/ensime/indexer/SearchService.scala
@@ -92,7 +92,7 @@ class SearchService(
     val bases = {
       config.modules.flatMap {
         case (name, m) =>
-          m.targets.flatMap { d => scan(d) } ::: m.testTargets.flatMap { d => scan(d) } :::
+          m.targetDirs.flatMap { d => scan(d) } ::: m.testTargetDirs.flatMap { d => scan(d) } :::
             m.compileJars.map(vfile) ::: m.testJars.map(vfile)
       }
     }.toSet + vfile(config.javaLib)

--- a/src/main/scala/org/ensime/indexer/SourceResolver.scala
+++ b/src/main/scala/org/ensime/indexer/SourceResolver.scala
@@ -5,6 +5,7 @@ import org.apache.commons.vfs2._
 import org.ensime.config._
 import pimpathon.list._
 import pimpathon.map._
+import pimpathon.multiMap._
 
 // mutable: lookup of user's source files are atomically updated
 class SourceResolver(config: EnsimeConfig) extends SourceListener with SLF4JLogging {

--- a/src/main/scala/org/ensime/server/Server.scala
+++ b/src/main/scala/org/ensime/server/Server.scala
@@ -1,5 +1,7 @@
 package org.ensime.server
 
+import com.google.common.base.Charsets
+import com.google.common.io.Files
 import java.io._
 import java.net.{ InetAddress, ServerSocket, Socket }
 import java.util.concurrent.atomic.AtomicBoolean
@@ -29,7 +31,7 @@ object Server {
     if (!ensimeFile.exists() || !ensimeFile.isFile)
       throw new RuntimeException(s".ensime file ($ensimeFile) not found")
 
-    val config = readEnsimeConfig(ensimeFile)
+    val config = EnsimeConfig.parse(Files.toString(ensimeFile, Charsets.UTF_8))
 
     initialiseServer(config)
   }
@@ -38,22 +40,6 @@ object Server {
     val server = new Server(config, "127.0.0.1", 0)
     server.start()
     server
-  }
-
-  /**
-   * ******************************************************************************
-   * Read a new style config from the given files.
-   * @param ensimeFile The base ensime file.   * @return
-   */
-  def readEnsimeConfig(ensimeFile: File): EnsimeConfig = {
-    val configSrc = Source.fromFile(ensimeFile)
-    try {
-      val content = configSrc.getLines().filterNot(_.startsWith(";;")).mkString("\n")
-      val parsed = SExpParser.read(content).asInstanceOf[SExpList]
-      EnsimeConfig.parse(parsed)
-    } finally {
-      configSrc.close()
-    }
   }
 }
 

--- a/src/main/scala/org/ensime/sexp/Sexp.scala
+++ b/src/main/scala/org/ensime/sexp/Sexp.scala
@@ -1,0 +1,111 @@
+package org.ensime.sexp
+
+import collection.breakOut
+import pimpathon.map._
+
+/**
+ * An S-Expression is either
+ *
+ * 1. an atom (i.e. symbol, string, number)
+ * 2. of the form `(x . y)` where `x` and `y` are S-Expressions (i.e. cons)
+ *
+ * Everything else is just sugar.
+ */
+sealed abstract class Sexp {
+  //  override def toString = compactPrint
+  def compactPrint = SexpCompactPrinter(this)
+  def prettyPrint = SexpPrettyPrinter(this)
+
+  def convertTo[T](implicit reader: SexpReader[T]): T = reader.read(this)
+
+  private[sexp] def isList: Boolean = false
+}
+
+case class SexpCons(x: Sexp, y: Sexp) extends Sexp {
+  private[sexp] override val isList = y.isList
+}
+
+sealed trait SexpAtom extends Sexp
+case class SexpChar(value: Char) extends SexpAtom
+case class SexpString(value: String) extends SexpAtom
+case class SexpNumber(value: BigDecimal) extends SexpAtom
+case class SexpSymbol(value: String) extends SexpAtom
+case object SexpNil extends SexpAtom {
+  private[sexp] override def isList = true
+}
+// https://www.gnu.org/software/emacs/manual/html_node/elisp/Float-Basics.html
+case object SexpPosInf extends SexpAtom
+case object SexpNegInf extends SexpAtom
+case object SexpNaN extends SexpAtom
+
+object SexpNumber {
+  def apply(n: Int) = new SexpNumber(BigDecimal(n))
+  def apply(n: Long) = new SexpNumber(BigDecimal(n))
+  def apply(n: Double) = n match {
+    case n if n.isNaN => SexpNil
+    case n if n.isInfinity => SexpNil
+    case _ => new SexpNumber(BigDecimal(n))
+  }
+  def apply(n: BigInt) = new SexpNumber(BigDecimal(n))
+  def apply(n: String) = new SexpNumber(BigDecimal(n))
+  def apply(n: Array[Char]) = new SexpNumber(BigDecimal(n))
+}
+
+/** Sugar for ("a" . ("b" . ("c" . nil))) */
+object SexpList {
+  def apply(els: Sexp*): Sexp = apply(els.toList)
+
+  def apply(els: List[Sexp]): Sexp = els match {
+    case Nil => SexpNil
+    case head :: tail => SexpCons(head, apply(tail))
+  }
+
+  def unapply(sexp: Sexp): Option[List[Sexp]] =
+    if (!sexp.isList) None
+    else {
+      def rec(s: Sexp): List[Sexp] = s match {
+        case SexpNil => Nil
+        case SexpCons(car, cdr) => car :: rec(cdr)
+        case _ => throw new IllegalStateException("Not a list: " + s)
+      }
+      val res = rec(sexp)
+      if (res.isEmpty) None
+      else Some(res)
+    }
+}
+
+/**
+ * Sugar for (:k1 v1 :k2 v2)
+ * [keyword symbols](https://www.gnu.org/software/emacs/manual/html_node/elisp/Symbol-Type.html):
+ */
+object SexpData {
+  def apply(kvs: (SexpSymbol, Sexp)*): Sexp = apply(kvs.toList)
+
+  def apply(kvs: List[(SexpSymbol, Sexp)]): Sexp =
+    if (kvs.isEmpty)
+      SexpNil
+    else {
+      val mapped = kvs.toMap
+      require(mapped.size == kvs.size, "duplicate keys not allowed: " + mapped.keys)
+      require(mapped.keys.forall(_.value.startsWith(":")), "keys must start with ':' " + mapped.keys)
+      SexpList(kvs.flatMap { case (k, v) => k :: v :: Nil }(breakOut): List[Sexp])
+    }
+
+  def unapply(sexp: Sexp): Option[Map[SexpSymbol, Sexp]] = sexp match {
+    case SexpList(values) =>
+      val props = {
+        values.grouped(2).collect {
+          case List(SexpSymbol(key), value) if key.startsWith(":") =>
+            (SexpSymbol(key), value)
+        }
+      }.toMap
+      // props.size counts unique keys. We only create data when keys
+      // are not duplicated or we could introduce losses
+      if (values.isEmpty || 2 * props.size != values.size)
+        None
+      else
+        Some(props)
+
+    case _ => None
+  }
+}

--- a/src/main/scala/org/ensime/sexp/SexpCompactPrinter.scala
+++ b/src/main/scala/org/ensime/sexp/SexpCompactPrinter.scala
@@ -1,0 +1,43 @@
+package org.ensime.sexp
+
+object SexpCompactPrinter extends SexpPrinter {
+
+  def print(sexp: Sexp, sb: StringBuilder): Unit = sexp match {
+    case atom: SexpAtom => printAtom(atom, sb)
+    case SexpData(data) => printData(data, sb)
+    case SexpList(els) => printList(els, sb)
+    case SexpCons(x, y) => printCons(x, y, sb)
+  }
+
+  protected def printCons(x: Sexp, y: Sexp, sb: StringBuilder): Unit = {
+    // recursive, could blow up for big trees
+    sb.append('(')
+    print(x, sb)
+    sb.append(" . ")
+    print(y, sb)
+    sb.append(')')
+  }
+
+  protected def printData(data: Map[SexpSymbol, Sexp], sb: StringBuilder): Unit =
+    if (data.isEmpty) print(SexpNil, sb)
+    else {
+      sb.append('(')
+      printSeq(data, sb.append(' ')) { el =>
+        printSymbol(el._1.value, sb)
+        sb.append(' ')
+        print(el._2, sb)
+      }
+      sb.append(')')
+    }
+
+  protected def printList(els: List[Sexp], sb: StringBuilder): Unit =
+    if (els.isEmpty) print(SexpNil, sb)
+    else {
+      sb.append('(')
+      printSeq(els, sb.append(' ')) {
+        print(_, sb)
+      }
+      sb.append(')')
+    }
+
+}

--- a/src/main/scala/org/ensime/sexp/SexpFormat.scala
+++ b/src/main/scala/org/ensime/sexp/SexpFormat.scala
@@ -1,0 +1,49 @@
+package org.ensime.sexp
+
+import annotation.implicitNotFound
+
+/** Provides the S-Exp deserialization for type T. */
+@implicitNotFound(msg = "Cannot find SexpReader or SexpFormat type class for ${T}")
+trait SexpReader[T] {
+  def read(value: Sexp): T
+}
+
+object SexpReader {
+  implicit def func2Reader[T](f: Sexp => T): SexpReader[T] = new SexpReader[T] {
+    def read(sexp: Sexp) = f(sexp)
+  }
+}
+
+/** Provides the S-Exp serialization for type T. */
+@implicitNotFound(msg = "Cannot find SexpWriter or SexpFormat type class for ${T}")
+trait SexpWriter[T] {
+  def write(obj: T): Sexp
+}
+
+object SexpWriter {
+  implicit def func2Writer[T](f: T => Sexp): SexpWriter[T] = new SexpWriter[T] {
+    def write(obj: T) = f(obj)
+  }
+}
+
+/** Provides the S-Exp deserialization and serialization for type T. */
+trait SexpFormat[T] extends SexpReader[T] with SexpWriter[T]
+
+object SexpFormat {
+  /**
+   * Some implicit implementations of an `SexpFormat` return a class
+   * that is refined by a type parameter or similar. Such
+   * implementations are very inefficient because the class is created
+   * every single time its use is invoked, resulting in excessive
+   * memory churn. To workaround the problem, this may be used to assign
+   * the implementation to an `implicit val` which is re-used.
+   *
+   * In addition, limitations in the current release of Shapeless
+   * (2.0.0) mean that nested case classes are not allowed unless the
+   * nested types have a pre-computed `implicit val` as provided by
+   * this.
+   *
+   * See https://github.com/typelevel/scala/issues/83 for more.
+   */
+  def apply[T](implicit f: SexpFormat[T]) = f
+}

--- a/src/main/scala/org/ensime/sexp/SexpParser.scala
+++ b/src/main/scala/org/ensime/sexp/SexpParser.scala
@@ -1,0 +1,121 @@
+package org.ensime.sexp
+
+import org.parboiled.scala._
+
+import org.ensime.util.ParboiledParser
+
+/**
+ * Parse Emacs Lisp into an `Sexp`. Other lisp variants may
+ * require tweaking, e.g. Scheme's nil, infinity, NaN, etc.
+ */
+object SexpParser extends ParboiledParser[Sexp] {
+  protected val Top = SexpP
+
+  // e.g. for .el files
+  def flatParse(el: String): Sexp = parse("(" + el + "\n)")
+
+  private lazy val SexpP: Rule1[Sexp] = rule("Sexp") {
+    SexpAtomP | SexpListP | SexpConsP | SexpQuotedP
+  }
+
+  private lazy val SexpAtomP: Rule1[SexpAtom] = rule("Atom") {
+    SexpNilP | SexpCharP | SexpStringP | SexpNaNP | SexpNumberP | SexpSymbolP
+  }
+
+  private lazy val SexpNilP: Rule1[SexpAtom] = rule("nil") {
+    ("nil" | (LeftBrace ~ RightBrace))
+  } ~> { _ => SexpNil }
+
+  private lazy val SexpCharP: Rule1[SexpChar] = rule("Char") {
+    ch('?') ~ NormalChar
+  } ~~> { c => SexpChar(c.head) }
+
+  private lazy val SexpStringP: Rule1[SexpString] = rule("String") {
+    ch('"') ~ zeroOrMore(Character) ~~> (chars => SexpString(chars.mkString(""))) ~ ch('"')
+  }
+
+  private lazy val SexpNumberP: Rule1[SexpNumber] = rule("Number") {
+    (group(Integer ~ optional(Frac) ~ optional(Exp)))
+  } ~> {
+    value => SexpNumber(BigDecimal(value))
+  }
+
+  private lazy val SexpNaNP: Rule1[SexpAtom] = rule("NaN") {
+    ("-1.0e+INF" ~> { _ => SexpNegInf }) |
+      ("1.0e+INF" ~> { _ => SexpPosInf }) |
+      (optional("-") ~ "0.0e+NaN" ~> { _ => SexpNaN })
+  }
+
+  private lazy val SexpSymbolP: Rule1[SexpSymbol] = rule("Symbol") {
+    // ? allowed at the end of symbol names
+    oneOrMore(Alpha | Digit | SymbolSpecial) ~ optional("?")
+  } ~> SexpSymbol.apply
+
+  private lazy val SexpListP: Rule1[Sexp] = rule("List") {
+    LeftBrace ~ (SexpP ~ zeroOrMore(Whitespace ~ SexpP)) ~ RightBrace
+  } ~~> {
+    (head, tail) => SexpList(head :: tail)
+  }
+
+  private lazy val SexpConsP: Rule1[SexpCons] = rule("Cons") {
+    LeftBrace ~
+      SexpP ~ Whitespace ~ "." ~ Whitespace ~ SexpP ~ RightBrace
+  } ~~> {
+    (x, y) => SexpCons(x, y)
+  }
+
+  private val SexpQuote = SexpSymbol("quote")
+  private lazy val SexpQuotedP: Rule1[Sexp] = rule("Quoted") {
+    "'" ~ SexpP
+  } ~~> { v => SexpCons(SexpQuote, v) }
+
+  private lazy val Character: Rule1[String] = rule("Character") { EscapedChar | NormalChar }
+  private lazy val EscapedChar: Rule1[String] = rule("EscapedChar") {
+    "\\" ~ ANY ~> { s => unescape(s) }
+  }
+  private lazy val NormalChar: Rule1[String] = rule("NormalChar") { !anyOf("\"\\") ~ ANY ~> identity }
+
+  // Rule0 primitives and helpers...
+  private lazy val Alpha = rule("Alpha") { "a" - "z" | "A" - "Z" }
+  private lazy val Integer = rule("Integer") { optional("-") ~ (("1" - "9") ~ Digits | Digit) }
+  private lazy val Digits = rule("Digits") { oneOrMore(Digit) }
+  private lazy val Digit = rule("Digit") { "0" - "9" }
+  private lazy val Frac = rule("Frac") { "." ~ Digits }
+  private lazy val Exp = rule("Exp") { ignoreCase("e") ~ optional(anyOf("+-")) ~ Digits }
+
+  private lazy val SymbolSpecial = rule("SymbolSpecial") { anyOf("+-*/_~!@$%^&=:<>{}") }
+
+  private lazy val Whitespace = rule("Whitespace") { zeroOrMore(Comment | anyOf(" \n\r\t\f")) }
+  private lazy val Comment = rule("Comment") { ";" ~ zeroOrMore(noneOf("\n")) ~ ("\n" | EOI) }
+
+  private lazy val LeftBrace = rule("(") { Whitespace ~ "(" ~ Whitespace }
+  private lazy val RightBrace = rule(")") { Whitespace ~ ")" ~ Whitespace }
+
+  // https://www.gnu.org/software/emacs/manual/html_node/elisp/Basic-Char-Syntax.html
+  // https://www.gnu.org/software/emacs/manual/html_node/elisp/Syntax-for-Strings.html
+  // Not supported: https://www.gnu.org/software/emacs/manual/html_node/elisp/Non_002dASCII-in-Strings.html
+  private[sexp] val specialChars = Map[String, String](
+    "\"" -> "\"",
+    "a" -> 7.toChar.toString,
+    "b" -> "\b",
+    "t" -> "\t",
+    "n" -> "\n",
+    "v" -> 11.toChar.toString,
+    "f" -> "\f",
+    "r" -> "\r",
+    "e" -> 27.toChar.toString,
+    "s" -> " ",
+    "d" -> 127.toChar.toString,
+    "\\" -> "\\"
+  )
+  private val ignore = Set("\n", " ")
+
+  private def unescape(c: String): String = {
+    if (ignore(c)) ""
+    else {
+      val unescaped = specialChars.get(c)
+      require(unescaped.isDefined, c + " is not a valid escaped character")
+      unescaped.get
+    }
+  }
+}

--- a/src/main/scala/org/ensime/sexp/SexpPrettyPrinter.scala
+++ b/src/main/scala/org/ensime/sexp/SexpPrettyPrinter.scala
@@ -1,0 +1,65 @@
+package org.ensime.sexp
+
+import scala.annotation.tailrec
+
+/**
+ * The output is a non-standard interpretation of "pretty lisp" ---
+ * emacs style formatting requires counting the length of the text on
+ * the current line and indenting off that, which is not so easy when
+ * all you have is a `StringBuilder`.
+ */
+trait SexpPrettyPrinter extends SexpPrinter {
+  val Indent = 2
+
+  def print(sexp: Sexp, sb: StringBuilder): Unit = print(sexp, sb, 0)
+
+  private def print(sexp: Sexp, sb: StringBuilder, indent: Int): Unit = sexp match {
+    case SexpData(data) => printData(data, sb, indent)
+    case SexpList(els) => printList(els, sb, indent)
+    case SexpCons(x, y) => printCons(x, y, sb, indent)
+    case atom: SexpAtom => printAtom(atom, sb)
+  }
+
+  protected def printCons(x: Sexp, y: Sexp, sb: StringBuilder, indent: Int): Unit = {
+    // recursive, could blow up for big trees
+    sb.append('(')
+    print(x, sb, indent)
+    sb.append(" .\n")
+    printIndent(sb, indent + Indent)
+    print(y, sb, indent + Indent)
+    sb.append(')')
+  }
+
+  protected def printData(data: Map[SexpSymbol, Sexp], sb: StringBuilder, indent: Int): Unit =
+    if (data.isEmpty) print(SexpNil, sb)
+    else {
+      sb.append("(\n")
+      printSeq(data, sb.append('\n')) { el =>
+        printIndent(sb, indent + Indent)
+        printSymbol(el._1.value, sb)
+        sb.append(' ')
+        print(el._2, sb, indent + Indent)
+      }
+      sb.append('\n')
+      printIndent(sb, indent)
+      sb.append(')')
+    }
+
+  protected def printList(els: List[Sexp], sb: StringBuilder, indent: Int): Unit =
+    if (els.isEmpty) print(SexpNil, sb)
+    else {
+      sb.append('(')
+      printSeq(els, { sb.append("\n"); printIndent(sb, indent + Indent) }) {
+        print(_, sb, indent + Indent)
+      }
+      sb.append(')')
+    }
+
+  protected def printIndent(sb: StringBuilder, indent: Int): Unit =
+    (0 until indent) foreach { _ =>
+      sb.append(' ')
+    }
+
+}
+
+object SexpPrettyPrinter extends SexpPrettyPrinter

--- a/src/main/scala/org/ensime/sexp/SexpPrinter.scala
+++ b/src/main/scala/org/ensime/sexp/SexpPrinter.scala
@@ -1,0 +1,88 @@
+package org.ensime.sexp
+
+/**
+ * Emacs flavoured lisp printer.
+ */
+trait SexpPrinter extends (Sexp => String) {
+  /**
+   * Convert the input to a `String` (constructing the entire `String`
+   * in memory).
+   */
+  def apply(x: Sexp): String = {
+    val sb = new StringBuilder
+    print(x, sb)
+    sb.toString
+  }
+
+  /**
+   * Convert the input to a `String` with a swank message title.
+   */
+  def apply(x: Sexp, swank: String, rpc: Long): String = {
+    val sb = new StringBuilder
+    print(x, swank, rpc, sb)
+    sb.toString
+  }
+
+  /**
+   * Perform the side effect of rendering `x` to `sb`, wrapping in a
+   * swank message title and RPC id.
+   */
+  def print(x: Sexp, swank: String, rpc: Long, sb: StringBuilder): Unit = {
+    sb.append('(').append(swank).append(' ')
+    print(x, sb)
+    sb.append(' ').append(rpc).append(')')
+  }
+
+  /**
+   * Perform the side effect of rendering `x` to `sb`, which may
+   * reduce memory requirements when rendering very large objects.
+   */
+  def print(x: Sexp, sb: StringBuilder): Unit
+
+  protected def printAtom(sexp: SexpAtom, sb: StringBuilder): Unit = sexp match {
+    case SexpChar(c) => sb.append('?').append(c)
+    case SexpSymbol(s) => printSymbol(s, sb)
+    case SexpString(s) => printString(s, sb)
+    // will not work for Scheme
+    // e.g. http://rosettacode.org/wiki/Infinity#Scheme
+    case SexpNil => sb.append("nil")
+    case SexpNegInf => sb.append("-1.0e+INF")
+    case SexpPosInf => sb.append("1.0e+INF")
+    case SexpNaN => sb.append("0.0e+NaN")
+    case SexpNumber(n) =>
+      // .toString and .apply does not round-trip for really big exponents
+      // but PlainString can be *really* slow and eat up loads of memory
+      //sb.append(n.underlying.toPlainString)
+      //sb.append(n.underlying.toEngineeringString())
+      sb.append(n.toString)
+  }
+
+  // we prefer not to escape some characters when in strings
+  private val exclude = Set("\n", "\t", " ")
+  private val specials = SexpParser.specialChars.toList.map(_.swap)
+  private val stringSpecials = SexpParser.specialChars.toList.map(_.swap).filterNot {
+    case (from, to) => exclude(from)
+  }
+
+  protected def printSymbol(s: String, sb: StringBuilder): Unit = {
+    val escaped = specials.foldLeft(s) {
+      case (r, (from, to)) => r.replace(from, "\\" + to)
+    }
+    sb.append(escaped)
+  }
+
+  protected def printString(s: String, sb: StringBuilder): Unit = {
+    val escaped = stringSpecials.foldLeft(s) {
+      case (r, (from, to)) => r.replace(from, "\\" + to)
+    }
+    sb.append('"').append(escaped).append('"')
+  }
+
+  protected def printSeq[A](iterable: Iterable[A], printSeparator: => Unit)(f: A => Unit) {
+    var first = true
+    iterable.foreach { a =>
+      if (first) first = false else printSeparator
+      f(a)
+    }
+  }
+}

--- a/src/main/scala/org/ensime/sexp/formats/BasicFormats.scala
+++ b/src/main/scala/org/ensime/sexp/formats/BasicFormats.scala
@@ -1,0 +1,87 @@
+package org.ensime.sexp.formats
+
+import org.ensime.sexp._
+
+trait BasicFormats {
+
+  implicit object UnitFormat extends SexpFormat[Unit] {
+    def write(x: Unit) = SexpNil
+    def read(value: Sexp) = ()
+  }
+
+  implicit object BooleanFormat extends SexpFormat[Boolean] {
+    // all non-nil Sexps are technically "true"
+    private val SexpTrue = SexpSymbol("t")
+    def write(x: Boolean) = if (x) SexpTrue else SexpNil
+    def read(value: Sexp) = value match {
+      case SexpNil => false
+      case _ => true
+    }
+  }
+
+  implicit object CharFormat extends SexpFormat[Char] {
+    def write(x: Char) = SexpChar(x)
+    def read(value: Sexp) = value match {
+      case SexpChar(x) => x
+      case x => deserializationError(x)
+    }
+  }
+
+  implicit object StringFormat extends SexpFormat[String] {
+    def write(x: String) = SexpString(x)
+    def read(value: Sexp) = value match {
+      case SexpString(x) => x
+      case x => deserializationError(x)
+    }
+  }
+
+  implicit object SymbolFormat extends SexpFormat[Symbol] {
+    def write(x: Symbol) = SexpString(x.name)
+    def read(value: Sexp) = value match {
+      case SexpString(x) => Symbol(x)
+      case x => deserializationError(x)
+    }
+  }
+
+  /**
+   * NOTE Emacs will not be able to correctly interpret arbitrary
+   * precision numbers because - unlike other lisps - it uses a
+   * reduced form of C double/integer precision. A round-trip via
+   * Emacs for very large numbers will return `SexpPosInf`.
+   *
+   * The built-in Emacs library `'calc` has a few data formats
+   * http://www.gnu.org/software/emacs/manual/html_mono/calc.html#Data-Type-Formats
+   * but they fall short and require specific interpretation within
+   * the `'calc` framework.
+   *
+   * If you need Emacs-specific support for arbitrary precision
+   * numbers, override this implementation with one that adheres to
+   * the arbitrary precision framework of your choice.
+   */
+  implicit def ViaBigDecimalFormat[T](implicit c: BigDecimalConvertor[T]) =
+    new SexpFormat[T] {
+      def write(x: T): Sexp =
+        if (c.isNaN(x)) SexpNaN
+        else if (c.isPosInf(x)) SexpPosInf
+        else if (c.isNegInf(x)) SexpNegInf
+        else SexpNumber(c.to(x))
+
+      def read(value: Sexp): T = value match {
+        case SexpNumber(x) => c.from(x)
+        case SexpNaN => c.NaN
+        case SexpPosInf => c.PosInf
+        case SexpNegInf => c.NegInf
+        case x => deserializationError(x)
+      }
+    }
+
+  // boilerplate for performance (uses ViaBigDecimal)
+  implicit val IntFormat = SexpFormat[Int]
+  implicit val LongFormat = SexpFormat[Long]
+  implicit val FloatFormat = SexpFormat[Float]
+  implicit val DoubleFormat = SexpFormat[Double]
+  implicit val ByteFormat = SexpFormat[Byte]
+  implicit val ShortFormat = SexpFormat[Short]
+  implicit val BigIntFormat = SexpFormat[BigInt]
+  implicit val BigDecimalFormat = SexpFormat[BigDecimal]
+}

--- a/src/main/scala/org/ensime/sexp/formats/BigDecimalConvertor.scala
+++ b/src/main/scala/org/ensime/sexp/formats/BigDecimalConvertor.scala
@@ -1,0 +1,80 @@
+package org.ensime.sexp.formats
+
+import collection.BitSet
+import collection.{ immutable => im }
+
+class BigDecimalConvertor[T](
+    val to: T => BigDecimal,
+    val from: BigDecimal => T) {
+  protected def unsupported(message: String) =
+    throw new UnsupportedOperationException(message)
+
+  def isPosInf(t: T): Boolean = false
+  def PosInf: T = unsupported("Positive infinity")
+  def isNegInf(t: T): Boolean = false
+  def NegInf: T = unsupported("Negative infinity")
+  def isNaN(t: T): Boolean = false
+  def NaN: T = unsupported("NaN")
+}
+
+object BigDecimalConvertor {
+  // an implicit already exists from many of these types to BigDecimal
+  implicit val IntBigConv = new BigDecimalConvertor[Int](identity, _.intValue)
+  implicit val LongBigConv = new BigDecimalConvertor[Long](identity, _.longValue)
+  implicit val FloatBigConv = new BigDecimalConvertor[Float](identity, _.floatValue) {
+    override def isPosInf(t: Float) = t.isPosInfinity
+    override def PosInf = Float.PositiveInfinity
+    override def isNegInf(t: Float) = t.isNegInfinity
+    override def NegInf = Float.NegativeInfinity
+    override def isNaN(t: Float) = t.isNaN
+    override def NaN = Float.NaN
+  }
+  implicit val DoubleBigConv = new BigDecimalConvertor[Double](identity, _.doubleValue) {
+    override def isPosInf(t: Double) = t.isPosInfinity
+    override def PosInf = Double.PositiveInfinity
+    override def isNegInf(t: Double) = t.isNegInfinity
+    override def NegInf = Double.NegativeInfinity
+    override def isNaN(t: Double) = t.isNaN
+    override def NaN = Double.NaN
+  }
+  implicit val ByteBigConv = new BigDecimalConvertor[Byte](identity, _.byteValue)
+  implicit val ShortBigConv = new BigDecimalConvertor[Short](identity, _.shortValue)
+  implicit val BigIntBigConv = new BigDecimalConvertor[BigInt](BigDecimal.apply, _.toBigInt)
+  implicit val BigDecimalBigConv = new BigDecimalConvertor[BigDecimal](identity, identity)
+}
+
+object BigIntConvertor {
+  def fromBitSet(bitSet: BitSet): BigInt =
+    fromBitMask(bitSet.toBitMask)
+
+  def toBitSet(bigInt: BigInt): im.BitSet = {
+    im.BitSet.fromBitMaskNoCopy(toBitMask(bigInt))
+  }
+
+  /** @param bitmask is the same format as used by `BitSet` */
+  private def fromBitMask(bitmask: Array[Long]): BigInt = {
+    val bytes = Array.ofDim[Byte](bitmask.length * 8)
+    val bb = java.nio.ByteBuffer.wrap(bytes)
+    bitmask.reverse foreach bb.putLong
+    BigInt(bytes)
+  }
+
+  /** @return the same format as used by `BitSet` */
+  private def toBitMask(bigInt: BigInt): Array[Long] = {
+    // bytes may not be padded to be divisible by 8
+    val bytes = {
+      val raw = bigInt.toByteArray
+      val rem = raw.length % 8
+      if (rem == 0) raw
+      else Array.ofDim[Byte](8 - rem) ++ raw
+    }
+    val longLength = bytes.length / 8
+    val bb = java.nio.ByteBuffer.wrap(bytes)
+    // asLongBuffer.array doesn't support .array
+    val longs = Array.ofDim[Long](longLength)
+    for { i <- 0 until longLength } {
+      longs(i) = bb.getLong(i * 8)
+    }
+    longs.reverse
+  }
+}

--- a/src/main/scala/org/ensime/sexp/formats/CollectionFormats.scala
+++ b/src/main/scala/org/ensime/sexp/formats/CollectionFormats.scala
@@ -1,0 +1,203 @@
+package org.ensime.sexp.formats
+
+import collection.GenTraversableOnce
+import collection.generic.CanBuildFrom
+import collection.breakOut
+import collection.{ immutable => im, mutable => mut }
+
+import org.ensime.sexp._
+import scala.collection.GenMap
+import scala.collection.GenTraversable
+import scala.collection.generic.IsTraversableLike
+
+/**
+ * Support for anything with a `CanBuildFrom`.
+ */
+trait CollectionFormats {
+  this: BasicFormats =>
+
+  import scala.language.higherKinds
+
+  /*
+   Implementation note. Ideally, and intuitively, we'd like to be able
+   to write the type signature of this implicit method as
+
+     getTraversableformat[E, T <: GenTraversable[E]](implicit
+       cbf: CanBuildFrom[T, E, T],
+       ef:  SexpFormat[E]
+     )
+
+   but due to limitations of the Scala compiler, the "kindedness" of a
+   type parameter restricts what it can be equated to. A no-param type
+   such as `T` (of `*` kind) cannot be equated to a one-param type
+   such as `T[E]` (of `* -> *` kind), which cannot be equated to a
+   two-param type such as `T[K, V]` (of `* -> * -> *` kind).
+
+   This deficiency is tracked under
+   [SI-2712](https://issues.scala-lang.org/browse/SI-2712)
+   "implement higher-order unification for type constructor inference".
+
+   The workaround is to define the types with the correct kindedness
+   (using free type parameters) and then introducing implicit evidence
+   to restrict the free type parameters (note that `<:<` is defined in
+   Predef).
+
+   SIDENOTE: An alternative way of implementing genTraversableFormat
+   would be to define it using a refinement:
+
+     genTraversbaleFormat[E, T](implicit
+       itl: IsTraversableLike[T] { type A = E },
+       cbf: CanBuildFrom[T, E, T],
+       ef: SexpFormat[E]
+     )
+
+   but this only works because `IsTraversableLike` is using the evidence
+   trick under the hood.
+   */
+  implicit def genTraversableFormat[T[_], E](
+    implicit evidence: T[E] <:< GenTraversable[E],
+    cbf: CanBuildFrom[T[E], E, T[E]],
+    ef: SexpFormat[E]): SexpFormat[T[E]] = new SexpFormat[T[E]] {
+    def write(t: T[E]) = SexpList(t.map(_.toSexp)(breakOut): List[Sexp])
+
+    def read(v: Sexp): T[E] = v match {
+      case SexpNil => cbf().result()
+      case SexpList(els) => els.map(_.convertTo[E])(breakOut)
+      case x => deserializationError(x)
+    }
+  }
+
+  /*
+   We could potentially have a specialised mapDataFormat (using
+   `SexpData`) if we know that the keys can be converted into
+   `SexpSymbol`, but that would overcomplicate the `SexpFormat`
+   hierarchy.
+   */
+  implicit def genMapFormat[M[_, _], K, V](
+    implicit ev: M[K, V] <:< GenMap[K, V],
+    cbf: CanBuildFrom[M[K, V], (K, V), M[K, V]],
+    kf: SexpFormat[K],
+    vf: SexpFormat[V]): SexpFormat[M[K, V]] = new SexpFormat[M[K, V]] {
+    def write(m: M[K, V]) =
+      SexpList(m.map {
+        case (k, v) => SexpList(k.toSexp, v.toSexp)
+      }(breakOut): List[Sexp]
+      )
+
+    def read(v: Sexp): M[K, V] = v match {
+      case SexpNil => cbf().result
+      case SexpList(els) => els.map {
+        case SexpList(sk :: sv :: Nil) => (sk.convertTo[K], sv.convertTo[V])
+        case x => deserializationError(x)
+      }(breakOut)
+      case x => deserializationError(x)
+    }
+  }
+
+  /**
+   * We only support deserialisation via `im.BitSet` as the general
+   * case requires going through a proxy to convert the bitmask into
+   * elements that can be read via `CanBuildFrom`. If you have your
+   * own (possibly compressed) implementation of `BitSet` you will
+   * need to provide your own format.
+   *
+   * We encode the `BigInt` form as a String using emacs `calc-eval`
+   * notation (radix is part of the string). See `ViaBigDecimalFormat`
+   * for a longer discussion about emacs number formats.
+   *
+   * This can potentially be used in Emacs using the following (which
+   * will parse the strings into big ints every time it is queried, so
+   * it's not particularly efficient):
+   *
+   *   (require 'calc)
+   *   (defmath bitsetAnd (bitset i)
+   *     (logand (lsh 1 i (+ 1 i)) bitset (+ 1 i)))
+   *   (defun bitsetContains (bitset i)
+   *     (not (string= "0"
+   *       (calc-eval "bitsetAnd($, $$)" 'num bitset i))))
+   *
+   *   (bitsetContains "10#3" 0) ; 't
+   *   (bitsetContains "10#3" 1) ; 't
+   *   (bitsetContains "10#3" 2) ; nil
+   *   (bitsetContains "32#10000000000000001" 0) ; t
+   *   (bitsetContains "16#10000000000000001" 64) ; t
+   *   (bitsetContains "16#10000000000000002" 1) ; t
+   *   (bitsetContains "16#10000000000000002" 64) ; t
+   *   (bitsetContains "16#10000000000000002" 0) ; nil
+   */
+  implicit object BitSetFormat extends SexpFormat[collection.BitSet] {
+    private val Radix = 16
+    private val CalcEval = "(\\d+)#(\\d+)"r
+
+    def write(bs: collection.BitSet) =
+      if (bs.isEmpty) SexpNil
+      else {
+        val bigInt = BigIntConvertor.fromBitSet(bs)
+        SexpString(Radix + "#" + bigInt.toString(Radix))
+      }
+
+    // NOTE: returns immutable BitSet
+    def read(m: Sexp): im.BitSet = m match {
+      case SexpNil => im.BitSet()
+      case SexpString(CalcEval(radix, num)) =>
+        val bigInt = BigInt(num, radix.toInt)
+        BigIntConvertor.toBitSet(bigInt)
+      case x => deserializationError(x)
+    }
+  }
+
+  implicit object ImBitSetFormat extends SexpFormat[im.BitSet] {
+    def write(bs: im.BitSet) = BitSetFormat.write(bs)
+    def read(m: Sexp) = BitSetFormat.read(m)
+  }
+
+  private val start = SexpSymbol(":start")
+  private val end = SexpSymbol(":end")
+  private val step = SexpSymbol(":step")
+  private val inclusive = SexpSymbol(":inclusive")
+  implicit object RangeFormat extends SexpFormat[im.Range] {
+    def write(r: im.Range) = SexpData(
+      start -> SexpNumber(r.start),
+      end -> SexpNumber(r.end),
+      step -> SexpNumber(r.step))
+
+    def read(s: Sexp) = s match {
+      case SexpData(data) =>
+        (data(start), data(end), data(step)) match {
+          case (SexpNumber(s), SexpNumber(e), SexpNumber(st)) =>
+            Range(s.toInt, e.toInt, st.toInt)
+          case _ => deserializationError(s)
+        }
+      case _ => deserializationError(s)
+    }
+  }
+
+  // note that the type has to be im.NumericRange[E]
+  // not im.NumericRange.{Inclusive, Exclusive}[E]
+  // (same problem as above, but getting the cons is trickier)
+  implicit def numericRangeFormat[E](implicit nf: SexpFormat[E],
+    n: Numeric[E],
+    int: Integral[E]): SexpFormat[im.NumericRange[E]] = new SexpFormat[im.NumericRange[E]] {
+    def write(r: im.NumericRange[E]) = SexpData(
+      start -> r.start.toSexp,
+      end -> r.end.toSexp,
+      step -> r.step.toSexp,
+      inclusive -> BooleanFormat.write(r.isInclusive)
+    )
+
+    def read(s: Sexp): im.NumericRange[E] = s match {
+      case SexpData(data) =>
+        (data(start), data(end), data(step), data(inclusive)) match {
+          case (s, e, st, incl) if (BooleanFormat.read(incl)) =>
+            im.NumericRange.inclusive(
+              s.convertTo[E], e.convertTo[E], st.convertTo[E])
+          case (s, e, st, incl) =>
+            im.NumericRange(s.convertTo[E], e.convertTo[E], st.convertTo[E])
+          case _ => deserializationError(s)
+        }
+      case _ => deserializationError(s)
+    }
+  }
+
+}
+

--- a/src/main/scala/org/ensime/sexp/formats/DefaultSexpProtocol.scala
+++ b/src/main/scala/org/ensime/sexp/formats/DefaultSexpProtocol.scala
@@ -1,0 +1,9 @@
+package org.ensime.sexp.formats
+
+trait DefaultSexpProtocol
+  extends BasicFormats
+  with StandardFormats
+  with CollectionFormats
+  with ProductFormats
+
+object DefaultSexpProtocol extends DefaultSexpProtocol

--- a/src/main/scala/org/ensime/sexp/formats/FamilyFormats.scala
+++ b/src/main/scala/org/ensime/sexp/formats/FamilyFormats.scala
@@ -1,0 +1,55 @@
+package org.ensime.sexp.formats
+
+import scala.reflect.runtime.universe._
+import shapeless._
+
+import org.ensime.sexp._
+
+/**
+ * Helper methods for generating wrappers for types in a family, also
+ * known as "type hints".
+ *
+ * See https://gist.github.com/fommil/3a04661116c899056197
+ *
+ * Boilerplate blocked on https://github.com/milessabin/shapeless/issues/238
+ */
+trait FamilyFormats {
+
+  // // unlike case classes, include the type hint in the serialised form
+  // // TODO: get this working as part of a family, rather than just standalone
+  // implicit def singletonFormat[T <: Singleton](
+  //   implicit w: Witness.Aux[T]) = new SexpFormat[T] {
+  //   // TODO: scala names https://github.com/milessabin/shapeless/issues/256
+  //   private val sexp = SexpSymbol(w.value.getClass.getName)
+  //   private val value = w.value
+  //   def write(t: T) = sexp
+  //   def read(v: Sexp) =
+  //     if (v == sexp) value
+  //     else deserializationError(v)
+  // }
+
+  case class TypeHint[T](hint: SexpSymbol)
+  implicit def typehint[T: TypeTag]: TypeHint[T] =
+    TypeHint(SexpSymbol(":" + typeOf[T].dealias.toString.split("(\\.|\\$)").last))
+
+  abstract class TraitFormat[T] extends SexpFormat[T] {
+    protected def wrap[E](t: E)(implicit th: TypeHint[E], sf: SexpFormat[E]): Sexp =
+      SexpData(th.hint -> t.toSexp)
+
+    // implement by matching on the implementations and passing off to wrap
+    // def write(t: T): Sexp
+
+    final def read(sexp: Sexp): T = sexp match {
+      case SexpData(map) if map.size == 1 =>
+        map.head match {
+          case (hint, value) => read(hint, value)
+        }
+
+      case x => deserializationError(x)
+    }
+
+    // implement by matching on the hint and passing off to convertTo[Impl]
+    protected def read(hint: SexpSymbol, value: Sexp): T
+  }
+
+}

--- a/src/main/scala/org/ensime/sexp/formats/ProductFormats.scala
+++ b/src/main/scala/org/ensime/sexp/formats/ProductFormats.scala
@@ -1,0 +1,96 @@
+package org.ensime.sexp.formats
+
+import org.ensime.sexp._
+import shapeless._
+
+trait LowPriorityProductFormats {
+
+  /*
+   Implementation note: this (and the `FamilyFormat`s) is likely to be
+   replaced by a cleaner `(Labelled)TypeClass` implementation when
+   shapeless 2.1 is released: it can handle the products and co-products
+   at the same time (i.e. case classes, tuples, and sealed traits)
+   */
+
+  trait HListFormat[L <: HList] {
+    def write(x: L): List[Sexp]
+    def read(values: List[Sexp]): L
+  }
+
+  object HListFormat {
+    implicit def hNilFormat: HListFormat[HNil] = new HListFormat[HNil] {
+      def write(x: HNil) = Nil
+      def read(value: List[Sexp]) = value match {
+        case Nil => HNil
+        case x => throw new DeserializationException(s"Didn't expect $x")
+      }
+    }
+
+    implicit def hListFormat[H, T <: HList](
+      implicit h: SexpFormat[H],
+      t: HListFormat[T]): HListFormat[H :: T] = new HListFormat[H :: T] {
+      def write(x: H :: T) = h.write(x.head) :: t.write(x.tail)
+
+      def read(values: List[Sexp]): H :: T = {
+        import HList.ListCompat._
+        values match {
+          case head :: tail => h.read(head) :: t.read(tail)
+          case x => throw new DeserializationException("Didn't expect Nil")
+        }
+      }
+    }
+  }
+
+  /* We really want to have just `T` and its various representations,
+   * e.g. `R <: Generic[T].Repr`, in the type parameters --- but
+   * that's not possible due to limitations of the type system.
+   *
+   * Therefore we have to define the type very loosely (e.g. `R <:
+   * HList`) and then restrict it by asking for an implicit `Aux`
+   * which serves the purpose of the thing it is aux-ing. All the
+   * implementations of the `Aux`s are provided by shapeless macros.
+   */
+  implicit def labelledProductFormat[T, R <: HList, LR <: HList, K <: HList](
+    implicit g: Generic.Aux[T, R],
+    lg: LabelledGeneric.Aux[T, LR],
+    k: ops.record.Keys.Aux[LR, K],
+    ltl: ops.hlist.ToList[K, Symbol],
+    r: HListFormat[R]): SexpFormat[T] = new SexpFormat[T] {
+
+    private val keys = k().toList[Symbol].map { sym =>
+      SexpSymbol(":" + sym.name)
+    }
+
+    def write(x: T): Sexp =
+      if (keys.isEmpty) SexpNil
+      else SexpData(keys zip r.write(g.to(x)))
+
+    def read(value: Sexp): T = value match {
+      case SexpNil => g.from(r.read(Nil))
+      case SexpData(pairs) =>
+        val els = keys.map { k =>
+          // missing keys are interpreted as nil
+          pairs.get(k).getOrElse(SexpNil)
+        }
+        g.from(r.read(els))
+
+      case x =>
+        deserializationError(x)
+    }
+  }
+}
+
+trait ProductFormats extends LowPriorityProductFormats {
+  // higher priority so that tuples and case classes are not ambiguous
+  implicit def tupleProductFormat[T, R <: HList, T2](
+    implicit g: Generic.Aux[T, R],
+    t: ops.hlist.Tupler.Aux[R, T2],
+    p: T =:= T2,
+    r: HListFormat[R]): SexpFormat[T] = new SexpFormat[T] {
+    def write(x: T): Sexp = SexpList(r.write(g.to(x)))
+    def read(value: Sexp): T = value match {
+      case SexpList(els) => g.from(r.read(els))
+      case x => deserializationError(x)
+    }
+  }
+}

--- a/src/main/scala/org/ensime/sexp/formats/SexpFormatUtils.scala
+++ b/src/main/scala/org/ensime/sexp/formats/SexpFormatUtils.scala
@@ -1,0 +1,47 @@
+package org.ensime.sexp.formats
+
+import scala.util.Try
+
+import org.ensime.sexp._
+
+/**
+ * Utility methods for creating custom `SexpFormat`s.
+ */
+object SexpFormatUtils {
+  /**
+   * Lazy wrapper around serialization. Useful when you want to
+   * serialize (mutually) recursive structures.
+   */
+  def lazyFormat[T](format: => SexpFormat[T]) = new SexpFormat[T] {
+    lazy val delegate = format
+    def write(x: T) = delegate.write(x)
+    def read(value: Sexp) = delegate.read(value)
+  }
+
+  /**
+   * Wraps an existing `SexpReader` with `Exception` protection.
+   */
+  def safeReader[A: SexpReader] = new SexpReader[Try[A]] {
+    def read(value: Sexp) = Try(value.convertTo[A])
+  }
+
+  /**
+   * Turns an `SexpWriter` into a `SexpFormat` that throws an
+   * `UnsupportedOperationException` for reads.
+   */
+  def lift[T](writer: SexpWriter[T]) = new SexpFormat[T] {
+    def write(obj: T): Sexp = writer.write(obj)
+    def read(value: Sexp) =
+      throw new UnsupportedOperationException("SexpReader implementation missing")
+  }
+
+  /**
+   * Turns an `SexpReader` into a `SexpFormat` that throws an
+   * `UnsupportedOperationException` for writes.
+   */
+  def lift[T](reader: SexpReader[T]) = new SexpFormat[T] {
+    def write(obj: T): Sexp =
+      throw new UnsupportedOperationException(s"SexpWriter implementation missing")
+    def read(value: Sexp) = reader.read(value)
+  }
+}

--- a/src/main/scala/org/ensime/sexp/formats/SexpFormats.scala
+++ b/src/main/scala/org/ensime/sexp/formats/SexpFormats.scala
@@ -1,0 +1,32 @@
+package org.ensime.sexp.formats
+
+import org.ensime.sexp._
+import scala.reflect.ClassTag
+
+trait SexpFormats {
+  /**
+   * Constructs an `SexpFormat` from its two parts, `SexpReader` and `SexpWriter`.
+   */
+  def sexpFormat[T](reader: SexpReader[T], writer: SexpWriter[T]) = new SexpFormat[T] {
+    def write(obj: T) = writer.write(obj)
+    def read(json: Sexp) = reader.read(json)
+  }
+
+  implicit def sexpIdentityFormat[T <: Sexp: ClassTag] = new SexpFormat[T] {
+    def write(o: T) = o
+    def read(v: Sexp) = v match {
+      case t: T => t
+      case x => deserializationError(x)
+    }
+  }
+
+  // performance boilerplate
+  implicit val SexpFormat_ = SexpFormat[Sexp]
+  implicit val SexpConsFormat = SexpFormat[SexpCons]
+  implicit val SexpAtomFormat = SexpFormat[SexpAtom]
+  implicit val SexpStringFormat = SexpFormat[SexpString]
+  implicit val SexpNumberFormat = SexpFormat[SexpNumber]
+  implicit val SexpCharFormat = SexpFormat[SexpChar]
+  implicit val SexpSymbolFormat = SexpFormat[SexpSymbol]
+
+}

--- a/src/main/scala/org/ensime/sexp/formats/StandardFormats.scala
+++ b/src/main/scala/org/ensime/sexp/formats/StandardFormats.scala
@@ -1,0 +1,151 @@
+package org.ensime.sexp.formats
+
+import java.io.File
+import java.net.URI
+import java.net.URL
+import java.text.DateFormat
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.TimeZone
+import java.util.UUID
+import scala.util.Try
+
+import org.ensime.sexp._
+import org.ensime.util.ThreadLocalSupport
+
+/**
+ * Formats for data types that are so popular that you'd expect them
+ * to "just work".
+ *
+ * Most people might expect `Option[T]` to output `nil` for `None` and
+ * the instance for `Some`, but that doesn't round-trip for nested
+ * types (think of `Option[List[T]]`). Instead we use a one-element
+ * list. If you want to have the non-round-trip behaviour, mix in
+ * `OptionAltFormat`.
+ */
+trait StandardFormats extends ThreadLocalSupport {
+  import SexpFormatUtils._
+
+  implicit def optionFormat[T: SexpFormat]: SexpFormat[Option[T]] = new SexpFormat[Option[T]] {
+    def write(option: Option[T]) = option match {
+      case Some(x) => SexpList(x.toSexp)
+      case None => SexpNil
+    }
+    def read(value: Sexp) = value match {
+      case SexpNil => None
+      case SexpList(s) => Some(s.head.convertTo[T])
+      case x => deserializationError(x)
+    }
+  }
+
+  private val LeftS = SexpSymbol(":left")
+  private val RightS = SexpSymbol(":right")
+  implicit def eitherFormat[L: SexpFormat, R: SexpFormat]: SexpFormat[Either[L, R]] =
+    new SexpFormat[Either[L, R]] {
+      def write(either: Either[L, R]) = either match {
+        case Left(b) => SexpData(LeftS -> b.toSexp)
+        case Right(a) => SexpData(RightS -> a.toSexp)
+      }
+      def read(value: Sexp) = value match {
+        case SexpData(contents) =>
+          (contents.get(LeftS), contents.get(RightS)) match {
+            case (Some(left), None) => Left(left.convertTo[L])
+            case (None, Some(right)) => Right(right.convertTo[R])
+            case x => deserializationError(value)
+          }
+        case x => deserializationError(x)
+      }
+    }
+
+  trait ViaString[T] {
+    def toSexpString(t: T): String
+    def fromSexpString(s: String): T
+  }
+  def viaString[T](via: ViaString[T]): SexpFormat[T] = new SexpFormat[T] {
+    def write(t: T): Sexp = SexpString(via.toSexpString(t))
+    def read(v: Sexp): T = v match {
+      case SexpString(s) => via.fromSexpString(s)
+      case x => deserializationError(x)
+    }
+  }
+
+  implicit val UuidFormat: SexpFormat[UUID] = viaString(new ViaString[UUID] {
+    def toSexpString(uuid: UUID) = uuid.toString
+    def fromSexpString(s: String) = UUID.fromString(s)
+  })
+
+  // URL is intentionally discouraged in data objects because .equals
+  // calls out to the interwebz.
+  // implicit val UrlFormat: SexpFormat[URL] = viaString(new ViaString[URL] {
+  //   def toSexpString(url: URL) = url.toExternalForm
+  //   def fromSexpString(s: String) = new URL(s)
+  // })
+
+  implicit val UriFormat: SexpFormat[URI] = viaString(new ViaString[URI] {
+    def toSexpString(uri: URI) = uri.toASCIIString
+    def fromSexpString(s: String) = new URI(s)
+  })
+
+  /**
+   * If you want to canonise files, mix in the optional `CanonFileFormat`
+   */
+  implicit val FileFormat: SexpFormat[File] = viaString(new ViaString[File] {
+    def toSexpString(file: File) = file.getPath()
+    def fromSexpString(s: String) = new File(s)
+  })
+
+  /**
+   * Uses ISO_8601 which is well supported on the emacs side (we
+   * suspend belief about `Date`'s mutability). If you want to use
+   * UNIX epoch time, override with your own implementation.
+   */
+  implicit val DateFormat: SexpFormat[Date] = viaString(new ViaString[Date] {
+    private val localFormatter = local {
+      // SimpleDateFormat isn't ISO_8601 compliant on Java 6, for a discussion see
+      // http://stackoverflow.com/questions/2201925
+      val s = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssZ")
+      s.setTimeZone(TimeZone.getTimeZone("UTC"))
+      s
+    }
+    def toSexpString(date: Date) = {
+      val formatted = localFormatter.get.format(date)
+      formatted.substring(0, 22) + ":" + formatted.substring(22)
+    }
+    def fromSexpString(s: String) = {
+      val s1 = s.replace("Z", "+00:00")
+      val processed = s1.substring(0, 22) + s1.substring(23)
+      localFormatter.get.parse(processed)
+    }
+  })
+}
+
+trait CanonFileFormat {
+  this: StandardFormats =>
+
+  import org.ensime.util.RichFile._
+
+  /**
+   * Intentionally canonicalises, round trip will not always equal.
+   */
+  override implicit val FileFormat: SexpFormat[File] = viaString(new ViaString[File] {
+    def toSexpString(file: File) = file.canon.getPath()
+    def fromSexpString(s: String) = new File(s).canon
+  })
+}
+
+trait OptionAltFormat {
+  this: StandardFormats =>
+
+  override implicit def optionFormat[T: SexpFormat]: SexpFormat[Option[T]] =
+    new SexpFormat[Option[T]] {
+      def write(option: Option[T]) = option match {
+        case Some(x) => x.toSexp
+        case None => SexpNil
+      }
+      def read(value: Sexp) = value match {
+        case SexpNil => None
+        case x => Some(x.convertTo[T])
+      }
+    }
+
+}

--- a/src/main/scala/org/ensime/sexp/formats/package.scala
+++ b/src/main/scala/org/ensime/sexp/formats/package.scala
@@ -1,0 +1,8 @@
+package org.ensime.sexp
+
+package object formats {
+  def deserializationError(got: Sexp) =
+    throw new DeserializationException(s"Didn't expect a $got")
+  def serializationError(msg: String) = throw new SerializationException(msg)
+}
+

--- a/src/main/scala/org/ensime/sexp/package.scala
+++ b/src/main/scala/org/ensime/sexp/package.scala
@@ -1,0 +1,19 @@
+package org.ensime
+
+package object sexp {
+  implicit def pimpAny[T](any: T) = new PimpedAny(any)
+  implicit def pimpString(string: String) = new PimpedString(string)
+}
+
+package sexp {
+  class DeserializationException(msg: String, cause: Throwable = null) extends RuntimeException(msg, cause)
+  class SerializationException(msg: String) extends RuntimeException(msg)
+
+  private[sexp] class PimpedAny[T](any: T) {
+    def toSexp(implicit writer: SexpWriter[T]): Sexp = writer.write(any)
+  }
+
+  private[sexp] class PimpedString(string: String) {
+    def parseSexp: Sexp = SexpParser.parse(string)
+  }
+}

--- a/src/test/scala/org/ensime/config/EnsimeConfigSpec.scala
+++ b/src/test/scala/org/ensime/config/EnsimeConfigSpec.scala
@@ -19,10 +19,7 @@ class EnsimeConfigSpec extends FunSpec with Matchers {
   }
 
   def test(dir: File, contents: String, testFn: (EnsimeConfig) => Unit): Unit = {
-    val ensimeFile = dir / ".ensime"
-    writeToFile(contents, ensimeFile)
-    val config = Server.readEnsimeConfig(ensimeFile)
-    testFn(config)
+    testFn(EnsimeConfig.parse(contents))
   }
 
   describe("ProjectConfigSpec") {
@@ -88,7 +85,7 @@ class EnsimeConfigSpec extends FunSpec with Matchers {
           val module1 = config.modules("module1")
           assert(module1.name == "module1")
           assert(module1.dependencies.isEmpty)
-          assert(module1.targets.size === 1)
+          assert(module1.targetDirs.size === 1)
         })
       }
     }
@@ -102,6 +99,7 @@ class EnsimeConfigSpec extends FunSpec with Matchers {
 
           val dirStr = TestUtil.fileToWireString(dir)
           val cacheStr = TestUtil.fileToWireString(dir / ".ensime_cache")
+          val abcDirStr = TestUtil.fileToWireString(dir / "abc")
 
           test(dir, s"""
 (:name "project"
@@ -111,9 +109,9 @@ class EnsimeConfigSpec extends FunSpec with Matchers {
  :source-mode ${if (sourceMode) "t" else "nil"}
  :subprojects ((:name "module1"
                 :scala-version "2.10.4"
-                :targets ("abc"))))""", { implicit config =>
+                :targets (${abcDirStr}))))""", { implicit config =>
             assert(config.sourceMode == sourceMode)
-            assert(config.runtimeClasspath == Set(dir / "abc"))
+            assert(config.runtimeClasspath == Set(dir / "abc"), config)
             assert(config.compileClasspath == (
               if (sourceMode) Set.empty else Set(dir / "abc")
             ))

--- a/src/test/scala/org/ensime/config/ScalariformFormatSpec.scala
+++ b/src/test/scala/org/ensime/config/ScalariformFormatSpec.scala
@@ -1,0 +1,30 @@
+package org.ensime.config
+
+import org.ensime.sexp._
+import org.ensime.sexp.formats._
+
+import scalariform.formatter.preferences._
+
+class ScalariformFormatSpec extends FormatSpec {
+
+  object ScalariformProtocol extends DefaultSexpProtocol with ScalariformFormat
+  import ScalariformProtocol._
+
+  val prefs = FormattingPreferences().
+    setPreference(DoubleIndentClassDeclaration, true).
+    setPreference(IndentSpaces, 13)
+
+  it("should parse some example config") {
+    val text = """(:doubleIndentClassDeclaration t
+                     :indentSpaces 13)"""
+    val recover = text.parseSexp.convertTo[FormattingPreferences]
+    assert(recover.preferencesMap == prefs.preferencesMap)
+  }
+
+  it("should create valid output") {
+    assert(prefs.toSexp === SexpList(
+      SexpSymbol(":doubleIndentClassDeclaration"), SexpSymbol("t"),
+      SexpSymbol(":indentSpaces"), SexpNumber(13)
+    ))
+  }
+}

--- a/src/test/scala/org/ensime/indexer/SearchServiceSpec.scala
+++ b/src/test/scala/org/ensime/indexer/SearchServiceSpec.scala
@@ -22,11 +22,11 @@ class SearchServiceSpec extends FunSpec with Matchers with SLF4JLogging {
 
     // to reduce test time
     val trimmed = module.copy(
-      compileJars = Nil,
-      testJars = module.testJars filter (_.getName.contains("scalatest_"))
+      `compile-deps` = Nil,
+      `test-deps` = module.testJars filter (_.getName.contains("scalatest_"))
     )
     config.copy(
-      modules = Map(trimmed.name -> trimmed)
+      subprojects = List(trimmed)
     )
   }
 
@@ -53,7 +53,7 @@ class SearchServiceSpec extends FunSpec with Matchers with SLF4JLogging {
       val now = System.currentTimeMillis()
       for {
         m <- config.modules.values
-        r <- m.targets ++ m.testTargets
+        r <- m.targetDirs ++ m.testTargetDirs
         f <- r.tree
       } {
         // simulate a full recompile
@@ -67,7 +67,7 @@ class SearchServiceSpec extends FunSpec with Matchers with SLF4JLogging {
 
     it("should remove classfiles that have been deleted", SlowTest) {
       val module = config.modules.values.toList.head
-      val classfile = module.targets.head / "org/ensime/indexer/SearchService.class"
+      val classfile = module.targetDirs.head / "org/ensime/indexer/SearchService.class"
       assert(classfile.exists)
       classfile.delete()
       assert(refresh() === (1, 0))

--- a/src/test/scala/org/ensime/sexp/SexpCompactPrinterSpec.scala
+++ b/src/test/scala/org/ensime/sexp/SexpCompactPrinterSpec.scala
@@ -1,0 +1,37 @@
+package org.ensime.sexp
+
+import org.scalatest.FunSpec
+
+class SexpCompactPrinterSpec extends FunSpec {
+
+  private val foo = SexpString("foo")
+  private val foosym = SexpSymbol("foo")
+  private val barsym = SexpSymbol("bar")
+  private def assertPrinter(sexp: Sexp, expect: String): Unit = {
+    assert(SexpCompactPrinter(sexp) === expect)
+  }
+
+  describe("CompactPrinter") {
+    it("should handle nil or empty lists/data") {
+      assertPrinter(SexpNil, "nil")
+      assertPrinter(SexpList(Nil), "nil")
+    }
+
+    it("should output lists of atoms") {
+      assertPrinter(SexpList(foo, SexpNumber(13), foosym), """("foo" 13 foo)""")
+    }
+
+    it("should output lists of lists") {
+      assertPrinter(SexpList(SexpList(foo), SexpList(foo)), """(("foo") ("foo"))""")
+    }
+
+    it("should output cons") {
+      assertPrinter(SexpCons(foosym, barsym), "(foo . bar)")
+    }
+
+    it("should output escaped characters") {
+      assertPrinter(SexpString("""C:\my\folder"""), """"C:\\my\\folder"""")
+    }
+
+  }
+}

--- a/src/test/scala/org/ensime/sexp/SexpParserCheck.scala
+++ b/src/test/scala/org/ensime/sexp/SexpParserCheck.scala
@@ -1,0 +1,80 @@
+package org.ensime.sexp
+
+import org.scalacheck.Arbitrary
+import org.scalacheck.Gen
+import org.scalatest.FunSpec
+import org.scalatest.prop.GeneratorDrivenPropertyChecks
+
+class SexpParserCheck extends FunSpec
+    with GeneratorDrivenPropertyChecks
+    with ArbitrarySexp {
+
+  import SexpParser.parse
+
+  it("should round-trip Sexp <=> String") {
+    forAll { (sexp: Sexp) =>
+      val compact = SexpCompactPrinter(sexp)
+      //println(compact)
+      val pretty = SexpPrettyPrinter(sexp)
+      // it might be worthwhile creating a test-only printer that adds
+      // superfluous whitespace/comments
+
+      assert(parse(compact) === sexp, compact)
+      assert(parse(pretty) === sexp, pretty)
+    }
+  }
+}
+
+trait ArbitrarySexp {
+
+  import org.scalacheck.Arbitrary._
+  import org.scalacheck.Gen._
+
+  // avoid stackoverflows with http://stackoverflow.com/questions/19829293
+
+  lazy val genSexpSymbol: Gen[SexpSymbol] =
+    alphaStr.filter(_.nonEmpty).map(SexpSymbol(_))
+
+  lazy val genSexpKey: Gen[SexpSymbol] =
+    alphaStr.filter(_.nonEmpty).map { s => SexpSymbol(":" + s) }
+
+  // TODO: String/Char should be selected from a wider range
+  // TODO: arbitrary[BigDecimal] but it freezes the tests
+  // TODO: cons in SexpCons car, but it dramatically slows things
+  lazy val genSexpAtom: Gen[SexpAtom] = oneOf(
+    alphaNumChar.map(SexpChar(_)),
+    alphaStr.map(SexpString(_)),
+    genSexpSymbol,
+    arbitrary[Double].map(SexpNumber(_)),
+    //arbitrary[BigDecimal].map(SexpNumber(_)),
+    oneOf(SexpNil, SexpPosInf, SexpNegInf, SexpNaN)
+  )
+
+  def genSexpCons(level: Int): Gen[SexpCons] =
+    for {
+      car <- genSexpAtom
+      cdr <- genSexp(level + 1)
+    } yield SexpCons(car, cdr)
+
+  def genSexpList(level: Int): Gen[Sexp] =
+    nonEmptyListOf(genSexp(level + 1)).map(SexpList(_))
+
+  def genSexpData(level: Int): Gen[Sexp] =
+    mapOfN(2, zip(genSexpKey, genSexp(level + 1))).map {
+      kvs => SexpData(kvs.toList)
+    }
+
+  // our parser is soooo slow for deep trees
+  def genSexp(level: Int): Gen[Sexp] =
+    if (level >= 4) genSexpAtom
+    else lzy {
+      oneOf(
+        genSexpAtom,
+        genSexpCons(level + 1),
+        genSexpList(level + 1),
+        genSexpData(level + 1)
+      )
+    }
+
+  implicit def arbSexp: Arbitrary[Sexp] = Arbitrary(genSexp(0))
+}

--- a/src/test/scala/org/ensime/sexp/SexpParserSpec.scala
+++ b/src/test/scala/org/ensime/sexp/SexpParserSpec.scala
@@ -1,0 +1,98 @@
+package org.ensime.sexp
+
+import com.google.common.base.Charsets
+import com.google.common.io.Files
+import org.scalatest.FunSpec
+import org.scalatest.Matchers
+import scala.util.Properties.userHome
+import pimpathon.file._
+import pimpathon.java.io.outputStream
+import pimpathon.java.io.inputStream
+
+class SexpParserSpec extends FunSpec with Matchers {
+  import SexpParser.{ parse, flatParse }
+
+  val foo = SexpString("foo")
+  val bar = SexpString("bar")
+  val one = SexpNumber(1)
+  val negtwo = SexpNumber(-2)
+  val pi = SexpNumber("3.14")
+  val fourexp = SexpNumber("4e+16")
+  val foosym = SexpSymbol("foo")
+  val barsym = SexpSymbol("bar")
+  val fookey = SexpSymbol(":foo")
+  val barkey = SexpSymbol(":bar")
+
+  describe("PimpedString") {
+    it("should use the parser") {
+      import org.ensime.sexp._
+      assert("nil".parseSexp === SexpNil)
+    }
+  }
+
+  describe("Sexp Parser") {
+    ignore("should parse my .emacs") {
+      // a good source of corner cases!
+      val dotemacs = file(userHome + "/.emacs")
+      val contents = Files.toString(dotemacs, Charsets.UTF_8)
+      println(flatParse(contents).prettyPrint)
+      //println(flatParse(contents).compactPrint)
+      //println(flatParse(contents).toBasic)
+    }
+
+    it("should parse nil") {
+      assert(parse("nil") === SexpNil)
+      assert(parse("()") === SexpNil)
+      assert(parse("( )") === SexpNil)
+      assert(parse("(;blah\n)") === SexpNil)
+    }
+
+    it("should parse lists of strings") {
+      assert(parse("""("foo" "bar")""") === SexpList(foo, bar))
+    }
+
+    it("should parse escaped chars in strings") {
+      assert(parse(""""z \\ \" \t \\t \\\t x\ x"""") === SexpString("z \\ \" \t \\t \\\t xx"))
+
+      assert(parse(""""C:\\my\\folder"""") === SexpString("""C:\my\folder"""))
+    }
+
+    it("should parse lists of chars") {
+      assert(parse("""(?f ?b)""") === SexpList(SexpChar('f'), SexpChar('b')))
+    }
+
+    it("should parse lists of symbols") {
+      assert(parse("(foo bar is?)") === SexpList(foosym, barsym, SexpSymbol("is?")))
+    }
+
+    it("should parse lists of numbers") {
+      assert(parse("(1 -2 3.14 4e+16)") === SexpList(one, negtwo, pi, fourexp))
+    }
+
+    it("should parse NaN") {
+      assert(parse("0.0e+NaN") === SexpNaN)
+      assert(parse("-0.0e+NaN") === SexpNaN)
+    }
+
+    it("should parse infinity") {
+      assert(parse("1.0e+INF") === SexpPosInf)
+      assert(parse("-1.0e+INF") === SexpNegInf)
+    }
+
+    it("should parse lists within lists") {
+      assert(parse("""((foo))""") === SexpList(SexpList(foosym)))
+      assert(parse("""((foo) foo)""") === SexpList(SexpList(foosym), foosym))
+    }
+
+    it("should parse quoted expressions") {
+      assert(parse("""'(:foo "foo" :bar "bar")""") ===
+        SexpCons(SexpSymbol("quote"), SexpList(fookey, foo, barkey, bar)))
+
+      assert(parse("'foo") === SexpCons(SexpSymbol("quote"), foosym))
+    }
+
+    it("should parse cons") {
+      assert(parse("(foo . bar)") === SexpCons(foosym, barsym))
+    }
+  }
+}

--- a/src/test/scala/org/ensime/sexp/SexpPrettyPrinterSpec.scala
+++ b/src/test/scala/org/ensime/sexp/SexpPrettyPrinterSpec.scala
@@ -1,0 +1,64 @@
+package org.ensime.sexp
+
+import org.scalatest.FunSpec
+
+class SexpPrettyPrinterSpec extends FunSpec {
+
+  private val foo = SexpString("foo")
+  private val foosym = SexpSymbol("foo")
+  private val barsym = SexpSymbol("bar")
+  private val fookey = SexpSymbol(":foo")
+  private val barkey = SexpSymbol(":bar")
+  private def assertPrinter(sexp: Sexp, expect: String): Unit = {
+    //    println("GOT\n" + SexpPrettyPrinter(sexp))
+    //    println("EXPECT\n" + expect)
+    assert(SexpPrettyPrinter(sexp) === expect.replace("\r", ""))
+  }
+
+  describe("CompactPrinter") {
+    it("should handle nil or empty lists/data") {
+      assertPrinter(SexpNil, "nil")
+      assertPrinter(SexpList(Nil), "nil")
+    }
+
+    it("should output lists of atoms") {
+      assertPrinter(SexpList(foo, SexpNumber(13), foosym),
+        """("foo"
+          |  13
+          |  foo)""".stripMargin)
+    }
+
+    it("should output lists of lists") {
+      assertPrinter(SexpList(SexpList(foo), SexpList(foo)),
+        """(("foo")
+          |  ("foo"))""".stripMargin)
+    }
+
+    it("should output data") {
+      assertPrinter(SexpData(fookey -> foosym, barkey -> foosym),
+        """(
+  :foo foo
+  :bar foo
+)""")
+
+      val datum = SexpData(fookey -> foo, barkey -> foo)
+      assertPrinter(SexpData(
+        fookey -> datum,
+        barkey -> datum), """(
+  :foo (
+    :foo "foo"
+    :bar "foo"
+  )
+  :bar (
+    :foo "foo"
+    :bar "foo"
+  )
+)""")
+    }
+
+    it("should output cons") {
+      assertPrinter(SexpCons(foosym, barsym), "(foo .\n  bar)")
+    }
+
+  }
+}

--- a/src/test/scala/org/ensime/sexp/SexpSpec.scala
+++ b/src/test/scala/org/ensime/sexp/SexpSpec.scala
@@ -1,0 +1,93 @@
+package org.ensime.sexp
+
+import org.scalatest._
+
+class SexpSpec extends FunSpec with Matchers {
+
+  val foostring = SexpString("foo")
+  val barstring = SexpString("bar")
+  val foosym = SexpSymbol("foo")
+  val barsym = SexpSymbol("bar")
+  val fookey = SexpSymbol(":foo")
+  val barkey = SexpSymbol(":bar")
+
+  describe("SexpList") {
+    it("should create from varargs") {
+      assert(SexpList(foosym, barsym) === SexpList(List(foosym, barsym)))
+    }
+
+    it("should unroll as basic") {
+      assert(SexpList(Nil) === SexpNil)
+
+      assert(SexpList(foosym) ===
+        SexpCons(foosym, SexpNil))
+
+      assert(SexpList(foosym, barsym) ===
+        SexpCons(foosym, SexpCons(barsym, SexpNil)))
+    }
+
+    it("should match lists") {
+      SexpCons(foosym, SexpNil) match {
+        case SexpList(els) if els == List(foosym) =>
+        case _ => fail
+      }
+      SexpCons(foosym, SexpCons(barsym, SexpNil)) match {
+        case SexpList(els) if els == List(foosym, barsym) =>
+        case _ => fail
+      }
+      SexpNil match {
+        case SexpList(_) => fail
+        case _ =>
+      }
+    }
+  }
+
+  describe("SexpData") {
+    it("should create from varargs") {
+      assert(SexpData(
+        fookey -> barsym,
+        barkey -> foosym
+      ) === SexpList(
+          fookey, barsym,
+          barkey, foosym
+        ))
+    }
+
+    it("should unroll as basic") {
+      assert(SexpData(
+        fookey -> barsym,
+        barkey -> foosym
+      ) === SexpCons(
+          fookey, SexpCons(
+            barsym, SexpCons(
+              barkey, SexpCons(
+                foosym, SexpNil)))))
+    }
+
+    it("should match SexpData") {
+      SexpCons(
+        fookey, SexpCons(
+          barsym, SexpCons(
+            barkey, SexpCons(
+              foosym, SexpNil)))) match {
+          case SexpData(kvs) if kvs.size == 2 =>
+          case _ => fail
+        }
+
+      SexpNil match {
+        case SexpData(_) => fail
+        case _ =>
+      }
+    }
+  }
+
+  describe("SexpCons") {
+    it("should unroll as fully basic") {
+      val a = SexpList(foosym)
+      val b = SexpList(barsym)
+      assert(SexpCons(a, b) ===
+        SexpCons(SexpCons(foosym, SexpNil), SexpCons(barsym, SexpNil))
+      )
+    }
+  }
+}

--- a/src/test/scala/org/ensime/sexp/formats/BasicFormatsSpec.scala
+++ b/src/test/scala/org/ensime/sexp/formats/BasicFormatsSpec.scala
@@ -1,0 +1,82 @@
+package org.ensime.sexp.formats
+
+import org.scalatest.FunSpec
+import org.scalatest.Matchers
+import org.ensime.sexp._
+
+trait FormatSpec extends FunSpec {
+  val foo = SexpString("foo")
+  val bar = SexpSymbol("bar")
+
+  import org.ensime.sexp.pimpAny
+  def assertFormat[T: SexpFormat](start: T, expect: Sexp): Unit = {
+    assert(start.toSexp === expect)
+    assert(expect.convertTo[T] === start)
+  }
+}
+
+class BasicFormatsSpec extends FormatSpec with BasicFormats {
+  describe("BasicFormats") {
+    it("should support Int") {
+      assertFormat(13, SexpNumber(13))
+      assertFormat(-1, SexpNumber(-1))
+      assertFormat(0, SexpNumber(0))
+      assertFormat(Int.MaxValue, SexpNumber(Int.MaxValue))
+      assertFormat(Int.MinValue, SexpNumber(Int.MinValue))
+    }
+
+    it("should support Long") {
+      assertFormat(13L, SexpNumber(13))
+      assertFormat(-1L, SexpNumber(-1))
+      assertFormat(0L, SexpNumber(0))
+      assertFormat(Long.MaxValue, SexpNumber(Long.MaxValue))
+      assertFormat(Long.MinValue, SexpNumber(Long.MinValue))
+    }
+
+    it("should support Float") {
+      assertFormat(13.0f, SexpNumber(13.0f))
+      assertFormat(-1.0f, SexpNumber(-1.0f))
+      assertFormat(0.0f, SexpNumber(0.0f))
+      assertFormat(Float.MaxValue, SexpNumber(Float.MaxValue))
+      assertFormat(Float.MinValue, SexpNumber(Float.MinValue))
+      assertFormat(Float.NegativeInfinity, SexpNegInf)
+      assertFormat(Float.PositiveInfinity, SexpPosInf)
+
+      // remember NaN != NaN
+      assert(Float.NaN.toSexp === SexpNaN)
+      assert(SexpNaN.convertTo[Float].isNaN)
+    }
+
+    it("should support Double") {
+      assertFormat(13.0d, SexpNumber(13.0d))
+      assertFormat(-1.0d, SexpNumber(-1.0d))
+      assertFormat(0.0d, SexpNumber(0.0d))
+      assertFormat(Double.MaxValue, SexpNumber(Double.MaxValue))
+      assertFormat(Double.MinValue, SexpNumber(Double.MinValue))
+      assertFormat(Double.NegativeInfinity, SexpNegInf)
+      assertFormat(Double.PositiveInfinity, SexpPosInf)
+
+      // remember NaN != NaN
+      assert(Double.NaN.toSexp === SexpNaN)
+      assert(SexpNaN.convertTo[Double].isNaN)
+    }
+
+    it("should support Boolean") {
+      assertFormat(true, SexpSymbol("t"))
+      assertFormat(false, SexpNil)
+    }
+
+    it("should support Char") {
+      assertFormat('t', SexpChar('t'))
+    }
+
+    it("should support Unit") {
+      assertFormat((), SexpNil)
+    }
+
+    it("should support Symbol") {
+      assertFormat('blah, SexpString("blah"))
+    }
+  }
+
+}

--- a/src/test/scala/org/ensime/sexp/formats/BigIntConvertorSpec.scala
+++ b/src/test/scala/org/ensime/sexp/formats/BigIntConvertorSpec.scala
@@ -1,0 +1,58 @@
+package org.ensime.sexp.formats
+
+import BigIntConvertor._
+import org.scalacheck.{ Arbitrary, Gen }
+import org.scalatest._
+import org.scalatest.prop.GeneratorDrivenPropertyChecks
+import scala.collection.immutable.BitSet
+
+class BigIntConvertorSpec extends FunSpec {
+  private val examples = List(
+    BitSet() -> BigInt(0),
+    BitSet(0) -> BigInt(1),
+    BitSet(1) -> BigInt(2),
+    BitSet(64) -> BigInt("18446744073709551616"),
+    BitSet(0, 64) -> BigInt("18446744073709551617"),
+    BitSet(1, 64) -> BigInt("18446744073709551618")
+  )
+
+  it("should convert basic BigSet to BitInt") {
+    examples foreach {
+      case (bitset, bigint) => assert(fromBitSet(bitset) === bigint)
+    }
+  }
+
+  it("should convert basic BigInt to BitSet") {
+    examples foreach {
+      case (bitset, bigint) => assert(toBitSet(bigint) === bitset)
+    }
+  }
+}
+
+class BigIntConvertorCheck extends FunSpec with GeneratorDrivenPropertyChecks {
+
+  def positiveIntStream: Arbitrary[Stream[Int]] = Arbitrary {
+    Gen.containerOf[Stream, Int](Gen.chooseNum(0, 2 * Short.MaxValue))
+  }
+
+  implicit def arbitraryBitSet: Arbitrary[BitSet] = Arbitrary {
+    for (seq <- positiveIntStream.arbitrary) yield BitSet(seq: _*)
+  }
+
+  it("should round-trip BigInt <=> BitSet") {
+    forAll { (bigint: BigInt) =>
+      whenever(bigint >= 0) {
+        // the exact rules for which negative numbers are allowed
+        // seems to be quite complex, but certainly it is sometimes
+        // valid.
+        assert(fromBitSet(toBitSet(bigint)) === bigint)
+      }
+    }
+  }
+
+  it("should round-trip BitSet <=> BigInt") {
+    forAll { (bitset: BitSet) =>
+      assert(toBitSet(fromBitSet(bitset)) === bitset)
+    }
+  }
+}

--- a/src/test/scala/org/ensime/sexp/formats/CollectionFormatsSpec.scala
+++ b/src/test/scala/org/ensime/sexp/formats/CollectionFormatsSpec.scala
@@ -1,0 +1,171 @@
+
+package org.ensime.sexp.formats
+
+import collection.{ immutable => im, mutable => mut }
+
+import org.ensime.sexp._
+import collection.generic.CanBuildFrom
+import collection.breakOut
+
+// http://docs.scala-lang.org/overviews/collections/overview.html
+class CollectionFormatsSpec extends FormatSpec
+    with ProductFormats with CollectionFormats with BasicFormats {
+
+  val foos: List[String] = List("foo", "foo")
+  val expect = SexpList(foo, foo)
+
+  describe("CollectionFormats traits") {
+    it("should support Traversable") {
+      assertFormat(collection.Traversable[String](), SexpNil)
+      assertFormat(collection.Traversable(foos: _*), expect)
+    }
+
+    it("should support Iterable") {
+      assertFormat(collection.Iterable[String](), SexpNil)
+      assertFormat(collection.Iterable(foos: _*), expect)
+    }
+
+    it("should support Seq") {
+      assertFormat(collection.Seq[String](), SexpNil)
+      assertFormat(collection.Seq(foos: _*), expect)
+    }
+
+    it("should support IndexedSeq") {
+      assertFormat(collection.IndexedSeq[String](), SexpNil)
+      assertFormat(collection.IndexedSeq(foos: _*), expect)
+    }
+
+    it("should support LinearSeq") {
+      assertFormat(collection.LinearSeq[String](), SexpNil)
+      assertFormat(collection.LinearSeq(foos: _*), expect)
+    }
+
+    it("should support Set") {
+      assertFormat(collection.Set[String](), SexpNil)
+      assertFormat(collection.Set(foos: _*), SexpList(foo)) // dupes removed
+    }
+
+    it("should support SortedSet") {
+      assertFormat(collection.SortedSet[String](), SexpNil)
+      assertFormat(collection.SortedSet(foos: _*), SexpList(foo)) // dupes removed
+    }
+
+    it("should support BitSet") {
+      assertFormat(collection.BitSet(), SexpNil)
+      assertFormat(collection.BitSet(0, 1), SexpString("16#3"))
+      assertFormat(collection.BitSet(64), SexpString("16#10000000000000000"))
+      assertFormat(collection.BitSet(0, 64), SexpString("16#10000000000000001"))
+      assertFormat(collection.BitSet(1, 64), SexpString("16#10000000000000002"))
+    }
+
+    it("should support Map") {
+      assertFormat(collection.Map[String, String](), SexpNil)
+      assertFormat(collection.Map("foo" -> "foo"), SexpList(SexpList(foo, foo)))
+    }
+
+    it("should support SortedMap") {
+      assertFormat(collection.SortedMap[String, String](), SexpNil)
+      assertFormat(collection.SortedMap("foo" -> "foo"), SexpList(SexpList(foo, foo)))
+    }
+  }
+
+  describe("CollectionFormats immutable variants of the traits") {
+    it("should support Traversable") {
+      assertFormat(im.Traversable[String](), SexpNil)
+      assertFormat(im.Traversable(foos: _*), expect)
+    }
+
+    it("should support Iterable") {
+      assertFormat(im.Iterable[String](), SexpNil)
+      assertFormat(im.Iterable(foos: _*), expect)
+    }
+
+    it("should support Seq") {
+      assertFormat(im.Seq[String](), SexpNil)
+      assertFormat(im.Seq(foos: _*), expect)
+    }
+
+    it("should support IndexedSeq") {
+      assertFormat(im.IndexedSeq[String](), SexpNil)
+      assertFormat(im.IndexedSeq(foos: _*), expect)
+    }
+
+    it("should support LinearSeq") {
+      assertFormat(im.LinearSeq[String](), SexpNil)
+      assertFormat(im.LinearSeq(foos: _*), expect)
+    }
+
+    it("should support Set") {
+      assertFormat(im.Set[String](), SexpNil)
+      assertFormat(im.Set(foos: _*), SexpList(foo)) // dupes removed
+    }
+
+    it("should support SortedSet") {
+      assertFormat(im.SortedSet[String](), SexpNil)
+      assertFormat(im.SortedSet(foos: _*), SexpList(foo)) // dupes removed
+    }
+
+    it("should support BitSet") {
+      assertFormat(im.BitSet(), SexpNil)
+      assertFormat(im.BitSet(0, 1), SexpString("16#3"))
+      assertFormat(collection.BitSet(64), SexpString("16#10000000000000000"))
+      assertFormat(collection.BitSet(0, 64), SexpString("16#10000000000000001"))
+      assertFormat(collection.BitSet(1, 64), SexpString("16#10000000000000002"))
+    }
+
+    it("should support Map") {
+      assertFormat(im.Map[String, String](), SexpNil)
+      assertFormat(im.Map("foo" -> "foo"), SexpList(SexpList(foo, foo)))
+    }
+
+    it("should support SortedMap") {
+      assertFormat(im.SortedMap[String, String](), SexpNil)
+      assertFormat(im.SortedMap("foo" -> "foo"), SexpList(SexpList(foo, foo)))
+    }
+  }
+
+  describe("CollectionFormats immutable specific implementations") {
+    it("should support im.List") {
+      assertFormat(im.List[String](), SexpNil)
+      assertFormat(im.List(foos: _*), expect)
+    }
+
+    it("should support im.Vector") {
+      assertFormat(im.Vector[String](), SexpNil)
+      assertFormat(im.Vector(foos: _*), expect)
+    }
+
+    it("should support im.Range") {
+      assertFormat(im.Range(-100, 100),
+        SexpList(
+          SexpSymbol(":start"), SexpNumber(-100),
+          SexpSymbol(":end"), SexpNumber(100),
+          SexpSymbol(":step"), SexpNumber(1)))
+
+      assertFormat(im.Range(-100, 100, 2),
+        SexpList(
+          SexpSymbol(":start"), SexpNumber(-100),
+          SexpSymbol(":end"), SexpNumber(100),
+          SexpSymbol(":step"), SexpNumber(2)))
+    }
+
+    it("should support im.NumericRange") {
+      implicit val DoubleIntegral = Numeric.DoubleAsIfIntegral
+
+      assertFormat(-100.0 to 100.0 by 1.5,
+        SexpData(
+          SexpSymbol(":start") -> SexpNumber(-100),
+          SexpSymbol(":end") -> SexpNumber(100),
+          SexpSymbol(":step") -> SexpNumber(1.5),
+          SexpSymbol(":inclusive") -> SexpSymbol("t")))
+
+      assertFormat(-100.0 until 100.0 by 1.5,
+        SexpData(
+          SexpSymbol(":start") -> SexpNumber(-100),
+          SexpSymbol(":end") -> SexpNumber(100),
+          SexpSymbol(":step") -> SexpNumber(1.5),
+          SexpSymbol(":inclusive") -> SexpNil))
+    }
+
+  }
+}

--- a/src/test/scala/org/ensime/sexp/formats/DefaultSexpProtocolSpec.scala
+++ b/src/test/scala/org/ensime/sexp/formats/DefaultSexpProtocolSpec.scala
@@ -1,0 +1,50 @@
+package org.ensime.sexp.formats
+
+import org.ensime.sexp._
+
+// these are a sort of aggregated test, investigating behaviours of
+// interactions between the different formats.
+class DefaultSexpProtocolSpec extends FormatSpec {
+
+  describe("DefaultSexpProtocol") {
+    import DefaultSexpProtocol._
+
+    it("should support String as SexpString, not via IsTraversableLike") {
+      assertFormat("hello", SexpString("hello"))
+    }
+
+    it("should round-trip Option[List[T]]") {
+      val none: Option[List[String]] = None
+      val empty: Option[List[String]] = Some(Nil)
+      val list: Option[List[String]] = Some(List("boo"))
+
+      assertFormat(none, SexpNil)
+      assertFormat(empty, SexpList(SexpNil))
+      assertFormat(list, SexpList(SexpList(SexpString("boo"))))
+      assert(SexpNil.convertTo[Option[List[String]]] === None)
+      assert(SexpNil.convertTo[List[Option[String]]] === Nil)
+    }
+  }
+
+  describe("DefaultSexpProtocol with OptionAltFormat") {
+    object AlternativeProtocol extends DefaultSexpProtocol with OptionAltFormat
+    import AlternativeProtocol._
+
+    it("should predictably fail to round-trip Option[List[T]]") {
+
+      val none: Option[List[String]] = None
+      val empty: Option[List[String]] = Some(Nil)
+      val list: Option[List[String]] = Some(List("boo"))
+
+      assert(none.toSexp === SexpNil)
+      assert(empty.toSexp === SexpNil)
+      assert(list.toSexp === SexpList(SexpString("boo")))
+
+      assert(SexpNil.convertTo[Option[List[String]]] === None)
+
+      // and Lists of Options give empty lists, muahahaha
+      assert(SexpNil.convertTo[List[Option[String]]] === Nil)
+    }
+
+  }
+}

--- a/src/test/scala/org/ensime/sexp/formats/ExampleAst.scala
+++ b/src/test/scala/org/ensime/sexp/formats/ExampleAst.scala
@@ -1,0 +1,52 @@
+package org.ensime.sexp.formats
+
+/**
+ * An example Abstract Syntax Tree / family.
+ */
+object ExampleAst {
+  sealed trait Token {
+    val text: String
+  }
+
+  sealed trait RawToken extends Token
+  case class Split(text: String) extends RawToken
+  case class And(text: String) extends RawToken
+  case class Or(text: String) extends RawToken
+
+  sealed trait ContextualMarker extends RawToken
+  case class Like(text: String) extends ContextualMarker
+  case class Prefer(text: String) extends ContextualMarker
+  case class Negate(text: String) extends ContextualMarker
+
+  sealed trait TokenTree extends Token
+  sealed trait ContextualToken extends TokenTree
+  sealed trait CompressedToken extends TokenTree
+  case class Unparsed(text: String) extends TokenTree
+  case class AndCondition(left: TokenTree, right: TokenTree, text: String) extends TokenTree
+  case class OrCondition(left: TokenTree, right: TokenTree, text: String) extends TokenTree
+
+  case class Ignored(text: String = "") extends TokenTree
+  case class Unclear(text: String = "") extends TokenTree
+
+  sealed trait Term extends TokenTree {
+    val field: DatabaseField
+  }
+
+  case class DatabaseField(column: String)
+  case class FieldTerm(text: String, field: DatabaseField, value: String) extends Term
+  case class BoundedTerm(
+    text: String,
+    field: DatabaseField,
+    low: Option[String] = None,
+    high: Option[String] = None,
+    inclusive: Boolean = false) extends Term
+  case class LikeTerm(term: FieldTerm, like: Option[Like]) extends Term {
+    val text = like.map(_.text).getOrElse("")
+    val field = term.field
+  }
+  case class PreferToken(tree: TokenTree, before: Option[Prefer], after: Option[Prefer]) extends TokenTree {
+    val text = before.getOrElse("") + tree.text + after.getOrElse("")
+  }
+  case class InTerm(field: DatabaseField, value: List[String], text: String = "") extends CompressedToken
+  case class QualifierToken(text: String, field: DatabaseField) extends ContextualToken with Term
+}

--- a/src/test/scala/org/ensime/sexp/formats/FamilyFormatsSpec.scala
+++ b/src/test/scala/org/ensime/sexp/formats/FamilyFormatsSpec.scala
@@ -1,0 +1,108 @@
+package org.ensime.sexp.formats
+
+import org.ensime.sexp._
+import shapeless.LabelledGeneric
+
+class FamilyFormatsSpec extends FormatSpec with FamilyFormats {
+
+  case object Bloo
+
+  describe("FamilyFormats") {
+    // it("should support case objects") {
+    //   assertFormat(Bloo, SexpSymbol(Bloo.getClass.getName))
+    // }
+
+    it("should support an example AST") {
+      import DefaultSexpProtocol._
+      import ExampleAst._
+
+      // performance improvement - avoids creating afresh at each call
+      // site (only possible for the non-recursive classes)
+      // implicit val FieldTermF = SexpFormat[FieldTerm]
+      // implicit val BoundedTermF = SexpFormat[BoundedTerm]
+      // implicit val UnparsedF = SexpFormat[Unparsed]
+      // implicit val IgnoredF = SexpFormat[Ignored]
+      // implicit val UnclearF = SexpFormat[Unclear]
+      // implicit val InTermF = SexpFormat[InTerm]
+      // implicit val LikeTermF = SexpFormat[LikeTerm]
+      // implicit val QualifierTokenF = SexpFormat[QualifierToken]
+
+      /////////////////// START OF BOILERPLATE /////////////////
+      implicit object TokenTreeFormat extends TraitFormat[TokenTree] {
+        // get a performance improvement by creating as many implicit vals
+        // for TypeHint[T] as possible, e.g.
+        // implicit val FieldTermTH = typehint[FieldTerm]
+        // implicit val BoundedTermTH = typehint[BoundedTerm]
+        // implicit val UnparsedTH = typehint[Unparsed]
+        // implicit val IgnoredTH = typehint[Ignored]
+        // implicit val UnclearTH = typehint[Unclear]
+        // implicit val InTermTH = typehint[InTerm]
+        // implicit val LikeTermTH = typehint[LikeTerm]
+        // implicit val OrConditionTH = typehint[OrCondition]
+        // implicit val AndConditionTH = typehint[AndCondition]
+        // implicit val PreferTokenTH = typehint[PreferToken]
+        // implicit val QualifierTokenTH = typehint[QualifierToken]
+
+        def write(obj: TokenTree): Sexp = obj match {
+          case f: FieldTerm => wrap(f)
+          case b: BoundedTerm => wrap(b)
+          case u: Unparsed => wrap(u)
+          case i: Ignored => wrap(i)
+          case u: Unclear => wrap(u)
+          case i: InTerm => wrap(i)
+          case like: LikeTerm => wrap(like)
+          case a: AndCondition => wrap(a)
+          case o: OrCondition => wrap(o)
+          case prefer: PreferToken => wrap(prefer)
+          case q: QualifierToken => wrap(q)
+        }
+
+        def read(hint: SexpSymbol, value: Sexp): TokenTree = hint match {
+          case s if s == implicitly[TypeHint[FieldTerm]].hint => value.convertTo[FieldTerm]
+          case s if s == implicitly[TypeHint[BoundedTerm]].hint => value.convertTo[BoundedTerm]
+          case s if s == implicitly[TypeHint[Unparsed]].hint => value.convertTo[Unparsed]
+          case s if s == implicitly[TypeHint[Ignored]].hint => value.convertTo[Ignored]
+          case s if s == implicitly[TypeHint[Unclear]].hint => value.convertTo[Unclear]
+          case s if s == implicitly[TypeHint[InTerm]].hint => value.convertTo[InTerm]
+          case s if s == implicitly[TypeHint[LikeTerm]].hint => value.convertTo[LikeTerm]
+          case s if s == implicitly[TypeHint[AndCondition]].hint => value.convertTo[AndCondition]
+          case s if s == implicitly[TypeHint[OrCondition]].hint => value.convertTo[OrCondition]
+          case s if s == implicitly[TypeHint[PreferToken]].hint => value.convertTo[PreferToken]
+          case s if s == implicitly[TypeHint[QualifierToken]].hint => value.convertTo[QualifierToken]
+          // SAD FACE --- compiler doesn't catch typos on matches or missing impls
+          case _ => deserializationError(hint)
+        }
+      }
+      /////////////////// END OF BOILERPLATE /////////////////
+
+      val fieldTerm = FieldTerm("thing is ten", DatabaseField("THING"), "10")
+      val expectField = SexpData(
+        SexpSymbol(":text") -> SexpString("thing is ten"),
+        SexpSymbol(":field") -> SexpData(
+          SexpSymbol(":column") -> SexpString("THING")),
+        SexpSymbol(":value") -> SexpString("10"))
+
+      // confirm that the wrapper is picked up for a specific case class
+      assertFormat(fieldTerm, expectField)
+
+      val expectFieldTree = SexpData(SexpSymbol(":FieldTerm") -> expectField)
+
+      // confirm that the trait level formatter works
+      assertFormat(fieldTerm: TokenTree, expectFieldTree)
+
+      // confirm recursive works
+      val and = AndCondition(fieldTerm, fieldTerm, "wibble")
+      val expectAnd = SexpData(
+        SexpSymbol(":left") -> expectFieldTree,
+        SexpSymbol(":right") -> expectFieldTree,
+        SexpSymbol(":text") -> SexpString("wibble")
+      )
+      assertFormat(and, expectAnd)
+
+      val expectAndTree = SexpData(SexpSymbol(":AndCondition") -> expectAnd)
+
+      // and that the recursive type works as a trait
+      assertFormat(and: TokenTree, expectAndTree)
+    }
+  }
+}

--- a/src/test/scala/org/ensime/sexp/formats/ProductFormatsSpec.scala
+++ b/src/test/scala/org/ensime/sexp/formats/ProductFormatsSpec.scala
@@ -1,0 +1,94 @@
+package org.ensime.sexp.formats
+
+import org.ensime.sexp._
+
+import shapeless._
+
+class ProductFormatsSpec extends FormatSpec
+    with BasicFormats with StandardFormats with ProductFormats {
+
+  case class Foo(i: Int, s: String)
+  case class Bar(foo: Foo)
+  case class Baz()
+  case class Wibble(thing: String, thong: Int, bling: Option[String])
+
+  // describe("ProductFormats case classes") {
+  //   val foo = Foo(13, "foo")
+  //   val fooexpect = SexpData(
+  //     SexpSymbol(":i") -> SexpNumber(13),
+  //     SexpSymbol(":s") -> SexpString("foo")
+  //   )
+
+  //   it("should support primitive types") {
+  //     // will create the marshaller every time assertFormat is called
+  //     assertFormat(foo, fooexpect)
+  //     assertFormat(foo, fooexpect)
+  //     assertFormat(foo, fooexpect)
+  //   }
+
+  //   it("should support 'fast' case classes") {
+  //     // can't really test - its a side effect optimisation
+  //     implicit val FastFooFormat = SexpFormat[Foo]
+  //     assertFormat(foo, fooexpect)
+  //     assertFormat(foo, fooexpect)
+  //     assertFormat(foo, fooexpect)
+  //   }
+
+  //   it("should support nested case classes") {
+  //     val bar = Bar(foo)
+  //     val expect = SexpData(
+  //       SexpSymbol(":foo") -> fooexpect
+  //     )
+
+  //     // WORKAROUND http://stackoverflow.com/questions/25923974
+  //     implicit val FastFooFormat = SexpFormat[Foo]
+
+  //     assertFormat(bar, expect)
+  //   }
+
+  //   it("should support zero content case classes") {
+  //     assertFormat(Baz(), SexpNil)
+  //   }
+
+  //   it("should support missing fields as SexpNil / None") {
+  //     val wibble = Wibble("wibble", 13, Some("fork"))
+
+  //     assertFormat(wibble, SexpData(
+  //       SexpSymbol(":thing") -> SexpString("wibble"),
+  //       SexpSymbol(":thong") -> SexpNumber(13),
+  //       SexpSymbol(":bling") -> SexpList(SexpString("fork"))))
+
+  //     val wobble = Wibble("wibble", 13, None)
+
+  //     // write out None as SexpNil
+  //     assertFormat(wobble, SexpData(
+  //       SexpSymbol(":thing") -> SexpString("wibble"),
+  //       SexpSymbol(":thong") -> SexpNumber(13),
+  //       SexpSymbol(":bling") -> SexpNil))
+
+  //     // but tolerate missing entries
+  //     assert(SexpData(
+  //       SexpSymbol(":thing") -> SexpString("wibble"),
+  //       SexpSymbol(":thong") -> SexpNumber(13)
+  //     ).convertTo[Wibble] === wobble)
+  //   }
+  // }
+
+  // describe("ProductFormat tuples") {
+  //   val foo = (13, "foo")
+  //   val fooexpect = SexpList(SexpNumber(13), SexpString("foo"))
+
+  //   it("should support primitive types") {
+  //     assertFormat(foo, fooexpect)
+  //   }
+
+  //   it("should support 'fast' tuples") {
+  //     // can't really test - its a side effect optimisation
+  //     implicit val FastFooFormat = SexpFormat[(Int, String)]
+  //     assertFormat(foo, fooexpect)
+  //     assertFormat(foo, fooexpect)
+  //     assertFormat(foo, fooexpect)
+  //   }
+
+  // }
+}

--- a/src/test/scala/org/ensime/sexp/formats/SexpFormatUtilsSpec.scala
+++ b/src/test/scala/org/ensime/sexp/formats/SexpFormatUtilsSpec.scala
@@ -1,0 +1,71 @@
+package org.ensime.sexp.formats
+
+import scala.util._
+
+import org.ensime.sexp._
+
+class SexpFormatUtilsSpec extends FormatSpec with SexpFormats {
+  import SexpFormatUtils._
+
+  describe("SexpFormatUtils") {
+    it("should lift writers") {
+      val lifted = lift(new SexpWriter[SexpString] {
+        def write(o: SexpString) = o
+      })
+      assert(foo.toSexp(lifted) === foo)
+      intercept[UnsupportedOperationException] {
+        foo.convertTo[SexpString](lifted)
+      }
+    }
+
+    it("should lift readers") {
+      val lifted = lift(new SexpReader[SexpString] {
+        def read(o: Sexp) = o.asInstanceOf[SexpString]
+      })
+      assert(foo.convertTo[SexpString](lifted) === foo)
+      intercept[UnsupportedOperationException] {
+        foo.toSexp(lifted)
+      }
+    }
+
+    it("should combine readers and writers") {
+      val reader = new SexpReader[SexpString] {
+        def read(o: Sexp) = o.asInstanceOf[SexpString]
+      }
+      val writer = new SexpWriter[SexpString] {
+        def write(o: SexpString) = o
+      }
+      val combo = sexpFormat(reader, writer)
+
+      assert(foo.convertTo[SexpString](combo) === foo)
+      assert(foo.toSexp(combo) === foo)
+    }
+
+    it("should support lazy formats") {
+      var init = false
+      val lazyF = lazyFormat {
+        init = true
+        SexpStringFormat
+      }
+
+      assert(!init)
+      assert(SexpString("foo").convertTo[SexpString](lazyF) === SexpString("foo"))
+      assert(init)
+      assert(SexpString("foo").toSexp(lazyF) === SexpString("foo"))
+    }
+
+    it("should support safe readers") {
+      val safe = safeReader(
+        new SexpReader[SexpString] {
+          def read(value: Sexp) = value match {
+            case s: SexpString => s
+            case x => deserializationError(x)
+          }
+        }
+      )
+
+      assert(foo.convertTo[Try[SexpString]](safe) === Success(foo))
+      assert(bar.convertTo[Try[SexpString]](safe).isInstanceOf[Failure[_]])
+    }
+  }
+}

--- a/src/test/scala/org/ensime/sexp/formats/SexpFormatsSpec.scala
+++ b/src/test/scala/org/ensime/sexp/formats/SexpFormatsSpec.scala
@@ -1,0 +1,28 @@
+package org.ensime.sexp.formats
+
+import org.ensime.sexp._
+
+class SexpFormatsSpec extends FormatSpec with SexpFormats {
+
+  def assertFormat(sexp: Sexp): Unit = assertFormat(sexp, sexp)
+
+  describe("SexpFormats") {
+    it("should support SexpAtoms") {
+      assertFormat(SexpNil)
+      assertFormat(SexpPosInf)
+      assertFormat(SexpNegInf)
+      assertFormat(SexpNaN)
+      assertFormat(SexpNumber(1))
+      assertFormat(SexpString("hello"))
+      assertFormat(SexpSymbol("hello"))
+    }
+
+    it("should support SexpList") {
+      assertFormat(SexpList(foo, bar))
+    }
+
+    it("should support SexpCons") {
+      assertFormat(SexpCons(foo, bar))
+    }
+  }
+}

--- a/src/test/scala/org/ensime/sexp/formats/StandardFormatsSpec.scala
+++ b/src/test/scala/org/ensime/sexp/formats/StandardFormatsSpec.scala
@@ -1,0 +1,76 @@
+package org.ensime.sexp.formats
+
+import java.io.File
+import java.net.URI
+import java.net.URL
+import java.util.Date
+import java.util.UUID
+
+import org.ensime.sexp._
+import org.ensime.util.RichFile._
+
+class StandardFormatsSpec extends FormatSpec with StandardFormats with BasicFormats {
+  describe("StandardFormats") {
+    it("should support Option") {
+      val some = Some("thing")
+      assertFormat(some: Option[String], SexpList(SexpString("thing")))
+      assertFormat(None: Option[String], SexpNil)
+    }
+
+    it("should support Either") {
+      val left = Left(13)
+      val right = Right("thirteen")
+      assertFormat(left: Either[Int, String],
+        SexpData(SexpSymbol(":left") -> SexpNumber(13)))
+      assertFormat(right: Either[Int, String],
+        SexpData(SexpSymbol(":right") -> SexpString("thirteen")))
+    }
+
+    it("should support UUID") {
+      val uuid = UUID.randomUUID()
+      assertFormat(uuid, SexpString(uuid.toString()))
+    }
+
+    // it("should support URL") {
+    //   val github = "http://github.com/ensime/"
+    //   val url = new URL(github)
+    //   // hack to avoid calling URL.equals, which talks to the interwebz
+    //   assert(url.toSexp === SexpString(github))
+    //   assert(SexpString(github).convertTo[URL].toExternalForm === github)
+    // }
+
+    it("should support URI") {
+      val github = "http://github.com/ensime/"
+      val url = new URI(github)
+      assertFormat(url, SexpString(github))
+    }
+
+    it("should support File") {
+      val file = new File("foo")
+      assertFormat(file, SexpString("foo"))
+    }
+
+    it("should support Date") {
+      val date = new Date(1414326493000L)
+      assertFormat(date, SexpString("2014-10-26T12:28:13+00:00"))
+
+      val unix = new Date(0L)
+      assertFormat(unix, SexpString("1970-01-01T00:00:00+00:00"))
+    }
+  }
+}
+
+class AltStandardFormatsSpec extends FormatSpec
+    with StandardFormats with CanonFileFormat {
+
+  describe("StandardFormats with CanonFileFormat") {
+    it("should support canonicalised Files") {
+      val file = new File("foo")
+      val canon = file.canon
+      // non-canon files won't deserialise into exactly the same file
+      assert(file.toSexp === SexpString(canon.getPath))
+      assertFormat(canon, SexpString(canon.getPath))
+    }
+  }
+
+}

--- a/src/test/scala/org/ensime/test/TestUtil.scala
+++ b/src/test/scala/org/ensime/test/TestUtil.scala
@@ -10,6 +10,7 @@ import org.ensime.config._
 import org.ensime.util.RichFile._
 import org.ensime.util.FileUtils.jdkDir
 import scala.concurrent.duration._
+import scalariform.formatter.preferences.FormattingPreferences
 
 object TestUtil {
 
@@ -69,7 +70,7 @@ object TestUtil {
         copyDirectory(file(testSourcePath), testSourcesDir)
 
       EnsimeModule(
-        "single", classesDir :: Nil, testClassesDir :: Nil, Nil,
+        "single", None, classesDir :: Nil, None, testClassesDir :: Nil, Nil,
         if (jars) compileJars else List(scalaLib), Nil,
         if (jars) testJars else Nil,
         mainSourcesDir :: testSourcesDir :: Nil,
@@ -78,17 +79,17 @@ object TestUtil {
     }
 
     if (classes)
-      copyDirectory(compileClassDirs, module.targets.head)
+      copyDirectory(compileClassDirs, module.targetDirs.head)
     if (testClasses)
-      copyDirectory(testClassDirs, module.testTargets.head)
+      copyDirectory(testClassDirs, module.testTargetDirs.head)
 
     val cacheDir = base / ".ensime_cache"
     cacheDir.mkdirs()
 
     EnsimeConfig(
-      base.canon, cacheDir.canon,
-      "simple", scalaVersion, Nil, Map(module.name -> module),
-      javaSource.toList
+      base.canon, cacheDir.canon, "simple", scalaVersion,
+      Nil, javaSource.toList, List(module),
+      FormattingPreferences(), false, Nil
     )
   }
 


### PR DESCRIPTION
I hereby extend [Greenspun's 10th rule](http://en.wikipedia.org/wiki/Greenspun%27s_tenth_rule) to Scala.

_Any sufficiently complicated C or Fortran program contains an ad hoc, informally-specified, bug-ridden, slow implementation of half of Common Lisp._

I went a wee bit overboard. This patch includes a shapeless-powered S-Expression serialisation framework based heavily on [spray-json](https://github.com/spray/spray-json) (but with lots of generics to reduce boilerplate). @sirthias may be interested to look at this and discuss further offline - I have some more to say about the shapeless work, see my PR over at https://github.com/milessabin/shapeless/pull/262

I have only moved over our config file parser to use this, but in tandem with #681 this will make changes to the protocol **a hell of a lot easier**. Also, when backported to 2.10, we can depend on `ensime-server` from `ensime-sbt` to share a common domain model for the configuration.

Also, some updates to random third party libraries.
