### PR TITLE
Random wartremover and lint cleanups

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,5 @@
 import sbt._
 import java.io._
-import java.util.concurrent.atomic.AtomicReference
 import net.virtualvoid.sbt.graph.Plugin.graphSettings
 import ScoverageSbtPlugin.ScoverageKeys
 import org.scoverage.coveralls.CoverallsPlugin.coverallsSettings
@@ -80,8 +79,6 @@ scalacOptions in Compile ++= Seq(
   "-encoding", "UTF-8", "-target:jvm-1.6", "-feature", "-deprecation",
   "-Xfatal-warnings",
   "-language:postfixOps", "-language:implicitConversions"
-  //"-P:wartremover:only-warn-traverser:org.brianmckenna.wartremover.warts.Unsafe"
-  //"-P:wartremover:traverser:org.brianmckenna.wartremover.warts.Unsafe"
 )
 
 javacOptions in (Compile, compile) ++= Seq (

--- a/src/main/scala/org/ensime/config/EnsimeConfig.scala
+++ b/src/main/scala/org/ensime/config/EnsimeConfig.scala
@@ -6,7 +6,6 @@ import org.ensime.sexp._
 import org.ensime.sexp.formats._
 import org.ensime.util._
 import pimpathon.file._
-import scala.util.Properties
 import scalariform.formatter.preferences.FormattingPreferences
 import RichFile._
 import FileUtils.jdkDir
@@ -23,7 +22,7 @@ case class EnsimeConfig(
     `source-mode`: Boolean,
     `debug-args`: List[String]) extends SLF4JLogging {
   (`root-dir` :: `cache-dir` :: referenceSourceJars).foreach { f =>
-    require(f.exists, f + " is required but does not exist")
+    require(f.exists, "" + f + " is required but does not exist")
   }
 
   // convertors between the "legacy" names and the preferred ones
@@ -85,7 +84,7 @@ case class EnsimeModule(
   // only check the files, not the directories, see below
   (`compile-deps` ::: `runtime-deps` :::
     `test-deps` ::: `reference-source-roots`).foreach { f =>
-      require(f.exists, f + " is required but does not exist")
+      require(f.exists, "" + f + " is required but does not exist")
     }
   // the preferred accessors
   val targetDirs = targets ++ target.toIterable
@@ -104,13 +103,13 @@ case class EnsimeModule(
    We use the canonical form of files/directories to keep OS X happy
    when loading S-Expressions. But the canon may fail to resolve if
    the file/directory does not exist, so we force create all required
-   directories and then re-canon them, which is - admitedly - a weird
+   directories and then re-canon them, which is - admittedly - a weird
    side-effect.
    */
   private[config] def validated(): EnsimeModule = {
     (targetDirs ++ testTargetDirs ++ sourceRoots).foreach { dir =>
       if (!dir.exists()) {
-        log.warn(dir + " does not exist, creating")
+        log.warn("" + dir + " does not exist, creating")
         dir.mkdirs()
       }
     }
@@ -137,6 +136,6 @@ object EnsimeConfig {
 
   def parse(config: String): EnsimeConfig = {
     val raw = config.parseSexp.convertTo[EnsimeConfig]
-    raw.validated
+    raw.validated()
   }
 }

--- a/src/main/scala/org/ensime/indexer/RecursiveExtSelector.scala
+++ b/src/main/scala/org/ensime/indexer/RecursiveExtSelector.scala
@@ -1,0 +1,10 @@
+package org.ensime.indexer
+
+import org.apache.commons.vfs2.{ FileSelectInfo, FileSelector }
+
+private[indexer] abstract class RecursiveExtSelector extends FileSelector {
+  def includeFile(info: FileSelectInfo): Boolean =
+    include(info.getFile.getName.getExtension)
+  def traverseDescendents(info: FileSelectInfo) = true
+  def include: Set[String]
+}

--- a/src/main/scala/org/ensime/indexer/SearchService.scala
+++ b/src/main/scala/org/ensime/indexer/SearchService.scala
@@ -228,12 +228,12 @@ class SearchService(
   def classfileAdded(f: FileObject): Unit = classfileChanged(f)
 
   def classfileRemoved(f: FileObject): Unit = Future {
-    backlog.put(f, Nil)
+    backlog.put((f, Nil))
   }(worker.context)
 
   def classfileChanged(f: FileObject): Unit = Future {
-    val syms = extractSymbols(f, f)
-    backlog.put(f, syms)
+    val symbols = extractSymbols(f, f)
+    backlog.put((f, symbols))
   }(worker.context)
 
 }

--- a/src/main/scala/org/ensime/indexer/lucene/DocumentProvider.scala
+++ b/src/main/scala/org/ensime/indexer/lucene/DocumentProvider.scala
@@ -1,0 +1,7 @@
+package org.ensime.indexer.lucene
+
+import org.apache.lucene.document.Document
+
+trait DocumentProvider[T] {
+  def toDocument(t: T): Document
+}

--- a/src/main/scala/org/ensime/indexer/lucene/DocumentRecovery.scala
+++ b/src/main/scala/org/ensime/indexer/lucene/DocumentRecovery.scala
@@ -1,0 +1,8 @@
+package org.ensime.indexer.lucene
+
+import org.apache.lucene.document.Document
+
+trait DocumentRecovery[T] {
+  def toEntity(d: Document): T
+}
+

--- a/src/main/scala/org/ensime/indexer/lucene/Entity.scala
+++ b/src/main/scala/org/ensime/indexer/lucene/Entity.scala
@@ -1,0 +1,5 @@
+package org.ensime.indexer.lucene
+
+trait Entity extends Product {
+  def id: String
+}

--- a/src/main/scala/org/ensime/indexer/lucene/EntityS.scala
+++ b/src/main/scala/org/ensime/indexer/lucene/EntityS.scala
@@ -1,0 +1,5 @@
+package org.ensime.indexer.lucene
+
+abstract class EntityS[T <: Entity](clazz: Class[T]) extends Serializer(clazz) {
+  def id(t: T) = t.id
+}

--- a/src/main/scala/org/ensime/indexer/lucene/QueryProvider.scala
+++ b/src/main/scala/org/ensime/indexer/lucene/QueryProvider.scala
@@ -1,0 +1,7 @@
+package org.ensime.indexer.lucene
+
+import org.apache.lucene.search.Query
+
+trait QueryProvider[T] {
+  def createQuery(t: T): Query
+}

--- a/src/main/scala/org/ensime/indexer/lucene/Serializer.scala
+++ b/src/main/scala/org/ensime/indexer/lucene/Serializer.scala
@@ -1,0 +1,32 @@
+package org.ensime.indexer.lucene
+
+import org.apache.lucene.document.Field.Store
+import org.apache.lucene.document.{ Document, StringField }
+import org.apache.lucene.index.Term
+import org.apache.lucene.search.BooleanClause.Occur._
+import org.apache.lucene.search.{ BooleanQuery, Query, TermQuery }
+
+abstract class Serializer[T](clazz: Class[T])
+    extends DocumentProvider[T] with DocumentRecovery[T] with QueryProvider[T] {
+  private val TypeField = new StringField("TYPE", clazz.getSimpleName, Store.YES)
+  private val TypeTerm = new TermQuery(new Term(TypeField.name, TypeField.stringValue))
+
+  def id(t: T): String
+
+  final def toDocument(t: T): Document = {
+    val doc = new Document
+    doc.add(TypeField)
+    doc.add(new StringField("ID", id(t), Store.NO))
+    addFields(doc, t)
+    doc
+  }
+  def addFields(doc: Document, t: T): Unit
+
+  final def createQuery(e: T): Query = {
+    new BooleanQuery {
+      add(TypeTerm, MUST)
+      add(new TermQuery(new Term("ID", id(e))), MUST)
+    }
+  }
+}
+

--- a/src/main/scala/org/ensime/indexer/lucene/SimpleLucene.scala
+++ b/src/main/scala/org/ensime/indexer/lucene/SimpleLucene.scala
@@ -87,7 +87,7 @@ class SimpleLucene(path: File, analyzers: Map[String, Analyzer]) extends SLF4JLo
       results += result
       if (log.isTraceEnabled) {
         val explanation = searcher.explain(query, hit.doc)
-        log.trace(result + " scored " + explanation)
+        log.trace("" + result + " scored " + explanation)
       }
     }
 

--- a/src/main/scala/org/ensime/indexer/lucene/package.scala
+++ b/src/main/scala/org/ensime/indexer/lucene/package.scala
@@ -28,52 +28,11 @@ import org.apache.lucene.search.BooleanClause.Occur.MUST
 import Field._
 
 package object lucene {
-  trait DocumentProvider[T] {
-    def toDocument(t: T): Document
-  }
-  trait DocumentRecovery[T] {
-    def toEntity(d: Document): T
-  }
-  trait QueryProvider[T] {
-    def createQuery(t: T): Query
-  }
-  trait Entity extends Product {
-    def id: String
-  }
-
   implicit class RichEntity[T <: Entity](e: T) {
     def toDocument(implicit p: DocumentProvider[T]) = p.toDocument(e)
   }
 
   implicit class RichDocument(d: Document) {
     def toEntity[T](implicit p: DocumentRecovery[T]) = p.toEntity(d)
-  }
-
-  abstract class Serializer[T](clazz: Class[T])
-      extends DocumentProvider[T] with DocumentRecovery[T] with QueryProvider[T] {
-    private val TypeField = new StringField("TYPE", clazz.getSimpleName, Store.YES)
-    private val TypeTerm = new TermQuery(new Term(TypeField.name, TypeField.stringValue))
-
-    def id(t: T): String
-
-    final def toDocument(t: T): Document = {
-      val doc = new Document
-      doc.add(TypeField)
-      doc.add(new StringField("ID", id(t), Store.NO))
-      addFields(doc, t)
-      doc
-    }
-    def addFields(doc: Document, t: T): Unit
-
-    final def createQuery(e: T): Query = {
-      new BooleanQuery {
-        add(TypeTerm, MUST)
-        add(new TermQuery(new Term("ID", id(e))), MUST)
-      }
-    }
-  }
-
-  abstract class EntityS[T <: Entity](clazz: Class[T]) extends Serializer(clazz) {
-    def id(t: T) = t.id
   }
 }

--- a/src/main/scala/org/ensime/indexer/package.scala
+++ b/src/main/scala/org/ensime/indexer/package.scala
@@ -14,13 +14,6 @@ package object indexer {
   private[indexer] def vjar(jar: File) = vfs.resolveFile("jar:" + jar.getAbsolutePath)
   private[indexer] def vjar(jar: FileObject) = vfs.resolveFile("jar:" + jar.getName.getURI)
 
-  private[indexer] abstract class RecursiveExtSelector extends FileSelector {
-    def includeFile(info: FileSelectInfo): Boolean =
-      include(info.getFile.getName.getExtension)
-    def traverseDescendents(info: FileSelectInfo) = true
-    def include: Set[String]
-  }
-
   private[indexer] object ClassfileSelector extends RecursiveExtSelector {
     val include = Set("class")
   }

--- a/src/main/scala/org/ensime/model/Model.scala
+++ b/src/main/scala/org/ensime/model/Model.scala
@@ -291,13 +291,14 @@ trait ModelBuilders { self: RichPresentationCompiler =>
   private val typeCache = new mutable.HashMap[Int, Type]
   private val typeCacheReverse = new mutable.HashMap[Type, Int]
 
-  def clearTypeCache() {
+  def clearTypeCache(): Unit = {
     typeCache.clear()
     typeCacheReverse.clear()
   }
   def typeById(id: Int): Option[Type] = {
     typeCache.get(id)
   }
+
   def cacheType(tpe: Type): Int = {
     if (typeCacheReverse.contains(tpe)) {
       typeCacheReverse(tpe)

--- a/src/main/scala/org/ensime/server/Project.scala
+++ b/src/main/scala/org/ensime/server/Project.scala
@@ -60,7 +60,7 @@ class Project(
 
   protected val actor = actorSystem.actorOf(Props(new ProjectActor()), "project")
 
-  def !(msg: AnyRef) {
+  def !(msg: AnyRef): Unit = {
     actor ! msg
   }
 
@@ -114,7 +114,7 @@ class Project(
     private var asyncEvents = Vector[ProtocolEvent]()
     private var asyncListeners: List[ProtocolEvent => Unit] = Nil
 
-    override def receive = waiting orElse ready
+    override def receive: Receive = waiting orElse ready
 
     private val ready: Receive = {
       case Retypecheck =>
@@ -151,7 +151,7 @@ class Project(
     }
   }
 
-  protected def addUndo(sum: String, changes: Iterable[FileEdit]) {
+  protected def addUndo(sum: String, changes: Iterable[FileEdit]): Unit = {
     undoCounter += 1
     undos(undoCounter) = Undo(undoCounter, sum, changes.toList)
   }
@@ -172,14 +172,14 @@ class Project(
     }
   }
 
-  def initProject() {
+  def initProject(): Unit = {
     startCompiler()
     shutdownDebugger()
     undos.clear()
     undoCounter = 0
   }
 
-  protected def startCompiler() {
+  protected def startCompiler(): Unit = {
     val newAnalyzer = actorSystem.actorOf(Props(
       new Analyzer(actor, indexer, search, config)), "analyzer")
     analyzer = Some(newAnalyzer)
@@ -195,12 +195,12 @@ class Project(
     }
   }
 
-  protected def shutdownDebugger() {
+  protected def shutdownDebugger(): Unit = {
     debugger.foreach(_ ! DebuggerShutdownEvent)
     debugger = None
   }
 
-  protected def shutdownServer() {
+  protected def shutdownServer(): Unit = {
     val t = new Thread() {
       override def run(): Unit = {
         log.info("Server is exiting...")

--- a/src/main/scala/org/ensime/server/ProjectRPCTarget.scala
+++ b/src/main/scala/org/ensime/server/ProjectRPCTarget.scala
@@ -163,7 +163,7 @@ trait ProjectRPCTarget extends RPCTarget { self: Project =>
     callVoidRPC(getAnalyzer, RemoveFileReq(file))
   }
 
-  override def rpcUnloadAll() {
+  override def rpcUnloadAll(): Unit = {
     callVoidRPC(getAnalyzer, UnloadAllReq)
   }
 

--- a/src/main/scala/org/ensime/server/Refactoring.scala
+++ b/src/main/scala/org/ensime/server/Refactoring.scala
@@ -90,7 +90,7 @@ trait RefactoringHandler { self: Analyzer =>
 
   val effects: mutable.HashMap[Int, RefactorEffect] = new mutable.HashMap
 
-  def handleRefactorPrepareRequest(req: RefactorPrepareReq) {
+  def handleRefactorPrepareRequest(req: RefactorPrepareReq): Unit = {
     val procedureId = req.procedureId
     val refactor = req.refactor
     val result = scalaCompiler.askPrepareRefactor(procedureId, refactor)
@@ -104,7 +104,7 @@ trait RefactoringHandler { self: Analyzer =>
     sender ! result
   }
 
-  def handleRefactorExec(req: RefactorExecReq) {
+  def handleRefactorExec(req: RefactorExecReq): Unit = {
     val procedureId = req.procedureId
     effects.get(procedureId) match {
       case Some(effect: RefactorEffect) =>
@@ -119,7 +119,7 @@ trait RefactoringHandler { self: Analyzer =>
     }
   }
 
-  def handleRefactorCancel(req: RefactorCancelReq) {
+  def handleRefactorCancel(req: RefactorCancelReq): Unit = {
     effects.remove(req.procedureId)
     sender ! VoidResponse
   }

--- a/src/main/scala/org/ensime/server/RichPresentationCompiler.scala
+++ b/src/main/scala/org/ensime/server/RichPresentationCompiler.scala
@@ -81,17 +81,17 @@ trait RichCompilerControl extends CompilerControl with RefactoringControl with C
   def askPackageByPath(path: String): Option[PackageInfo] =
     askOption(PackageInfo.fromPath(path))
 
-  def askReloadFile(f: SourceFile) {
+  def askReloadFile(f: SourceFile): Unit = {
     askReloadFiles(List(f))
   }
 
-  def askReloadFiles(files: Iterable[SourceFile]) {
+  def askReloadFiles(files: Iterable[SourceFile]): Either[Unit, Throwable] = {
     val x = new Response[Unit]()
     askReload(files.toList, x)
     x.get
   }
 
-  def askLoadedTyped(f: SourceFile) {
+  def askLoadedTyped(f: SourceFile): Either[Tree, Throwable] = {
     val x = new Response[Tree]()
     askLoadedTyped(f, x)
     x.get
@@ -99,7 +99,7 @@ trait RichCompilerControl extends CompilerControl with RefactoringControl with C
 
   def askUnloadAllFiles(): Unit = askOption(unloadAllFiles())
 
-  def askRemoveAllDeleted() = askOption(removeAllDeleted())
+  def askRemoveAllDeleted(): Option[Unit] = askOption(removeAllDeleted())
 
   def askRemoveDeleted(f: File) = askOption(removeDeleted(AbstractFile.getFile(f)))
 
@@ -144,9 +144,9 @@ trait RichCompilerControl extends CompilerControl with RefactoringControl with C
     askOption(
       new SemanticHighlighting(this).symbolDesignationsInRegion(p, tpes)).getOrElse(SymbolDesignations("", List.empty))
 
-  def askClearTypeCache() = clearTypeCache()
+  def askClearTypeCache(): Unit = clearTypeCache()
 
-  def askNotifyWhenReady() = ask(setNotifyWhenReady)
+  def askNotifyWhenReady(): Unit = ask(setNotifyWhenReady)
 
   def createSourceFile(path: String) = getSourceFile(path)
   def createSourceFile(file: AbstractFile) = getSourceFile(file)
@@ -188,7 +188,7 @@ class RichPresentationCompiler(
   }
 
   /** Called from typechecker every time a top-level class or object is entered.*/
-  override def registerTopLevelSym(sym: Symbol) {
+  override def registerTopLevelSym(sym: Symbol): Unit = {
     super.registerTopLevelSym(sym)
     symsByFile(sym.sourceFile) += sym
   }
@@ -203,7 +203,7 @@ class RichPresentationCompiler(
    * syncTopLevelSyms, since the units in question will
    * never be reloaded again.
    */
-  def removeAllDeleted() {
+  def removeAllDeleted(): Unit = {
     allSources = allSources.filter { _.file.exists }
     val deleted = symsByFile.keys.filter { !_.exists }
     for (f <- deleted) {
@@ -212,7 +212,7 @@ class RichPresentationCompiler(
   }
 
   /** Remove symbols defined by file that no longer exist. */
-  def removeDeleted(f: AbstractFile) {
+  def removeDeleted(f: AbstractFile): Unit = {
     val syms = symsByFile(f)
     for (s <- syms) {
       s.owner.info.decls unlink s
@@ -223,7 +223,7 @@ class RichPresentationCompiler(
 
   private def typePublicMembers(tpe: Type): Iterable[TypeMember] = {
     val members = new mutable.LinkedHashMap[Symbol, TypeMember]
-    def addTypeMember(sym: Symbol, pre: Type, inherited: Boolean, viaView: Symbol) {
+    def addTypeMember(sym: Symbol, pre: Type, inherited: Boolean, viaView: Symbol): Unit = {
       try {
         val m = new TypeMember(
           sym,
@@ -420,7 +420,7 @@ class RichPresentationCompiler(
     super.isOutOfDate
   }
 
-  protected def setNotifyWhenReady() {
+  protected def setNotifyWhenReady(): Unit = {
     notifyWhenReady = true
   }
 
@@ -431,7 +431,7 @@ class RichPresentationCompiler(
     }
   }
 
-  override def askShutdown() {
+  override def askShutdown(): Unit = {
     super.askShutdown()
     parent = null
     indexer = null

--- a/src/main/scala/org/ensime/server/Server.scala
+++ b/src/main/scala/org/ensime/server/Server.scala
@@ -14,7 +14,6 @@ import org.ensime.util._
 import org.slf4j._
 import org.slf4j.bridge.SLF4JBridgeHandler
 
-import scala.io.Source
 import scala.util.Properties
 import scala.util.Properties._
 
@@ -54,7 +53,7 @@ class Server(config: EnsimeConfig,
   import org.ensime.server.Server.log
 
   // the config file parsing will attempt to create directories that are expected
-  require(config.cacheDir.isDirectory, config.cacheDir + " is not a valid cache directory")
+  require(config.cacheDir.isDirectory, "" + config.cacheDir + " is not a valid cache directory")
 
   val actorSystem = ActorSystem.create()
   // TODO move this to only be started when we want to receive
@@ -68,7 +67,7 @@ class Server(config: EnsimeConfig,
 
   val project = new Project(config, actorSystem)
 
-  def start() {
+  def start(): Unit = {
     project.initProject()
     startSocketListener()
   }
@@ -76,7 +75,7 @@ class Server(config: EnsimeConfig,
   private val hasShutdownFlag = new AtomicBoolean(false)
   def startSocketListener(): Unit = {
     val t = new Thread(new Runnable() {
-      def run() {
+      def run(): Unit = {
         try {
           while (!hasShutdownFlag.get()) {
             try {
@@ -97,7 +96,7 @@ class Server(config: EnsimeConfig,
     t.start()
   }
 
-  def shutdown() {
+  def shutdown(): Unit = {
     log.info("Shutting down server")
     hasShutdownFlag.set(true)
     listener.close()
@@ -134,7 +133,7 @@ class SocketReader(socket: Socket, protocol: Protocol, handler: ActorRef) extend
   val in = new BufferedInputStream(socket.getInputStream)
   val reader = new InputStreamReader(in, "UTF-8")
 
-  override def run() {
+  override def run(): Unit = {
     try {
       while (true) {
         val msg: WireFormat = protocol.readMessage(reader)
@@ -167,7 +166,7 @@ class SocketHandler(socket: Socket,
   val reader = new SocketReader(socket, protocol, self)
   val out = new BufferedOutputStream(socket.getOutputStream)
 
-  def write(value: WireFormat) {
+  def write(value: WireFormat): Unit = {
     try {
       protocol.writeMessage(value, out)
     } catch {
@@ -177,7 +176,7 @@ class SocketHandler(socket: Socket,
     }
   }
 
-  override def preStart() {
+  override def preStart(): Unit = {
     reader.start()
   }
 

--- a/src/main/scala/org/ensime/sexp/Sexp.scala
+++ b/src/main/scala/org/ensime/sexp/Sexp.scala
@@ -1,7 +1,6 @@
 package org.ensime.sexp
 
 import collection.breakOut
-import pimpathon.map._
 
 /**
  * An S-Expression is either
@@ -42,8 +41,8 @@ object SexpNumber {
   def apply(n: Int) = new SexpNumber(BigDecimal(n))
   def apply(n: Long) = new SexpNumber(BigDecimal(n))
   def apply(n: Double) = n match {
-    case n if n.isNaN => SexpNil
-    case n if n.isInfinity => SexpNil
+    case _ if n.isNaN => SexpNil
+    case _ if n.isInfinity => SexpNil
     case _ => new SexpNumber(BigDecimal(n))
   }
   def apply(n: BigInt) = new SexpNumber(BigDecimal(n))

--- a/src/main/scala/org/ensime/sexp/SexpPrinter.scala
+++ b/src/main/scala/org/ensime/sexp/SexpPrinter.scala
@@ -11,7 +11,7 @@ trait SexpPrinter extends (Sexp => String) {
   def apply(x: Sexp): String = {
     val sb = new StringBuilder
     print(x, sb)
-    sb.toString
+    sb.toString()
   }
 
   /**
@@ -20,7 +20,7 @@ trait SexpPrinter extends (Sexp => String) {
   def apply(x: Sexp, swank: String, rpc: Long): String = {
     val sb = new StringBuilder
     print(x, swank, rpc, sb)
-    sb.toString
+    sb.toString()
   }
 
   /**
@@ -54,7 +54,7 @@ trait SexpPrinter extends (Sexp => String) {
       // but PlainString can be *really* slow and eat up loads of memory
       //sb.append(n.underlying.toPlainString)
       //sb.append(n.underlying.toEngineeringString())
-      sb.append(n.toString)
+      sb.append(n.toString())
   }
 
   // we prefer not to escape some characters when in strings
@@ -78,7 +78,7 @@ trait SexpPrinter extends (Sexp => String) {
     sb.append('"').append(escaped).append('"')
   }
 
-  protected def printSeq[A](iterable: Iterable[A], printSeparator: => Unit)(f: A => Unit) {
+  protected def printSeq[A](iterable: Iterable[A], printSeparator: => Unit)(f: A => Unit): Unit = {
     var first = true
     iterable.foreach { a =>
       if (first) first = false else printSeparator

--- a/src/main/scala/org/ensime/sexp/formats/BigDecimalConvertor.scala
+++ b/src/main/scala/org/ensime/sexp/formats/BigDecimalConvertor.scala
@@ -19,9 +19,9 @@ class BigDecimalConvertor[T](
 
 object BigDecimalConvertor {
   // an implicit already exists from many of these types to BigDecimal
-  implicit val IntBigConv = new BigDecimalConvertor[Int](identity, _.intValue)
-  implicit val LongBigConv = new BigDecimalConvertor[Long](identity, _.longValue)
-  implicit val FloatBigConv = new BigDecimalConvertor[Float](identity, _.floatValue) {
+  implicit val IntBigConv = new BigDecimalConvertor[Int](identity, _.intValue())
+  implicit val LongBigConv = new BigDecimalConvertor[Long](identity, _.longValue())
+  implicit val FloatBigConv = new BigDecimalConvertor[Float](identity, _.floatValue()) {
     override def isPosInf(t: Float) = t.isPosInfinity
     override def PosInf = Float.PositiveInfinity
     override def isNegInf(t: Float) = t.isNegInfinity
@@ -29,7 +29,7 @@ object BigDecimalConvertor {
     override def isNaN(t: Float) = t.isNaN
     override def NaN = Float.NaN
   }
-  implicit val DoubleBigConv = new BigDecimalConvertor[Double](identity, _.doubleValue) {
+  implicit val DoubleBigConv = new BigDecimalConvertor[Double](identity, _.doubleValue()) {
     override def isPosInf(t: Double) = t.isPosInfinity
     override def PosInf = Double.PositiveInfinity
     override def isNegInf(t: Double) = t.isNegInfinity
@@ -37,9 +37,9 @@ object BigDecimalConvertor {
     override def isNaN(t: Double) = t.isNaN
     override def NaN = Double.NaN
   }
-  implicit val ByteBigConv = new BigDecimalConvertor[Byte](identity, _.byteValue)
-  implicit val ShortBigConv = new BigDecimalConvertor[Short](identity, _.shortValue)
-  implicit val BigIntBigConv = new BigDecimalConvertor[BigInt](BigDecimal.apply, _.toBigInt)
+  implicit val ByteBigConv = new BigDecimalConvertor[Byte](identity, _.byteValue())
+  implicit val ShortBigConv = new BigDecimalConvertor[Short](identity, _.shortValue())
+  implicit val BigIntBigConv = new BigDecimalConvertor[BigInt](BigDecimal.apply, _.toBigInt())
   implicit val BigDecimalBigConv = new BigDecimalConvertor[BigDecimal](identity, identity)
 }
 

--- a/src/main/scala/org/ensime/sexp/formats/CollectionFormats.scala
+++ b/src/main/scala/org/ensime/sexp/formats/CollectionFormats.scala
@@ -1,14 +1,12 @@
 package org.ensime.sexp.formats
 
-import collection.GenTraversableOnce
 import collection.generic.CanBuildFrom
 import collection.breakOut
-import collection.{ immutable => im, mutable => mut }
+import collection.{ immutable => im }
 
 import org.ensime.sexp._
 import scala.collection.GenMap
 import scala.collection.GenTraversable
-import scala.collection.generic.IsTraversableLike
 
 /**
  * Support for anything with a `CanBuildFrom`.
@@ -85,7 +83,7 @@ trait CollectionFormats {
       )
 
     def read(v: Sexp): M[K, V] = v match {
-      case SexpNil => cbf().result
+      case SexpNil => cbf().result()
       case SexpList(els) => els.map {
         case SexpList(sk :: sv :: Nil) => (sk.convertTo[K], sv.convertTo[V])
         case x => deserializationError(x)

--- a/src/main/scala/org/ensime/sexp/package.scala
+++ b/src/main/scala/org/ensime/sexp/package.scala
@@ -1,8 +1,8 @@
 package org.ensime
 
 package object sexp {
-  implicit def pimpAny[T](any: T) = new PimpedAny(any)
-  implicit def pimpString(string: String) = new PimpedString(string)
+  implicit def pimpAny[T](any: T): PimpedAny[T] = new PimpedAny(any)
+  implicit def pimpString(string: String): PimpedString = new PimpedString(string)
 }
 
 package sexp {

--- a/src/main/scala/org/ensime/util/FileEdit.scala
+++ b/src/main/scala/org/ensime/util/FileEdit.scala
@@ -13,7 +13,7 @@ trait FileEdit extends Ordered[FileEdit] {
   import scala.math.Ordered.orderingToOrdered
 
   def compare(that: FileEdit): Int =
-    (this.file, this.from, this.to, this.text) compare (that.file, that.from, that.to, that.text)
+    (this.file, this.from, this.to, this.text).compare((that.file, that.from, that.to, that.text))
 }
 
 case class TextEdit(file: File, from: Int, to: Int, text: String) extends FileEdit

--- a/src/main/scala/org/ensime/util/FileUtil.scala
+++ b/src/main/scala/org/ensime/util/FileUtil.scala
@@ -4,12 +4,9 @@ import java.io._
 import java.net.URI
 import java.nio.charset.Charset
 import org.apache.commons.vfs2.FileObject
-import scala.collection.Seq
 import scala.collection.mutable
 import scala.util.Try
 import scala.sys.process._
-
-import pimpathon.file._
 
 /** A wrapper around file, allowing iteration either on direct children or on directory tree */
 class RichFile(file: File) {
@@ -199,7 +196,7 @@ object FileUtils {
       // Try to fail fast, before writing anything to disk.
       changes.foreach {
         case (f: File, s: String) => if (f.isDirectory || !f.canWrite) {
-          throw new IllegalArgumentException(f + " is not a writable file.")
+          throw new IllegalArgumentException("" + f + " is not a writable file.")
         }
         case _ =>
           throw new IllegalArgumentException("Invalid (File,String) pair.")

--- a/src/main/scala/org/ensime/util/ParboiledParser.scala
+++ b/src/main/scala/org/ensime/util/ParboiledParser.scala
@@ -28,7 +28,7 @@ trait ParboiledParser[T] extends Parser with ThreadLocalSupport {
 
   protected implicit class RulePimp(val rule: Rule0) {
     def save: Rule1[String] = { rule ~> (_.toString) }
-    def as[T](t: T): Rule1[T] = { rule ~> (_ => t) }
+    def as[P](t: P): Rule1[P] = { rule ~> (_ => t) }
   }
 
   protected def Top: Rule1[T]

--- a/src/main/scala/org/ensime/util/Reporter.scala
+++ b/src/main/scala/org/ensime/util/Reporter.scala
@@ -6,28 +6,28 @@ import scala.tools.nsc.reporters.Reporter
 import scala.reflect.internal.util.Position
 
 trait ReportHandler {
-  def messageUser(str: String)
-  def clearAllScalaNotes()
-  def clearAllJavaNotes()
-  def reportScalaNotes(notes: List[Note])
-  def reportJavaNotes(notes: List[Note])
+  def messageUser(str: String): Unit
+  def clearAllScalaNotes(): Unit
+  def clearAllJavaNotes(): Unit
+  def reportScalaNotes(notes: List[Note]): Unit
+  def reportJavaNotes(notes: List[Note]): Unit
 }
 
 class PresentationReporter(handler: ReportHandler) extends Reporter {
 
   val log = LoggerFactory.getLogger(classOf[PresentationReporter])
   private var enabled = true
-  def enable() { enabled = true }
-  def disable() { enabled = false }
+  def enable(): Unit = { enabled = true }
+  def disable(): Unit = { enabled = false }
 
-  override def reset() {
+  override def reset(): Unit = {
     super.reset()
     if (enabled) {
       handler.clearAllScalaNotes()
     }
   }
 
-  override def info0(pos: Position, msg: String, severity: Severity, force: Boolean) {
+  override def info0(pos: Position, msg: String, severity: Severity, force: Boolean): Unit = {
     severity.count += 1
     try {
       if (severity.id == 0) {
@@ -62,6 +62,5 @@ class PresentationReporter(handler: ReportHandler) extends Reporter {
       case c => c
     }
   }
-
 }
 

--- a/src/main/scala/org/ensime/util/SExp.scala
+++ b/src/main/scala/org/ensime/util/SExp.scala
@@ -119,7 +119,7 @@ object SExp {
   def propList(items: Iterable[(String, SExp)]): SExpList = {
     val nonNil = items.filter {
       case (s, NilAtom) => false
-      case (s, SExpList(items)) if items.isEmpty => false
+      case (s, SExpList(listItems)) if listItems.isEmpty => false
       case _ => true
     }
     SExpList(nonNil.flatMap(ea => List(key(ea._1), ea._2)).toList)

--- a/src/test/scala/org/ensime/config/EnsimeConfigSpec.scala
+++ b/src/test/scala/org/ensime/config/EnsimeConfigSpec.scala
@@ -1,6 +1,5 @@
 package org.ensime.config
 
-import org.ensime.server.Server
 import org.ensime.test.TestUtil
 import org.scalatest.{ Matchers, FunSpec }
 
@@ -109,7 +108,7 @@ class EnsimeConfigSpec extends FunSpec with Matchers {
  :source-mode ${if (sourceMode) "t" else "nil"}
  :subprojects ((:name "module1"
                 :scala-version "2.10.4"
-                :targets (${abcDirStr}))))""", { implicit config =>
+                :targets ($abcDirStr))))""", { implicit config =>
             assert(config.sourceMode == sourceMode)
             assert(config.runtimeClasspath == Set(dir / "abc"), config)
             assert(config.compileClasspath == (

--- a/src/test/scala/org/ensime/server/RefactoringHandlerSpec.scala
+++ b/src/test/scala/org/ensime/server/RefactoringHandlerSpec.scala
@@ -1,4 +1,4 @@
-package org.ensime
+package org.ensime.server
 
 import java.io.File
 import org.ensime.test.util.Helpers

--- a/src/test/scala/org/ensime/test/SExpSpec.scala
+++ b/src/test/scala/org/ensime/test/SExpSpec.scala
@@ -1,4 +1,5 @@
 package org.ensime.test
+
 import org.scalatest.FunSpec
 import org.scalatest.Matchers
 import org.ensime.util.{ SExpList, StringAtom, SExpParser, BooleanAtom }
@@ -6,7 +7,7 @@ import org.ensime.util.{ SExpList, StringAtom, SExpParser, BooleanAtom }
 class SExpSpec extends FunSpec with Matchers {
 
   describe("SExpSpec") {
-    def check(input: String, expected: String) {
+    def check(input: String, expected: String): Unit = {
       val result = SExpParser.read(input).toString
       assert(result == expected, "expected " + expected + " got " + result)
       // throw it through again - everything should round trip perfectly

--- a/src/test/scala/org/ensime/test/SwankProtocolSpec.scala
+++ b/src/test/scala/org/ensime/test/SwankProtocolSpec.scala
@@ -55,7 +55,7 @@ class SwankProtocolSpec extends FunSpec with ShouldMatchers with BeforeAndAfterA
         val latch = new CountDownLatch(1)
 
         val prot = new SwankProtocol(actorSystem, null, t) {
-          override def sendMessage(o: WireFormat) {
+          override def sendMessage(o: WireFormat): Unit = {
             out.send(o.toString)
             latch.countDown()
           }
@@ -344,7 +344,7 @@ class SwankProtocolSpec extends FunSpec with ShouldMatchers with BeforeAndAfterA
       }
     }
 
-    def testRefactorMethod(msg: String, desc: RefactorDesc) {
+    def testRefactorMethod(msg: String, desc: RefactorDesc): Unit = {
 
       val refactorEffect = new RefactorEffect(7, desc.refactorType, List(TextEdit(file3, 5, 7, "aaa")))
       val refactorResult = new RefactorResult(7, desc.refactorType, List(file3, file1))

--- a/src/test/scala/org/ensime/test/TestUtil.scala
+++ b/src/test/scala/org/ensime/test/TestUtil.scala
@@ -90,7 +90,7 @@ object TestUtil {
     EnsimeConfig(
       base.canon, cacheDir.canon, "simple", scalaVersion,
       compilerArgs, javaSource.toList, List(module),
-      FormattingPreferences(), false, Nil
+      FormattingPreferences(), `source-mode` = false, Nil
     )
   }
 

--- a/src/test/scala/org/ensime/test/intg/IntgUtil.scala
+++ b/src/test/scala/org/ensime/test/intg/IntgUtil.scala
@@ -68,7 +68,7 @@ object IntgUtil extends Assertions with SLF4JLogging {
       actor ! AsyncSent(event)
     }
 
-    def expectAsync(dur: FiniteDuration, expected: ProtocolEvent) {
+    def expectAsync(dur: FiniteDuration, expected: ProtocolEvent): Unit = {
 
       val askRes = Patterns.ask(actor, AsyncRequest(expected), dur)
       try {

--- a/src/test/scala/org/ensime/test/util/Helpers.scala
+++ b/src/test/scala/org/ensime/test/util/Helpers.scala
@@ -6,20 +6,16 @@ import akka.actor.ActorSystem
 import akka.actor.Props
 import akka.testkit.TestProbe
 import akka.testkit.TestActorRef
-import java.nio.charset.Charset
 
 import org.ensime.config.EnsimeConfig
 import org.ensime.indexer._
-import org.ensime.protocol.swank.SwankProtocol
 import org.ensime.server._
 import org.ensime.test.TestUtil
-import org.ensime.util.FileUtils
 import org.scalatest.exceptions.TestFailedException
 import org.slf4j.LoggerFactory
 import org.ensime.util.RichFile._
 
 import scala.reflect.internal.util.BatchSourceFile
-import scala.reflect.io.Path
 import scala.tools.nsc.Settings
 import scala.tools.nsc.{ Global => nscGlobal }
 import scala.tools.nsc.interactive.Global
@@ -109,11 +105,11 @@ object Helpers {
   }
 
   def readSrcFile(src: BatchSourceFile, encoding: String = "UTF-8"): String =
-    scala.tools.nsc.io.File(src.path)(encoding).slurp
+    scala.tools.nsc.io.File(src.path)(encoding).slurp()
 
   def contents(lines: String*) = lines.mkString("\n")
 
-  def expectFailure(msgLines: String*)(action: () => Unit) {
+  def expectFailure(msgLines: String*)(action: () => Unit): Unit = {
     try {
       action()
       throw new IllegalStateException("Expected failure! Should not have succeeded!")


### PR DESCRIPTION
Lots of minor tweaks based on -Xlint and enabling wartremover.

I would like to switch -Xlint on permently but it falls over on some of the akka code (inference of any).
I'll add comments on the various changes so you can see what they are based on.
