### PR TITLE
Use pres. compiler's charset when reading/writing files

### DIFF
--- a/src/main/scala/org/ensime/server/RichPresentationCompiler.scala
+++ b/src/main/scala/org/ensime/server/RichPresentationCompiler.scala
@@ -1,6 +1,7 @@
 package org.ensime.server
 
 import java.io.File
+import java.nio.charset.Charset
 import akka.actor.ActorRef
 import org.ensime.config._
 import org.ensime.indexer.SearchService
@@ -19,6 +20,8 @@ import scala.tools.refactoring.analysis.GlobalIndexes
 
 trait RichCompilerControl extends CompilerControl with RefactoringControl with CompletionControl {
   self: RichPresentationCompiler =>
+
+  def charset: Charset = Charset.forName(settings.encoding.value)
 
   def askOption[A](op: => A): Option[A] =
     try {

--- a/src/main/scala/org/ensime/util/FileUtil.scala
+++ b/src/main/scala/org/ensime/util/FileUtil.scala
@@ -86,8 +86,7 @@ object FileUtils {
     f.exists && f.getName.endsWith(".scala")
   }
 
-  def readFile(file: File): Either[IOException, String] = {
-    val cs = Charset.defaultCharset()
+  def readFile(file: File, cs: Charset): Either[IOException, String] = {
     try {
       val stream = new FileInputStream(file)
       try {
@@ -110,29 +109,32 @@ object FileUtils {
     }
   }
 
-  def replaceFileContents(file: File, newContents: String): Either[Exception, Unit] = {
+  def replaceFileContents(file: File, newContents: String, cs: Charset): Either[Exception, Unit] = {
     try {
-      val writer = new FileWriter(file)
+      val stream = new FileOutputStream(file)
+      val writer = new OutputStreamWriter(stream, cs)
       try {
         writer.write(newContents)
         Right(())
       } catch {
-        case e: IOException => Left(e)
+        case e: IOException =>
+          Left(e)
       } finally {
         writer.close()
       }
     } catch {
-      case e: Exception => Left(e)
+      case e: Exception =>
+        Left(e)
     }
   }
 
   // Note: we assume changes do not overlap
-  def inverseEdits(edits: Iterable[FileEdit]): List[FileEdit] = {
+  def inverseEdits(edits: Iterable[FileEdit], cs: Charset): List[FileEdit] = {
     val result = new mutable.ListBuffer[FileEdit]
     val editsByFile = edits.groupBy(_.file)
     editsByFile.foreach {
       case (file, fileEdits) =>
-        readFile(file) match {
+        readFile(file, cs) match {
           case Right(contents) =>
             var dy = 0
             for (ch <- fileEdits) {
@@ -155,14 +157,14 @@ object FileUtils {
     result.toList
   }
 
-  def writeChanges(changes: Iterable[FileEdit]): Either[Exception, Iterable[File]] = {
+  def writeChanges(changes: Iterable[FileEdit], cs: Charset): Either[Exception, Iterable[File]] = {
     val editsByFile = changes.collect { case ed: TextEdit => ed }.groupBy(_.file)
     val newFiles = changes.collect { case ed: NewFile => ed }
     try {
       val rewriteList = newFiles.map { ed => (ed.file, ed.text) } ++
         editsByFile.map {
           case (file, fileChanges) =>
-            readFile(file) match {
+            readFile(file, cs) match {
               case Right(contents) =>
                 val newContents = FileEdit.applyEdits(fileChanges.toList, contents)
                 (file, newContents)
@@ -175,7 +177,7 @@ object FileUtils {
         ed.file.delete()
       }
 
-      rewriteFiles(rewriteList) match {
+      rewriteFiles(rewriteList, cs) match {
         case Right(Right(_)) => Right(changes.groupBy(_.file).keys)
         case Right(Left(e)) => Left(new IllegalStateException(
           "Possibly incomplete write of change-set caused by: " + e))
@@ -191,7 +193,7 @@ object FileUtils {
    * before any disk writes, return Left(exception). If  an error occurs DURING
    * disk writes, return Right(Left(exception)). Otherwise, return Right(Right(()))
    */
-  def rewriteFiles(changes: Iterable[(File, String)]): Either[Exception, Either[Exception, Unit]] = {
+  def rewriteFiles(changes: Iterable[(File, String)], cs: Charset): Either[Exception, Either[Exception, Unit]] = {
     try {
 
       // Try to fail fast, before writing anything to disk.
@@ -206,7 +208,7 @@ object FileUtils {
       // Apply the changes. An error here may result in a corrupt disk state :(
       changes.foreach {
         case (file, newContents) =>
-          replaceFileContents(file, newContents) match {
+          replaceFileContents(file, newContents, cs) match {
             case Right(_) =>
             case Left(e) => Right(Left(e))
           }

--- a/src/test/scala/org/ensime/server/RefactoringHandlerSpec.scala
+++ b/src/test/scala/org/ensime/server/RefactoringHandlerSpec.scala
@@ -1,0 +1,41 @@
+package org.ensime
+
+import java.io.File
+import org.ensime.test.util.Helpers
+import org.scalatest.FunSpec
+import org.scalatest.Matchers
+import org.ensime.test.TestUtil._
+
+class RefactoringHandlerSpec extends FunSpec with Matchers {
+  describe("org.ensime.server.RefactoringHandler") {
+    it("should format files and preserve encoding") {
+      val encoding = "UTF-16"
+      implicit val cfg = { dir: File =>
+        basicConfig(dir, jars = false, compilerArgs = List("-encoding", encoding))
+      }
+      Helpers.withAnalyzer { (dir, analyzerRef) =>
+        val file = Helpers.srcFile(dir, "abc.scala", Helpers.contents(
+          "package blah",
+          "   class Something {",
+          "def f(i:   Int) =1",
+          " val x = (1\u21922)",
+          "   }"
+        ), write = true, encoding = encoding)
+
+        val analyzer = analyzerRef.underlyingActor
+
+        analyzer.handleFormatFiles(List(file.path))
+        val fileContents = Helpers.readSrcFile(file, encoding)
+
+        val expectedContents = Helpers.contents(
+          "package blah",
+          "class Something {",
+          "  def f(i: Int) = 1",
+          "  val x = (1 \u2192 2)",
+          "}"
+        )
+        assert(fileContents === expectedContents)
+      }
+    }
+  }
+}

--- a/src/test/scala/org/ensime/test/TestUtil.scala
+++ b/src/test/scala/org/ensime/test/TestUtil.scala
@@ -50,7 +50,8 @@ object TestUtil {
     testSources: Boolean = false,
     classes: Boolean = false,
     testClasses: Boolean = false,
-    jars: Boolean = true): EnsimeConfig = {
+    jars: Boolean = true,
+    compilerArgs: List[String] = List.empty): EnsimeConfig = {
     val base = tmp.canon
     require(base.isDirectory)
 
@@ -88,7 +89,7 @@ object TestUtil {
 
     EnsimeConfig(
       base.canon, cacheDir.canon, "simple", scalaVersion,
-      Nil, javaSource.toList, List(module),
+      compilerArgs, javaSource.toList, List(module),
       FormattingPreferences(), false, Nil
     )
   }

--- a/src/test/scala/org/ensime/util/FileUtilSpec.scala
+++ b/src/test/scala/org/ensime/util/FileUtilSpec.scala
@@ -1,5 +1,6 @@
 package org.ensime.util
 
+import java.nio.charset.Charset
 import akka.event.slf4j.SLF4JLogging
 import org.scalatest.{ Matchers, FunSpec }
 import pimpathon.file._
@@ -7,15 +8,17 @@ import pimpathon.file._
 class FileUtilSpec extends FunSpec with Matchers with SLF4JLogging {
   describe("FileUtils") {
     it("should roundtrip reading and writing a file") {
+      val cs = Charset.forName("UTF-16")
       withTempFile { f =>
         val contents =
           """abcdefghijklmnopqrstuvwxyz
             |1234567890
             |()
-            |{}""".stripMargin
-        FileUtils.replaceFileContents(f, contents)
+            |{}
+            |\u2192""".stripMargin
+        FileUtils.replaceFileContents(f, contents, cs)
 
-        val readback = FileUtils.readFile(f)
+        val readback = FileUtils.readFile(f, cs)
         readback match {
           case Left(e) => fail(e)
           case Right(readContents) => assert(readContents == contents)


### PR DESCRIPTION
Fix #663.   This change is a lot bigger than I anticipated! I had to move the methods that need a charset to the Analyzer's actor.
