### PR TITLE
Send type args for nullary method return types. + a little cleanup.

### DIFF
--- a/src/main/scala/org/ensime/model/Helpers.scala
+++ b/src/main/scala/org/ensime/model/Helpers.scala
@@ -76,9 +76,9 @@ trait Helpers { self: Global =>
   }
 
   def resultTypeName(tpe: Type): String = {
-    typeShortName(tpe) + (if (tpe.typeArgs.length > 0) {
+    typeShortName(tpe) + (if (tpe.typeArgs.size > 0) {
       "[" +
-        tpe.typeArgs.map(typeShortNameWithArgs).mkString(", ") +
+        tpe.typeArgs.map(typeShortNameWithArgs(_)).mkString(", ") +
         "]"
     } else { "" })
   }

--- a/src/main/scala/org/ensime/server/protocol/swank/SwankProtocolConversions.scala
+++ b/src/main/scala/org/ensime/server/protocol/swank/SwankProtocolConversions.scala
@@ -554,7 +554,6 @@ object SwankProtocolConversions {
       case value: PackageInfo => toWF(value)
       case value: TypeInfo => toWF(value)
       case value: NamedTypeMemberInfo => toWF(value)
-      case unknownValue => throw new IllegalStateException("Unknown EntityInfo: " + unknownValue)
     }
   }
 
@@ -567,7 +566,7 @@ object SwankProtocolConversions {
           (":arrow-type", true),
           (":result-type", toWF(value.resultType)),
           (":param-sections", SExp(value.paramSections.map(toWF))))
-      case value: TypeInfo =>
+      case value: BasicTypeInfo =>
         SExp.propList((":name", value.name),
           (":type-id", value.id),
           (":full-name", value.fullName),
@@ -576,7 +575,6 @@ object SwankProtocolConversions {
           (":members", SExp(value.members.map(toWF))),
           (":pos", value.pos.map(toWF).getOrElse('nil)),
           (":outer-type-id", value.outerTypeId.map(intToSExp).getOrElse('nil)))
-      case unknownValue => throw new IllegalStateException("Unknown TypeInfo: " + unknownValue)
     }
   }
 

--- a/src/test/scala/org/ensime/intg/BasicWorkflow.scala
+++ b/src/test/scala/org/ensime/intg/BasicWorkflow.scala
@@ -133,7 +133,7 @@ class BasicWorkflow extends FunSpec with Matchers {
         // loaded by the pres compiler
         val testMethodSymbolInfo = project.rpcSymbolAtPoint(fooFilePath, 276)
         testMethodSymbolInfo match {
-          case Some(SymbolInfo("testMethod", "testMethod", Some(OffsetSourcePosition(`fooFile`, 114)), ArrowTypeInfo("(i: Int, s: String)Int", 133, BasicTypeInfo("Int", 1, 'class, "scala.Int", List(), List(), None, None), List(ParamSectionInfo(List((i, BasicTypeInfo("Int", 1, 'class, "scala.Int", List(), List(), None, None)), (s, BasicTypeInfo("String", 39, 'class, "java.lang.String", List(), List(), None, None))), false))), true, Some(_))) =>
+          case Some(SymbolInfo("testMethod", "testMethod", Some(OffsetSourcePosition(`fooFile`, 114)), ArrowTypeInfo("(i: Int, s: String)Int", 126, BasicTypeInfo("Int", 1, 'class, "scala.Int", List(), List(), None, None), List(ParamSectionInfo(List((i, BasicTypeInfo("Int", 1, 'class, "scala.Int", List(), List(), None, None)), (s, BasicTypeInfo("String", 39, 'class, "java.lang.String", List(), List(), None, None))), false))), true, Some(_))) =>
           case _ =>
             fail("symbol at point (local test method), got: " + testMethodSymbolInfo)
         }


### PR DESCRIPTION
Previously you'd see a lot of "List", "Option" types showing up in the inspector without type arguments.