### PR TITLE
Fix missing line/offsets when looking up symbol positions

### DIFF
--- a/src/main/scala/org/ensime/indexer/SearchService.scala
+++ b/src/main/scala/org/ensime/indexer/SearchService.scala
@@ -130,6 +130,8 @@ class SearchService(
     } yield (r, i)
   }
 
+  def refreshResolver(): Unit = resolver.update()
+
   private def persist(check: FileCheck, symbols: List[FqnSymbol]): Unit = try {
     index.persist(check, symbols)
     db.persist(check, symbols)

--- a/src/main/scala/org/ensime/model/Helpers.scala
+++ b/src/main/scala/org/ensime/model/Helpers.scala
@@ -84,6 +84,30 @@ trait Helpers { self: Global =>
   }
 
   /**
+   *  Return the string used to index a symbol
+   */
+  def symbolIndexerName(sym: Symbol): String = {
+    def typeIndexerName(sym: Symbol): String = {
+      val owner = sym.owner
+      if (owner.isRoot || owner.isRootPackage) {
+        sym.nameString
+      } else if (owner.hasPackageFlag) {
+        owner.fullName + "." + sym.nameString
+      } else {
+        typeIndexerName(owner) + "$" + sym.nameString
+      }
+    }
+
+    if (sym.isType) {
+      typeIndexerName(sym)
+    } else if (sym.isModule || sym.isModuleClass) {
+      typeIndexerName(sym) + "$"
+    } else {
+      symbolIndexerName(sym.owner) + "." + sym.nameString
+    }
+  }
+
+  /**
    * Generate qualified name, without args postfix.
    */
   def typeFullName(tpe: Type): String = {

--- a/src/main/scala/org/ensime/protocol/SwankProtocol.scala
+++ b/src/main/scala/org/ensime/protocol/SwankProtocol.scala
@@ -93,7 +93,13 @@ class SwankProtocol(actorSystem: ActorSystem) extends Protocol {
     val dataString: String = value.toWireString
     val data: Array[Byte] = dataString.getBytes("UTF-8")
     val header: Array[Byte] = "%06x".format(data.length).getBytes("UTF-8")
-    log.info("Writing: " + dataString)
+
+    val displayStr = if (dataString.length > 3000)
+      dataString.take(3000) + "..."
+    else
+      dataString
+    log.info("Writing: " + displayStr)
+
     out.write(header)
     out.write(data)
     out.flush()

--- a/src/test/scala/org/ensime/test/RichPresentationCompilerSpec.scala
+++ b/src/test/scala/org/ensime/test/RichPresentationCompilerSpec.scala
@@ -1,10 +1,18 @@
 package org.ensime.test
 
 import akka.event.slf4j.SLF4JLogging
+import concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.Await
+import scala.concurrent.duration._
 import scala.reflect.internal.util.OffsetPosition
 import org.scalatest.FunSpec
 import org.scalatest.Matchers
 import org.slf4j.LoggerFactory
+
+import org.ensime.indexer.SearchService
+import org.ensime.indexer.SourceResolver
+import org.ensime.model.OffsetSourcePosition
+import org.ensime.server.RichPresentationCompiler
 import org.ensime.test.util.Helpers
 
 import pimpathon.file._
@@ -147,6 +155,82 @@ class RichPresentationCompilerSpec extends FunSpec with Matchers with SLF4JLoggi
         val supers = info.map(_.supers).getOrElse(List())
         val supersNames = supers.map(_.tpe.name).toList
         assert(supersNames.toSet === Set("pipo", "bidon", "Object", "Product", "Serializable", "Any"))
+      }
+    }
+
+    it("should get symbol positions for compiled files") {
+      Helpers.withPresCompiler { (dir, cc) =>
+        val defsFile = Helpers.srcFile(dir, "com/example/defs.scala", Helpers.contents(
+          "package com.example",
+          "object /*1*/A { ",
+          "   val /*1.1*/x: Int = 1",
+          "   class /*1.2*/X {} ",
+          "}",
+          "class  /*2*/B { ",
+          "   val /*2.1*/y: Int = 1",
+          "   def /*2.2*/meth(a: String): Int = 1",
+          "   def /*2.3*/meth(a: Int): Int = 1",
+          "}",
+          "trait  /*3*/C { ",
+          "   val /*3.1*/z: Int = 1",
+          "   class /*3.2*/Z {} ",
+          "}",
+          "class /*4*/D extends C { }"
+        ), write = true)
+        val usesFile = Helpers.srcFile(dir, "com/example/uses.scala", Helpers.contents(
+          "package com.example",
+          "object Test { ",
+          "   val x_1 = A/*1*/",
+          "   val x_1_1 = A.x/*1.1*/",
+          "   val x_1_2 = new A.X/*1.2*/",
+          "   val x_2 = new B/*2*/",
+          "   val x_2_1 = new B().y/*2.1*/",
+          "   val x_2_2 = new B().meth/*2.2*/(\"x\")",
+          "   val x_2_3 = new B().meth/*2.3*/(1)",
+          "   val x_3: C/*3*/ = new D/*4*/",
+          "   val x_3_1 = x_3.z/*3.1*/",
+          "   val x_3_2 = new x_3.Z/*3.2*/",
+          "}"
+        ))
+
+        def test(label: String, cc: RichPresentationCompiler) = {
+          val comment = "/*" + label + "*/"
+          val defPos = defsFile.content.mkString.indexOf(comment) + comment.length;
+          val usePos = usesFile.content.mkString.indexOf(comment) - 1;
+
+          // Create a fresh pres. compiler unaffected by previous tests
+
+          val cc1 = new RichPresentationCompiler(cc.config, cc.settings, cc.reporter, cc.parent, cc.indexer, cc.search)
+
+          try {
+            cc1.askReloadFile(usesFile)
+            cc1.askLoadedTyped(usesFile)
+
+            val info = cc1.askSymbolInfoAt(new OffsetPosition(usesFile, usePos)) match {
+              case Some(x) => x
+              case None => fail(s"For $comment, askSymbolInfoAt returned None")
+            }
+            val declPos = info.declPos
+            declPos match {
+              case Some(op: OffsetSourcePosition) => assert(op.offset === defPos)
+              case _ => fail(s"For $comment, unexpected declPos value: $declPos")
+            }
+          } finally {
+            cc1.askShutdown()
+          }
+        }
+
+        Helpers.compileScala(
+          List(defsFile.path),
+          (dir / "target" / "classes").getPath,
+          cc.settings.classpath.value
+        )
+
+        cc.search.refreshResolver()
+        Await.result(cc.search.refresh(), 180.seconds)
+
+        List("1", "1.1", "1.2", "2", "2.1", "2.2", "2.3", "3", "3.1", "3.2", "4").
+          foreach(test(_, cc))
       }
     }
   }

--- a/src/test/scala/org/ensime/test/util/Helpers.scala
+++ b/src/test/scala/org/ensime/test/util/Helpers.scala
@@ -12,35 +12,39 @@ import org.slf4j.LoggerFactory
 import org.ensime.util.RichFile._
 
 import scala.reflect.internal.util.BatchSourceFile
+import scala.reflect.io.Path
 import scala.tools.nsc.Settings
+import scala.tools.nsc.{ Global => nscGlobal }
 import scala.tools.nsc.interactive.Global
 import scala.tools.nsc.reporters.StoreReporter
+import scala.tools.nsc.reporters.ConsoleReporter
 
 import pimpathon.file._
 import TestUtil._
 
 object Helpers {
 
-  def withPresCompiler(action: (File, RichCompilerControl) => Any) =
+  def withPresCompiler(action: (File, RichPresentationCompiler) => Any) =
     withTempDirectory { tmpRaw =>
       val tmp = tmpRaw.canon
       require(tmp.isDirectory)
       implicit val actorSystem = ActorSystem.create()
 
+      val config = basicConfig(tmp, jars = false)
+
       val presCompLog = LoggerFactory.getLogger(classOf[Global])
       val settings = new Settings(presCompLog.error)
-      settings.embeddedDefaults[RichCompilerControl]
       settings.YpresentationDebug.value = presCompLog.isTraceEnabled
       settings.YpresentationVerbose.value = presCompLog.isDebugEnabled
       settings.verbose.value = presCompLog.isDebugEnabled
       //settings.usejavacp.value = true
       settings.bootclasspath.append(TestUtil.scalaLib.getAbsolutePath)
+      settings.classpath.value = config.compileClasspath.mkString(File.pathSeparator)
 
       val reporter = new StoreReporter()
       val indexer = TestProbe()
       val parent = TestProbe()
 
-      val config = basicConfig(tmp)
       val resolver = new SourceResolver(config)
       val search = new SearchService(config, resolver)
 
@@ -55,9 +59,25 @@ object Helpers {
       }
     }
 
+  def compileScala(paths: List[String], target: String, classPath: String): Unit = {
+    val settings = new Settings
+    settings.outputDirs.setSingleOutput(target)
+    val reporter = new ConsoleReporter(settings)
+    settings.classpath.value = classPath
+    val g = new nscGlobal(settings, reporter)
+    val run = new g.Run
+    run.compile(paths)
+  }
+
   // TODO: needs to be in the right place, need to get tmp dir
-  def srcFile(base: File, name: String, content: String) =
-    new BatchSourceFile((base / mainSourcePath / name).getPath, content)
+  def srcFile(base: File, name: String, content: String, write: Boolean = false) = {
+    val src = base / mainSourcePath / name
+    if (write) {
+      src.create()
+      src.writeBytes(content.getBytes)
+    }
+    new BatchSourceFile(src.getPath, content)
+  }
 
   def contents(lines: String*) = lines.mkString("\n")
 


### PR DESCRIPTION
This fixes #630 by using the presentation compiler as the last step of looking up the symbol. This may look like a step backward but it isn't so bad: the pres. compiler comes into play much less often than it used to, because `locateSymbolPos` is told to actually find the position only when absolutely needed.
