### PR TITLE
close #613 until it is fixed upstream

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -142,7 +142,7 @@ graphSettings
 scalariformSettings
 
 // let's bump this every time we get more tests
-ScoverageKeys.coverageMinimum :=74
+ScoverageKeys.coverageMinimum := 75
 
 ScoverageKeys.coverageFailOnMinimum := true
 


### PR DESCRIPTION
Each file watcher now consists of two watchers:

1. doing what we want it to do (watch for source/classfile changes)
2. a workaround looking for recreations of the folders that we are watching, resetting `1.` if that happens

to workaround an upstream bug.