### PR TITLE
Fix bug where empty parameter sections were always marked as implicit.

### DIFF
--- a/src/main/scala/org/ensime/model/Model.scala
+++ b/src/main/scala/org/ensime/model/Model.scala
@@ -497,8 +497,9 @@ trait ModelBuilders { self: RichPresentationCompiler =>
 
   object ParamSectionInfo {
     def apply(params: Iterable[Symbol]): ParamSectionInfo = {
-      new ParamSectionInfo(params.map { s => (s.nameString, TypeInfo(s.tpe)) },
-        params.forall { s => s.isImplicit })
+      new ParamSectionInfo(
+        params.map { s => (s.nameString, TypeInfo(s.tpe)) },
+        params.exists(_.isImplicit))
     }
   }
 


### PR DESCRIPTION
This was breaking param list expansion in Emacs.