### PR TITLE
use S-Express for SwankProtocolConversions

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -10,7 +10,7 @@ organization := "org.ensime"
 
 name := "ensime"
 
-scalaVersion := "2.11.4"
+scalaVersion := "2.11.5"
 
 version := "0.9.10-SNAPSHOT"
 
@@ -74,6 +74,8 @@ internalDependencyClasspath in Compile += { Attributed.blank(JavaTools) }
 internalDependencyClasspath in Test += { Attributed.blank(JavaTools) }
 
 scalacOptions in Compile ++= Seq(
+  // uncomment this to debug implicit resolution compilation problems
+  //"-Xlog-implicits",
   "-encoding", "UTF-8", "-target:jvm-1.6", "-feature", "-deprecation",
   "-Xfatal-warnings",
   "-language:postfixOps", "-language:implicitConversions"

--- a/src/main/scala/org/ensime/EnsimeApi.scala
+++ b/src/main/scala/org/ensime/EnsimeApi.scala
@@ -73,19 +73,19 @@ trait EnsimeApi {
   def rpcDebugAttachVM(hostname: String, port: String): DebugVmStatus
   def rpcDebugStopVM(): Boolean
   def rpcDebugRun(): Boolean
-  def rpcDebugContinue(threadId: Long): Boolean
+  def rpcDebugContinue(threadId: String): Boolean
   def rpcDebugSetBreakpoint(file: String, line: Int): Unit
   def rpcDebugClearBreakpoint(file: String, line: Int): Unit
   def rpcDebugClearAllBreakpoints(): Unit
   def rpcDebugListBreakpoints(): BreakpointList
-  def rpcDebugNext(threadId: Long): Boolean
-  def rpcDebugStep(threadId: Long): Boolean
-  def rpcDebugStepOut(threadId: Long): Boolean
-  def rpcDebugLocateName(threadId: Long, name: String): Option[DebugLocation]
+  def rpcDebugNext(threadId: String): Boolean
+  def rpcDebugStep(threadId: String): Boolean
+  def rpcDebugStepOut(threadId: String): Boolean
+  def rpcDebugLocateName(threadId: String, name: String): Option[DebugLocation]
   def rpcDebugValue(loc: DebugLocation): Option[DebugValue]
-  def rpcDebugToString(threadId: Long, loc: DebugLocation): Option[String]
+  def rpcDebugToString(threadId: String, loc: DebugLocation): Option[String]
   def rpcDebugSetValue(loc: DebugLocation, newValue: String): Boolean
-  def rpcDebugBacktrace(threadId: Long, index: Int, count: Int): DebugBacktrace
+  def rpcDebugBacktrace(threadId: String, index: Int, count: Int): DebugBacktrace
   def rpcDebugActiveVM(): Boolean
 }
 

--- a/src/main/scala/org/ensime/core/Analyzer.scala
+++ b/src/main/scala/org/ensime/core/Analyzer.scala
@@ -49,7 +49,7 @@ class Analyzer(
       project ! AsyncEvent(ClearAllScalaNotesEvent)
     }
     override def reportScalaNotes(notes: List[Note]): Unit = {
-      project ! AsyncEvent(NewScalaNotesEvent(NoteList(full = false, notes)))
+      project ! AsyncEvent(NewScalaNotesEvent(isFull = false, notes))
     }
   }
 

--- a/src/main/scala/org/ensime/core/EnsimeEvent.scala
+++ b/src/main/scala/org/ensime/core/EnsimeEvent.scala
@@ -1,31 +1,71 @@
 package org.ensime.core
 
+import java.io.File
 import org.ensime.model.LineSourcePosition
-import org.ensime.util.NoteList
+import org.ensime.util.Note
 
-/**
- * A asynchronous swank protocol event
- */
+/** Asynchronous swank protocol event */
 sealed trait EnsimeEvent
-
 sealed trait GeneralSwankEvent extends EnsimeEvent
+sealed trait DebugEvent extends EnsimeEvent
 
+/** Generic background notification. */
 case class SendBackgroundMessageEvent(code: Int, detail: Option[String]) extends GeneralSwankEvent
+
+/** The presentation compiler is ready to accept requests. */
 case object AnalyzerReadyEvent extends GeneralSwankEvent
+
+/** The presentation compiler has finished analysing the entire project. */
 case object FullTypeCheckCompleteEvent extends GeneralSwankEvent
+
+/** The search engine has finished indexing the classpath. */
 case object IndexerReadyEvent extends GeneralSwankEvent
+
+/** The presentation compiler was restarted. Existing `:type-id`s are invalid. */
 case object CompilerRestartedEvent extends GeneralSwankEvent
 
+/** The presentation compiler has invalidated all existing notes.  */
 case object ClearAllScalaNotesEvent extends GeneralSwankEvent
-case class NewScalaNotesEvent(noteList: NoteList) extends GeneralSwankEvent
 
-sealed trait DebugEvent extends EnsimeEvent
-case class DebugStepEvent(threadId: Long, threadName: String, pos: LineSourcePosition) extends DebugEvent
-case class DebugBreakEvent(threadId: Long, threadName: String, pos: LineSourcePosition) extends DebugEvent
-case class DebugVMStartEvent() extends DebugEvent
-case class DebugVMDisconnectEvent() extends DebugEvent
-case class DebugExceptionEvent(excId: Long, threadId: Long, threadName: String, pos: Option[LineSourcePosition]) extends DebugEvent
-case class DebugThreadStartEvent(threadId: Long) extends DebugEvent
-case class DebugThreadDeathEvent(threadId: Long) extends DebugEvent
-case class DebugOutputEvent(out: String) extends DebugEvent
+/** The presentation compiler is providing notes: e.g. errors, warnings. */
+case class NewScalaNotesEvent(
+  isFull: Boolean,
+  notes: List[Note]) extends GeneralSwankEvent
+
+/** The debugged VM has stepped to a new location and is now paused awaiting control. */
+case class DebugStepEvent(
+  threadId: String,
+  threadName: String,
+  file: File,
+  line: Int) extends DebugEvent
+
+/** The debugged VM has stopped at a breakpoint. */
+case class DebugBreakEvent(
+  threadId: String,
+  threadName: String,
+  file: File,
+  line: Int) extends DebugEvent
+
+/** The debugged VM has started. */
+case object DebugVMStartEvent extends DebugEvent
+
+/** The debugger has disconnected from the debugged VM. */
+case object DebugVMDisconnectEvent extends DebugEvent
+
+/** The debugged VM has thrown an exception and is now paused waiting for control. */
+case class DebugExceptionEvent(
+  exception: Long,
+  threadId: String,
+  threadName: String,
+  file: Option[File],
+  line: Option[Int]) extends DebugEvent
+
+/** A new thread has started. */
+case class DebugThreadStartEvent(threadId: String) extends DebugEvent
+
+/** A thread has died. */
+case class DebugThreadDeathEvent(threadId: String) extends DebugEvent
+
+/** Communicates stdout/stderr of debugged VM to client. */
+case class DebugOutputEvent(body: String) extends DebugEvent
 

--- a/src/main/scala/org/ensime/core/ProjectEnsimeApiImpl.scala
+++ b/src/main/scala/org/ensime/core/ProjectEnsimeApiImpl.scala
@@ -91,7 +91,7 @@ trait ProjectEnsimeApiImpl extends EnsimeApi { self: Project =>
     callRPC[Boolean](acquireDebugger, DebugRunReq)
   }
 
-  override def rpcDebugContinue(threadId: Long): Boolean = {
+  override def rpcDebugContinue(threadId: String): Boolean = {
     callRPC[Boolean](acquireDebugger, DebugContinueReq(threadId))
   }
 
@@ -111,19 +111,19 @@ trait ProjectEnsimeApiImpl extends EnsimeApi { self: Project =>
     callRPC[BreakpointList](acquireDebugger, DebugListBreakpointsReq)
   }
 
-  override def rpcDebugNext(threadId: Long): Boolean = {
+  override def rpcDebugNext(threadId: String): Boolean = {
     callRPC[Boolean](acquireDebugger, DebugNextReq(threadId))
   }
 
-  override def rpcDebugStep(threadId: Long): Boolean = {
+  override def rpcDebugStep(threadId: String): Boolean = {
     callRPC[Boolean](acquireDebugger, DebugStepReq(threadId))
   }
 
-  override def rpcDebugStepOut(threadId: Long): Boolean = {
+  override def rpcDebugStepOut(threadId: String): Boolean = {
     callRPC[Boolean](acquireDebugger, DebugStepOutReq(threadId))
   }
 
-  override def rpcDebugLocateName(threadId: Long, name: String): Option[DebugLocation] = {
+  override def rpcDebugLocateName(threadId: String, name: String): Option[DebugLocation] = {
     callRPC[Option[DebugLocation]](acquireDebugger, DebugLocateNameReq(threadId, name))
   }
 
@@ -131,7 +131,7 @@ trait ProjectEnsimeApiImpl extends EnsimeApi { self: Project =>
     callRPC[Option[DebugValue]](acquireDebugger, DebugValueReq(loc))
   }
 
-  override def rpcDebugToString(threadId: Long, loc: DebugLocation): Option[String] = {
+  override def rpcDebugToString(threadId: String, loc: DebugLocation): Option[String] = {
     callRPC[Option[String]](acquireDebugger, DebugToStringReq(threadId, loc))
   }
 
@@ -139,7 +139,7 @@ trait ProjectEnsimeApiImpl extends EnsimeApi { self: Project =>
     callRPC[Boolean](acquireDebugger, DebugSetValueReq(loc, newValue))
   }
 
-  override def rpcDebugBacktrace(threadId: Long, index: Int, count: Int): DebugBacktrace = {
+  override def rpcDebugBacktrace(threadId: String, index: Int, count: Int): DebugBacktrace = {
     callRPC[DebugBacktrace](acquireDebugger, DebugBacktraceReq(threadId, index, count))
   }
 

--- a/src/main/scala/org/ensime/indexer/SourceResolver.scala
+++ b/src/main/scala/org/ensime/indexer/SourceResolver.scala
@@ -43,7 +43,7 @@ class SourceResolver(config: EnsimeConfig) extends SourceListener with SLF4JLogg
     val srcJars = config.referenceSourceJars.toSet ++ {
       for {
         (_, module) <- config.modules
-        srcArchive <- module.referenceSourcesJars
+        srcArchive <- module.referenceSourceJars
       } yield srcArchive
     }
     for {

--- a/src/main/scala/org/ensime/model/ReplConfig.scala
+++ b/src/main/scala/org/ensime/model/ReplConfig.scala
@@ -6,4 +6,5 @@ import java.io.File
  * Created by rorygraves on 29/12/14.
  */
 // bit of a rubbish class
-class ReplConfig(val classpath: Set[File])
+// SH -- agreed. The client should be able to do all this without asking the server.
+case class ReplConfig(classpath: Set[File])

--- a/src/main/scala/org/ensime/server/ConnectionInfo.scala
+++ b/src/main/scala/org/ensime/server/ConnectionInfo.scala
@@ -1,9 +1,9 @@
 package org.ensime.server
 
-class ConnectionInfo {
-  val pid = None
-  val serverName: String = "ENSIME-ReferenceServer"
-
+case class EnsimeImplementation(
+  name: String)
+case class ConnectionInfo(
+  pid: Option[Int] = None,
+  implementation: EnsimeImplementation = EnsimeImplementation("ENSIME"),
   // Please also update changelog in SwankProtocol.scala
-  val protocolVersion: String = "0.8.11"
-}
+  version: String = "0.8.11")

--- a/src/main/scala/org/ensime/server/protocol/swank/SwankProtocol.scala
+++ b/src/main/scala/org/ensime/server/protocol/swank/SwankProtocol.scala
@@ -25,6 +25,7 @@ class SwankProtocol(actorSystem: ActorSystem,
    * Protocol Version: 0.8.11 (Must match version at ConnectionInfo.protocolVersion)
    *
    * Protocol Change Log:
+   *
    *   0.8.11
    *     Some calls now take (:file "filename" :contents "xxxx")
    *       as a way to transmit source files:
@@ -668,10 +669,10 @@ class SwankProtocol(actorSystem: ActorSystem,
        */
       case ("swank:typecheck-file", StringAtom(file) :: StringAtom(contents) :: Nil) =>
         rpcTarget.rpcTypecheckFiles(List(ContentsSourceFileInfo(new File(file), contents)), async = false)
-        sendRPCReturn(wfTrue, callId)
+        sendRPCReturn(toWF(true), callId)
       case ("swank:typecheck-file", SourceFileInfoExtractor(fileInfo) :: Nil) =>
         rpcTarget.rpcTypecheckFiles(List(fileInfo), async = false)
-        sendRPCReturn(wfTrue, callId)
+        sendRPCReturn(toWF(true), callId)
 
       /**
        * Doc RPC:
@@ -889,8 +890,7 @@ class SwankProtocol(actorSystem: ActorSystem,
        */
       case ("swank:package-member-completion", StringAtom(path) :: StringAtom(prefix) :: Nil) =>
         val members = rpcTarget.rpcPackageMemberCompletion(path, prefix)
-        val resultWF = toWF(members.map(toWF))
-        sendRPCReturn(resultWF, callId)
+        sendRPCReturn(toWF(members), callId)
 
       /**
        * Doc RPC:
@@ -916,8 +916,7 @@ class SwankProtocol(actorSystem: ActorSystem,
        */
       case ("swank:call-completion", IntAtom(id) :: Nil) =>
         val result = rpcTarget.rpcCallCompletion(id)
-        val wfResult = result.map(toWF).getOrElse(wfNull)
-        sendRPCReturn(wfResult, callId)
+        sendRPCReturn(toWF(result), callId)
 
       /**
        * Doc RPC:
@@ -939,8 +938,7 @@ class SwankProtocol(actorSystem: ActorSystem,
        */
       case ("swank:uses-of-symbol-at-point", StringAtom(file) :: IntAtom(point) :: Nil) =>
         val result = rpcTarget.rpcUsesOfSymAtPoint(file, point)
-        val wfResult = toWF(result.map(toWF))
-        sendRPCReturn(wfResult, callId)
+        sendRPCReturn(toWF(result), callId)
 
       /**
        * Doc RPC:
@@ -962,8 +960,7 @@ class SwankProtocol(actorSystem: ActorSystem,
        */
       case ("swank:member-by-name", StringAtom(typeFullName) :: StringAtom(memberName) :: BooleanAtom(memberIsType) :: Nil) =>
         val result = rpcTarget.rpcMemberByName(typeFullName, memberName, memberIsType)
-        val wfResult = result.map(toWF).getOrElse(wfNull)
-        sendRPCReturn(wfResult, callId)
+        sendRPCReturn(toWF(result), callId)
 
       /**
        * Doc RPC:
@@ -983,11 +980,7 @@ class SwankProtocol(actorSystem: ActorSystem,
        */
       case ("swank:type-by-id", IntAtom(id) :: Nil) =>
         val result = rpcTarget.rpcTypeById(id)
-        val wfResult = result match {
-          case Some(info) => toWF(info)
-          case None => wfNull
-        }
-        sendRPCReturn(wfResult, callId)
+        sendRPCReturn(toWF(result), callId)
 
       /**
        * Doc RPC:
@@ -1006,11 +999,7 @@ class SwankProtocol(actorSystem: ActorSystem,
        */
       case ("swank:type-by-name", StringAtom(name) :: Nil) =>
         val result = rpcTarget.rpcTypeByName(name)
-        val wfResult = result match {
-          case Some(info) => toWF(info)
-          case None => wfNull
-        }
-        sendRPCReturn(wfResult, callId)
+        sendRPCReturn(toWF(result), callId)
 
       /**
        * Doc RPC:
@@ -1032,8 +1021,7 @@ class SwankProtocol(actorSystem: ActorSystem,
        */
       case ("swank:type-by-name-at-point", StringAtom(name) :: StringAtom(file) :: OffsetRangeExtractor(range) :: Nil) =>
         val result = rpcTarget.rpcTypeByNameAtPoint(name, file, range)
-        val wfResult = result.map(toWF).getOrElse(wfNull)
-        sendRPCReturn(wfResult, callId)
+        sendRPCReturn(toWF(result), callId)
 
       /**
        * Doc RPC:
@@ -1053,8 +1041,7 @@ class SwankProtocol(actorSystem: ActorSystem,
        */
       case ("swank:type-at-point", StringAtom(file) :: OffsetRangeExtractor(range) :: Nil) =>
         val result = rpcTarget.rpcTypeAtPoint(file, range)
-        val wfResult = result.map(toWF).getOrElse(wfNull)
-        sendRPCReturn(wfResult, callId)
+        sendRPCReturn(toWF(result), callId)
 
       /**
        * Doc RPC:
@@ -1076,8 +1063,7 @@ class SwankProtocol(actorSystem: ActorSystem,
        */
       case ("swank:inspect-type-at-point", StringAtom(file) :: OffsetRangeExtractor(range) :: Nil) =>
         val result = rpcTarget.rpcInspectTypeAtPoint(file, range)
-        val wfResult = result.map(toWF).getOrElse(wfNull)
-        sendRPCReturn(wfResult, callId)
+        sendRPCReturn(toWF(result), callId)
 
       /**
        * Doc RPC:
@@ -1097,8 +1083,7 @@ class SwankProtocol(actorSystem: ActorSystem,
        */
       case ("swank:inspect-type-by-id", IntAtom(id) :: Nil) =>
         val result = rpcTarget.rpcInspectTypeById(id)
-        val wfResult = result.map(toWF).getOrElse(wfNull)
-        sendRPCReturn(wfResult, callId)
+        sendRPCReturn(toWF(result), callId)
 
       /**
        * Doc RPC:
@@ -1118,8 +1103,7 @@ class SwankProtocol(actorSystem: ActorSystem,
        */
       case ("swank:inspect-type-by-name", StringAtom(name) :: Nil) =>
         val result = rpcTarget.rpcInspectTypeByName(name)
-        val wfResult = result.map(toWF).getOrElse(wfNull)
-        sendRPCReturn(wfResult, callId)
+        sendRPCReturn(toWF(result), callId)
 
       /**
        * Doc RPC:
@@ -1140,8 +1124,7 @@ class SwankProtocol(actorSystem: ActorSystem,
        */
       case ("swank:symbol-at-point", StringAtom(file) :: IntAtom(point) :: Nil) =>
         val result = rpcTarget.rpcSymbolAtPoint(file, point)
-        val wfResult = result.map(toWF).getOrElse(wfNull)
-        sendRPCReturn(wfResult, callId)
+        sendRPCReturn(toWF(result), callId)
 
       /**
        * Doc RPC:
@@ -1161,9 +1144,8 @@ class SwankProtocol(actorSystem: ActorSystem,
        *   (:file "SExp.scala" :offset 2848)).....))) 42)
        */
       case ("swank:inspect-package-by-path", StringAtom(path) :: Nil) =>
-        val result = rpcTarget.rpcInspectPackageByPath(path)
-        val wfResult = result.map(toWF).getOrElse(wfNull)
-        sendRPCReturn(wfResult, callId)
+        val result: Option[EntityInfo] = rpcTarget.rpcInspectPackageByPath(path)
+        sendRPCReturn(toWF(result), callId)
 
       /**
        * Doc RPC:
@@ -1495,7 +1477,7 @@ class SwankProtocol(actorSystem: ActorSystem,
        *   (:return (:ok t) 42)
        */
       case ("swank:debug-continue", StringAtom(threadId) :: Nil) =>
-        val result = rpcTarget.rpcDebugContinue(threadId.toLong)
+        val result = rpcTarget.rpcDebugContinue(threadId)
         sendRPCReturn(toWF(result), callId)
 
       /**
@@ -1514,7 +1496,7 @@ class SwankProtocol(actorSystem: ActorSystem,
        *   (:return (:ok t) 42)
        */
       case ("swank:debug-step", StringAtom(threadId) :: Nil) =>
-        val result = rpcTarget.rpcDebugStep(threadId.toLong)
+        val result = rpcTarget.rpcDebugStep(threadId)
         sendRPCReturn(toWF(result), callId)
 
       /**
@@ -1533,7 +1515,7 @@ class SwankProtocol(actorSystem: ActorSystem,
        *   (:return (:ok t) 42)
        */
       case ("swank:debug-next", StringAtom(threadId) :: Nil) =>
-        val result = rpcTarget.rpcDebugNext(threadId.toLong)
+        val result = rpcTarget.rpcDebugNext(threadId)
         sendRPCReturn(toWF(result), callId)
 
       /**
@@ -1552,7 +1534,7 @@ class SwankProtocol(actorSystem: ActorSystem,
        *   (:return (:ok t) 42)
        */
       case ("swank:debug-step-out", StringAtom(threadId) :: Nil) =>
-        val result = rpcTarget.rpcDebugStepOut(threadId.toLong)
+        val result = rpcTarget.rpcDebugStepOut(threadId)
         sendRPCReturn(toWF(result), callId)
 
       /**
@@ -1572,12 +1554,12 @@ class SwankProtocol(actorSystem: ActorSystem,
        *   (:return (:ok (:slot :thread-id "7" :frame 2 :offset 0)) 42)
        */
       case ("swank:debug-locate-name", StringAtom(threadId) :: StringAtom(name) :: Nil) =>
-        val result = rpcTarget.rpcDebugLocateName(threadId.toLong, name)
+        val result = rpcTarget.rpcDebugLocateName(threadId, name)
         result match {
           case Some(loc) =>
             sendRPCReturn(toWF(loc), callId)
           case None =>
-            sendRPCReturn(wfFalse, callId)
+            sendRPCReturn(toWF(false), callId)
         }
 
       /**
@@ -1600,7 +1582,7 @@ class SwankProtocol(actorSystem: ActorSystem,
         val result = rpcTarget.rpcDebugValue(loc)
         result match {
           case Some(value) => sendRPCReturn(toWF(value), callId)
-          case None => sendRPCReturn(wfFalse, callId)
+          case None => sendRPCReturn(toWF(false), callId)
         }
 
       /**
@@ -1621,10 +1603,10 @@ class SwankProtocol(actorSystem: ActorSystem,
        *   (:return (:ok "A little lamb") 42)
        */
       case ("swank:debug-to-string", StringAtom(threadId) :: DebugLocationExtractor(loc) :: Nil) =>
-        val result = rpcTarget.rpcDebugToString(threadId.toLong, loc)
+        val result = rpcTarget.rpcDebugToString(threadId, loc)
         result match {
           case Some(value) => sendRPCReturn(toWF(value), callId)
-          case None => sendRPCReturn(wfFalse, callId)
+          case None => sendRPCReturn(toWF(false), callId)
         }
       /**
        * Doc RPC:
@@ -1664,7 +1646,7 @@ class SwankProtocol(actorSystem: ActorSystem,
        *   (:return (:ok (:frames () :thread-id "23" :thread-name "main")) 42)
        */
       case ("swank:debug-backtrace", StringAtom(threadId) :: IntAtom(index) :: IntAtom(count) :: Nil) =>
-        val result = rpcTarget.rpcDebugBacktrace(threadId.toLong, index, count)
+        val result = rpcTarget.rpcDebugBacktrace(threadId, index, count)
         sendRPCReturn(toWF(result), callId)
 
       /**
@@ -1707,13 +1689,8 @@ class SwankProtocol(actorSystem: ActorSystem,
    * @param  value  The value to return.
    * @param  callId The id of the RPC call.
    */
-  def sendRPCReturn(value: WireFormat, callId: Int): Unit = {
-    value match {
-      case sexp: SExp =>
-        sendMessage(SExp(key(":return"), SExp(key(":ok"), sexp), callId))
-      case _ => throw new IllegalStateException("Not a SExp: " + value)
-    }
-  }
+  def sendRPCReturn(value: WireFormat, callId: Int): Unit =
+    sendMessage(value.withRpcReturn(callId))
 
   override def sendEvent(event: EnsimeEvent): Unit = {
     sendMessage(toWF(event))
@@ -1813,7 +1790,7 @@ object SwankProtocol {
             IntAtom(frame) <- m.get(key(":frame"));
             IntAtom(offset) <- m.get(key(":offset"))
           ) yield {
-            DebugStackSlot(id.toLong, frame, offset)
+            DebugStackSlot(id, frame, offset)
           }
         case _ => None
       }

--- a/src/main/scala/org/ensime/sexp/SexpFormat.scala
+++ b/src/main/scala/org/ensime/sexp/SexpFormat.scala
@@ -3,7 +3,7 @@ package org.ensime.sexp
 import annotation.implicitNotFound
 
 /** Provides the S-Exp deserialization for type T. */
-@implicitNotFound(msg = "Cannot find SexpReader or SexpFormat type class for ${T}")
+@implicitNotFound(msg = "Cannot find SexpReader or SexpFormat for ${T}")
 trait SexpReader[T] {
   def read(value: Sexp): T
 }
@@ -15,7 +15,7 @@ object SexpReader {
 }
 
 /** Provides the S-Exp serialization for type T. */
-@implicitNotFound(msg = "Cannot find SexpWriter or SexpFormat type class for ${T}")
+@implicitNotFound(msg = "Cannot find SexpWriter or SexpFormat for ${T}")
 trait SexpWriter[T] {
   def write(obj: T): Sexp
 }
@@ -27,6 +27,7 @@ object SexpWriter {
 }
 
 /** Provides the S-Exp deserialization and serialization for type T. */
+@implicitNotFound(msg = "Cannot find SexpFormat for ${T}")
 trait SexpFormat[T] extends SexpReader[T] with SexpWriter[T]
 
 object SexpFormat {

--- a/src/main/scala/org/ensime/sexp/formats/BasicFormats.scala
+++ b/src/main/scala/org/ensime/sexp/formats/BasicFormats.scala
@@ -35,9 +35,10 @@ trait BasicFormats {
     }
   }
 
-  implicit object SymbolFormat extends SexpFormat[Symbol] {
-    def write(x: Symbol) = SexpString(x.name)
-    def read(value: Sexp) = value match {
+  // val allows override
+  implicit val SymbolFormat = new SexpFormat[Symbol] {
+    def write(x: Symbol): Sexp = SexpString(x.name)
+    def read(value: Sexp): Symbol = value match {
       case SexpString(x) => Symbol(x)
       case x => deserializationError(x)
     }
@@ -84,4 +85,15 @@ trait BasicFormats {
   implicit val ShortFormat = SexpFormat[Short]
   implicit val BigIntFormat = SexpFormat[BigInt]
   implicit val BigDecimalFormat = SexpFormat[BigDecimal]
+}
+
+trait SymbolAltFormat {
+  this: BasicFormats =>
+  override implicit val SymbolFormat = new SexpFormat[Symbol] {
+    def write(x: Symbol): Sexp = SexpSymbol(x.name)
+    def read(value: Sexp): Symbol = value match {
+      case SexpSymbol(x) => Symbol(x)
+      case x => deserializationError(x)
+    }
+  }
 }

--- a/src/main/scala/org/ensime/sexp/formats/ProductFormats.scala
+++ b/src/main/scala/org/ensime/sexp/formats/ProductFormats.scala
@@ -58,7 +58,7 @@ trait LowPriorityProductFormats {
     r: HListFormat[R]): SexpFormat[T] = new SexpFormat[T] {
 
     private val keys = k().toList[Symbol].map { sym =>
-      SexpSymbol(":" + sym.name)
+      SexpSymbol(":" + toWireName(sym.name))
     }
 
     def write(x: T): Sexp =
@@ -78,6 +78,9 @@ trait LowPriorityProductFormats {
         deserializationError(x)
     }
   }
+
+  // capable of overloading for legacy formats
+  def toWireName(field: String): String = field
 }
 
 trait ProductFormats extends LowPriorityProductFormats {
@@ -93,4 +96,15 @@ trait ProductFormats extends LowPriorityProductFormats {
       case x => deserializationError(x)
     }
   }
+}
+
+/**
+ * By default, S-Express uses the same field names in the wire format
+ * as the code. But some protocols may prefer dashes with Scala code
+ * that uses camel case. This mix-in provides that behaviour.
+ */
+trait CamelCaseToDashes {
+  this: LowPriorityProductFormats =>
+  override def toWireName(field: String): String =
+    field.replaceAll("([A-Z])", "-$1").toLowerCase.replaceAll("^-", "")
 }

--- a/src/main/scala/org/ensime/util/FileEdit.scala
+++ b/src/main/scala/org/ensime/util/FileEdit.scala
@@ -18,13 +18,15 @@ trait FileEdit extends Ordered[FileEdit] {
 
 case class TextEdit(file: File, from: Int, to: Int, text: String) extends FileEdit
 
-case class NewFile(file: File, text: String) extends FileEdit {
-  def from: Int = 0
-  def to: Int = text.length - 1
+// the next case classes have weird fields because we need the values in the protocol
+case class NewFile(file: File, from: Int, to: Int, text: String) extends FileEdit
+object NewFile {
+  def apply(file: File, text: String): NewFile = new NewFile(file, 0, text.length - 1, text)
 }
-case class DeleteFile(file: File, text: String) extends FileEdit {
-  def from: Int = 0
-  def to: Int = text.length - 1
+
+case class DeleteFile(file: File, from: Int, to: Int, text: String) extends FileEdit
+object DeleteFile {
+  def apply(file: File, text: String): DeleteFile = new DeleteFile(file, 0, text.length - 1, text)
 }
 
 object FileEdit {

--- a/src/main/scala/org/ensime/util/Note.scala
+++ b/src/main/scala/org/ensime/util/Note.scala
@@ -1,11 +1,22 @@
 package org.ensime.util
 
-case class NoteList(full: Boolean, notes: Iterable[Note])
-
-case class Note(file: String, msg: String, severity: Int, beg: Int, end: Int, line: Int, col: Int) {
-  def friendlySeverity = severity match {
-    case 2 => 'error
-    case 1 => 'warn
-    case 0 => 'info
+sealed trait NoteSeverity
+case object NoteError extends NoteSeverity
+case object NoteWarn extends NoteSeverity
+case object NoteInfo extends NoteSeverity
+object NoteSeverity {
+  def apply(severity: Int) = severity match {
+    case 2 => NoteError
+    case 1 => NoteWarn
+    case 0 => NoteInfo
   }
 }
+
+case class Note(
+  file: String,
+  msg: String,
+  severity: NoteSeverity,
+  beg: Int,
+  end: Int,
+  line: Int,
+  col: Int)

--- a/src/main/scala/org/ensime/util/Reporter.scala
+++ b/src/main/scala/org/ensime/util/Reporter.scala
@@ -38,7 +38,7 @@ class PresentationReporter(handler: ReportHandler) extends Reporter {
             val note = new Note(
               f,
               formatMessage(msg),
-              severity.id,
+              NoteSeverity(severity.id),
               pos.start,
               pos.end,
               pos.line,

--- a/src/main/scala/org/ensime/util/SExp.scala
+++ b/src/main/scala/org/ensime/util/SExp.scala
@@ -3,7 +3,11 @@ package org.ensime.util
 import scala.collection.immutable.Map
 
 sealed trait SExp extends WireFormat {
-  override def toWireString: String = toString
+  def toWireString: String = toString
+
+  import SExp._
+  def withRpcReturn(callId: Int) = SExp(key(":return"), SExp(key(":ok"), this), callId)
+
   def toScala: Any = toString
 }
 

--- a/src/main/scala/org/ensime/util/WireFormat.scala
+++ b/src/main/scala/org/ensime/util/WireFormat.scala
@@ -2,5 +2,5 @@ package org.ensime.util
 
 trait WireFormat {
   def toWireString: String
+  def withRpcReturn(callId: Int): WireFormat
 }
-

--- a/src/test/scala/org/ensime/indexer/SearchServiceSpec.scala
+++ b/src/test/scala/org/ensime/indexer/SearchServiceSpec.scala
@@ -22,8 +22,8 @@ class SearchServiceSpec extends FunSpec with Matchers with SLF4JLogging {
 
     // to reduce test time
     val trimmed = module.copy(
-      `compile-deps` = Nil,
-      `test-deps` = module.testJars filter (_.getName.contains("scalatest_"))
+      compileDeps = Nil,
+      testDeps = module.testJars filter (_.getName.contains("scalatest_"))
     )
     config.copy(
       subprojects = List(trimmed)

--- a/src/test/scala/org/ensime/intg/BasicWorkflow.scala
+++ b/src/test/scala/org/ensime/intg/BasicWorkflow.scala
@@ -105,7 +105,7 @@ class BasicWorkflow extends FunSpec with Matchers {
         val inspectByIdOpt: Option[TypeInspectInfo] = project.rpcInspectTypeById(intTypeId)
 
         inspectByIdOpt match {
-          case Some(TypeInspectInfo(`intTypeInspectInfo`, Some(intCompanionId), supers)) =>
+          case Some(TypeInspectInfo(`intTypeInspectInfo`, Some(intCompanionId), supers, _)) =>
           case _ =>
             fail("inspect by id does not match expectations, got: " + inspectByIdOpt)
         }
@@ -179,14 +179,14 @@ class BasicWorkflow extends FunSpec with Matchers {
           case Right(RefactorEffect(1234, 'rename, List(
             TextEdit(`fooFile`, 214, 217, "bar"),
             TextEdit(`fooFile`, 252, 255, "bar"),
-            TextEdit(`fooFile`, 269, 272, "bar")))) =>
+            TextEdit(`fooFile`, 269, 272, "bar")), _)) =>
           case _ =>
             fail("Prepare refactor result does not match, got: " + prepareRefactorRes)
         }
 
         val execRefactorRes = project.rpcExecRefactor(1234, Symbols.Rename)
         execRefactorRes match {
-          case Right(RefactorResult(1234, 'rename, List(`fooFile`))) =>
+          case Right(RefactorResult(1234, 'rename, List(`fooFile`), _)) =>
           case _ =>
             fail("exec refactor does not match expectation: " + execRefactorRes)
         }

--- a/src/test/scala/org/ensime/intg/IntgUtil.scala
+++ b/src/test/scala/org/ensime/intg/IntgUtil.scala
@@ -139,8 +139,7 @@ object IntgUtil extends Assertions with SLF4JLogging {
 
       val connInfo = project.rpcConnectionInfo()
       assert(connInfo.pid == None)
-      assert(connInfo.serverName == "ENSIME-ReferenceServer")
-      assert(connInfo.protocolVersion == "0.8.11")
+      assert(connInfo.implementation.name == "ENSIME")
 
       project.rpcNotifyClientReady()
 

--- a/src/test/scala/org/ensime/model/SourcePositionSpec.scala
+++ b/src/test/scala/org/ensime/model/SourcePositionSpec.scala
@@ -16,7 +16,7 @@ class SourcePositionSpec extends FunSpec with Matchers {
   val f = module.sourceRoots.head / "blah.scala"
   f.writeLines(Nil)
   val r = vfs.toFileObject(f)
-  val scalatest = module.referenceSourcesJars.find(_.getName.contains("scalatest_")).get.getAbsoluteFile
+  val scalatest = module.referenceSourceJars.find(_.getName.contains("scalatest_")).get.getAbsoluteFile
   val jarentry = "jar:" + scalatest + "!/org/scalatest/FunSpec.scala"
 
   private def lookup(uri: String, line: Option[Int] = None) = {

--- a/src/test/scala/org/ensime/server/protocol/swank/SwankProtocolConversionsSpec.scala
+++ b/src/test/scala/org/ensime/server/protocol/swank/SwankProtocolConversionsSpec.scala
@@ -21,37 +21,37 @@ class SwankProtocolConversionsSpec extends FunSpec with Matchers {
         assert(toWF(FullTypeCheckCompleteEvent).toWireString === "(:full-typecheck-finished)")
         assert(toWF(IndexerReadyEvent).toWireString === "(:indexer-ready)")
 
-        assert(toWF(NewScalaNotesEvent(NoteList(full = false,
-          List(new Note("foo.scala", "testMsg", 1, 50, 55, 77, 5))))).toWireString === """(:scala-notes (:is-full nil :notes ((:severity warn :msg "testMsg" :beg 50 :end 55 :line 77 :col 5 :file "foo.scala"))))""")
+        assert(toWF(NewScalaNotesEvent(isFull = false,
+          List(new Note("foo.scala", "testMsg", NoteWarn, 50, 55, 77, 5)))).toWireString === """(:scala-notes (:is-full nil :notes ((:file "foo.scala" :msg "testMsg" :severity warn :beg 50 :end 55 :line 77 :col 5))))""")
 
         assert(toWF(ClearAllScalaNotesEvent).toWireString === "(:clear-all-scala-notes)")
 
         // toWF(evt: DebugEvent): WireFormat
         assert(toWF(DebugOutputEvent("XXX")).toWireString === """(:debug-event (:type output :body "XXX"))""")
-        assert(toWF(DebugStepEvent(207L, "threadNameStr", sourcePos1)).toWireString ===
-          """(:debug-event (:type step :thread-id "207" :thread-name "threadNameStr" :file """ + file1_str + """ :line 57))""")
-        assert(toWF(DebugBreakEvent(209L, "threadNameStr", sourcePos1)).toWireString ===
-          """(:debug-event (:type breakpoint :thread-id "209" :thread-name "threadNameStr" :file """ + file1_str + """ :line 57))""")
-        assert(toWF(DebugVMStartEvent()).toWireString === """(:debug-event (:type start))""")
-        assert(toWF(DebugVMDisconnectEvent()).toWireString === """(:debug-event (:type disconnect))""")
+        assert(toWF(DebugStepEvent("207", "threadNameStr", sourcePos1.file, sourcePos1.line)).toWireString ===
+          s"""(:debug-event (:type step :thread-id "207" :thread-name "threadNameStr" :file $file1_str :line 57))""")
+        assert(toWF(DebugBreakEvent("209", "threadNameStr", sourcePos1.file, sourcePos1.line)).toWireString ===
+          s"""(:debug-event (:type breakpoint :thread-id "209" :thread-name "threadNameStr" :file $file1_str :line 57))""")
+        assert(toWF(DebugVMStartEvent).toWireString === """(:debug-event (:type start))""")
+        assert(toWF(DebugVMDisconnectEvent).toWireString === """(:debug-event (:type disconnect))""")
 
-        assert(toWF(DebugExceptionEvent(33L, 209L, "threadNameStr", Some(sourcePos1))).toWireString ===
-          """(:debug-event (:type exception :exception "33" :thread-id "209" :thread-name "threadNameStr" :file """ + file1_str + """ :line 57))""")
+        assert(toWF(DebugExceptionEvent(33L, "209", "threadNameStr", Some(sourcePos1.file), Some(sourcePos1.line))).toWireString ===
+          """(:debug-event (:type exception :exception 33 :thread-id "209" :thread-name "threadNameStr" :file """ + file1_str + """ :line 57))""")
 
-        assert(toWF(DebugExceptionEvent(33L, 209L, "threadNameStr", None)).toWireString ===
-          """(:debug-event (:type exception :exception "33" :thread-id "209" :thread-name "threadNameStr" :file nil :line nil))""")
+        assert(toWF(DebugExceptionEvent(33L, "209", "threadNameStr", None, None)).toWireString ===
+          """(:debug-event (:type exception :exception 33 :thread-id "209" :thread-name "threadNameStr" :file nil :line nil))""")
 
-        assert(toWF(DebugThreadStartEvent(907L)).toWireString === """(:debug-event (:type threadStart :thread-id "907"))""")
-        assert(toWF(DebugThreadDeathEvent(907L)).toWireString === """(:debug-event (:type threadDeath :thread-id "907"))""")
+        assert(toWF(DebugThreadStartEvent("907")).toWireString === """(:debug-event (:type threadStart :thread-id "907"))""")
+        assert(toWF(DebugThreadDeathEvent("907")).toWireString === """(:debug-event (:type threadDeath :thread-id "907"))""")
 
         // toWF(obj: DebugLocation)
         assert(toWF(DebugObjectReference(57L).asInstanceOf[DebugLocation]).toWireString ===
-          """(:type reference :object-id "57")""")
+          """(:type reference :object-id 57)""")
         assert(toWF(DebugArrayElement(58L, 2).asInstanceOf[DebugLocation]).toWireString ===
-          """(:type element :object-id "58" :index 2)""")
+          """(:type element :object-id 58 :index 2)""")
         assert(toWF(DebugObjectField(58L, "fieldName").asInstanceOf[DebugLocation]).toWireString ===
-          """(:type field :object-id "58" :field "fieldName")""")
-        assert(toWF(DebugStackSlot(27L, 12, 23).asInstanceOf[DebugLocation]).toWireString ===
+          """(:type field :object-id 58 :field "fieldName")""")
+        assert(toWF(DebugStackSlot("27", 12, 23).asInstanceOf[DebugLocation]).toWireString ===
           """(:type slot :thread-id "27" :frame 12 :offset 23)""")
 
         // toWF(obj: DebugValue)
@@ -61,15 +61,15 @@ class SwankProtocolConversionsSpec extends FunSpec with Matchers {
           """(:val-type prim :summary "summaryStr" :type-name "typeNameStr")""")
 
         // toWF(evt: DebugClassField)
-        assert(toWF(debugClassField).toWireString === """(:index 19 :name "nameStr" :summary "summaryStr" :type-name "typeNameStr")""")
+        assert(toWF(debugClassField).toWireString === """(:index 19 :name "nameStr" :type-name "typeNameStr" :summary "summaryStr")""")
 
         // toWF(obj: DebugStringInstance)
         assert(toWF(DebugStringInstance("summaryStr", List(debugClassField), "typeNameStr", 5L).asInstanceOf[DebugValue]).toWireString ===
-          """(:val-type str :summary "summaryStr" :fields ((:index 19 :name "nameStr" :summary "summaryStr" :type-name "typeNameStr")) :type-name "typeNameStr" :object-id "5")""")
+          """(:val-type str :summary "summaryStr" :fields ((:index 19 :name "nameStr" :type-name "typeNameStr" :summary "summaryStr")) :type-name "typeNameStr" :object-id 5)""")
 
         // toWF(evt: DebugObjectInstance)
         assert(toWF(DebugObjectInstance("summaryStr", List(debugClassField), "typeNameStr", 5L).asInstanceOf[DebugValue]).toWireString ===
-          """(:val-type obj :fields ((:index 19 :name "nameStr" :summary "summaryStr" :type-name "typeNameStr")) :type-name "typeNameStr" :object-id "5")""")
+          """(:val-type obj :summary "summaryStr" :fields ((:index 19 :name "nameStr" :type-name "typeNameStr" :summary "summaryStr")) :type-name "typeNameStr" :object-id 5)""")
 
         // toWF(evt: DebugNullValue)
         assert(toWF(DebugNullValue("typeNameStr").asInstanceOf[DebugValue]).toWireString ===
@@ -77,21 +77,24 @@ class SwankProtocolConversionsSpec extends FunSpec with Matchers {
 
         // toWF(evt: DebugArrayInstance)
         assert(toWF(DebugArrayInstance(3, "typeName", "elementType", 5L).asInstanceOf[DebugValue]).toWireString ===
-          """(:val-type arr :length 3 :type-name "typeName" :element-type-name "elementType" :object-id "5")""")
+          """(:val-type arr :length 3 :type-name "typeName" :element-type-name "elementType" :object-id 5)""")
 
         // toWF(evt: DebugStackLocal)
         assert(toWF(debugStackLocal1).toWireString === """(:index 3 :name "name1" :summary "summary1" :type-name "type1")""")
 
         // toWF(evt: DebugStackFrame)
-        assert(toWF(debugStackFrame).toWireString === """(:index 7 :locals ((:index 3 :name "name1" :summary "summary1" :type-name "type1") (:index 4 :name "name2" :summary "summary2" :type-name "type2")) :num-args 4 :class-name "class1" :method-name "method1" :pc-location (:file """ + file1_str + """ :line 57) :this-object-id "7")""")
+        assert(toWF(debugStackFrame).toWireString === s"""(:index 7 :locals ((:index 3 :name "name1" :summary "summary1" :type-name "type1") (:index 4 :name "name2" :summary "summary2" :type-name "type2")) :num-args 4 :class-name "class1" :method-name "method1" :pc-location (:file ${file1_str} :line 57) :this-object-id 7)""")
 
         // toWF(evt: DebugBacktrace)
-        assert(toWF(DebugBacktrace(List(debugStackFrame), 17, "thread1")).toWireString === """(:frames ((:index 7 :locals ((:index 3 :name "name1" :summary "summary1" :type-name "type1") (:index 4 :name "name2" :summary "summary2" :type-name "type2")) :num-args 4 :class-name "class1" :method-name "method1" :pc-location (:file """ + file1_str + """ :line 57) :this-object-id "7")) :thread-id "17" :thread-name "thread1")""")
+        assert(toWF(DebugBacktrace(List(debugStackFrame), "17", "thread1")).toWireString === s"""(:frames ((:index 7 :locals ((:index 3 :name "name1" :summary "summary1" :type-name "type1") (:index 4 :name "name2" :summary "summary2" :type-name "type2")) :num-args 4 :class-name "class1" :method-name "method1" :pc-location (:file ${file1_str} :line 57) :this-object-id 7)) :thread-id "17" :thread-name "thread1")""")
 
         // toWF(pos: LineSourcePosition)
-        assert(toWF(sourcePos1).toWireString === """(:file """ + file1_str + """ :line 57)""")
+        assert(toWF(sourcePos1).toWireString === s"""(:file $file1_str :line 57)""")
+
         // toWF(pos: EmptySourcePosition)
-        assert(toWF(sourcePos3).toWireString === "t")
+        assert(toWF(sourcePos3).toWireString === "nil")
+        assert(toWF(sourcePos3: SourcePosition).toWireString === "(:type empty)")
+
         // toWF(pos: OffsetSourcePosition)
         assert(toWF(sourcePos4).toWireString === """(:file """ + file1_str + """ :offset 456)""")
 
@@ -106,66 +109,62 @@ class SwankProtocolConversionsSpec extends FunSpec with Matchers {
         //assert(toWF(ProjectConfig(name = Some("Project1"), sourceRoots = List(file2))).toWireString === """(:project-name "Project1" :source-roots (""" + file2_str + """))""")
 
         // toWF(config: ReplConfig)
-        assert(toWF(new ReplConfig(Set(file1))).toWireString === s"""(:classpath $file1_str)""")
+        assert(toWF(new ReplConfig(Set(file1))).toWireString === s"""(:classpath ($file1_str))""")
 
         // toWF(value: Boolean)
-        assert(wfTrue.toWireString === """t""")
-        assert(wfFalse.toWireString === """nil""")
+        assert(toWF(true).toWireString === """t""")
+        assert(toWF(false).toWireString === """nil""")
 
         // toWF(value: String)
         assert(toWF("ABC").toWireString === """"ABC"""")
 
         // toWF(value: Note)
         assert(toWF(note1).toWireString === note1Str)
-        //  toWF(notelist: NoteList)
-        assert(toWF(noteList).toWireString === noteListStr)
-
-        // toWF(values: Iterable[WireFormat])
-        assert(toWF(List(wfTrue, wfFalse, toWF("ABC"))).toWireString === """(t nil "ABC")""")
 
         // toWF(value: CompletionInfo)
-        assert(toWF(completionInfo).toWireString === """(:name "name" :type-sig (((("abc" "def") ("hij" "lmn"))) "ABC") :type-id 88 :to-insert "BAZ")""")
+        assert(toWF(completionInfo).toWireString === """(:name "name" :type-sig (((("abc" "def") ("hij" "lmn"))) "ABC") :type-id 88 :is-callable nil :relevance 90 :to-insert "BAZ")""")
 
         // toWF(value: CompletionInfo)
-        assert(toWF(completionInfo2).toWireString === """(:name "name2" :type-sig (((("abc" "def"))) "ABC") :type-id 90 :is-callable t)""")
+        assert(toWF(completionInfo2).toWireString === """(:name "name2" :type-sig (((("abc" "def"))) "ABC") :type-id 90 :is-callable t :relevance 91 :to-insert nil)""")
 
         // toWF(value: CompletionInfoList)
-        assert(toWF(CompletionInfoList("fooBar", List(completionInfo))).toWireString === """(:prefix "fooBar" :completions ((:name "name" :type-sig (((("abc" "def") ("hij" "lmn"))) "ABC") :type-id 88 :to-insert "BAZ")))""")
+        assert(toWF(CompletionInfoList("fooBar", List(completionInfo))).toWireString === """(:prefix "fooBar" :completions ((:name "name" :type-sig (((("abc" "def") ("hij" "lmn"))) "ABC") :type-id 88 :is-callable nil :relevance 90 :to-insert "BAZ")))""")
         // toWF(value: PackageMemberInfoLight)
         assert(toWF(new PackageMemberInfoLight("packageName")).toWireString === """(:name "packageName")""")
         // toWF(value: SymbolInfo)
-        assert(toWF(new SymbolInfo("name", "localName", None, typeInfo, false, Some(2))).toWireString === """(:name "name" :local-name "localName" :type (:name "type1" :type-id 7 :full-name "FOO.type1" :decl-as type1 :outer-type-id 8) :owner-type-id 2)""")
+        assert(toWF(new SymbolInfo("name", "localName", None, typeInfo, false, Some(2))).toWireString === """(:name "name" :local-name "localName" :decl-pos nil :type (:arrow-type nil :name "type1" :type-id 7 :decl-as type1 :full-name "FOO.type1" :type-args nil :members nil :pos nil :outer-type-id 8) :is-callable nil :owner-type-id 2)""")
 
         // toWF(value: NamedTypeMemberInfo)
-        assert(toWF(new NamedTypeMemberInfo("typeX", typeInfo, None, 'abcd)).toWireString === """(:name "typeX" :type (:name "type1" :type-id 7 :full-name "FOO.type1" :decl-as type1 :outer-type-id 8) :decl-as abcd)""")
+        assert(toWF(new NamedTypeMemberInfo("typeX", typeInfo, None, 'abcd)).toWireString === """(:name "typeX" :type (:arrow-type nil :name "type1" :type-id 7 :decl-as type1 :full-name "FOO.type1" :type-args nil :members nil :pos nil :outer-type-id 8) :pos nil :decl-as abcd)""")
 
         // toWF(value: EntityInfo)
         assert(toWF(entityInfo).toWireString === entityInfoStr)
 
         // toWF(value: TypeInfo)
-        assert(toWF(typeInfo).toWireString === """(:name "type1" :type-id 7 :full-name "FOO.type1" :decl-as type1 :outer-type-id 8)""")
+        assert(toWF(typeInfo).toWireString === """(:arrow-type nil :name "type1" :type-id 7 :decl-as type1 :full-name "FOO.type1" :type-args nil :members nil :pos nil :outer-type-id 8)""")
 
         // toWF(value: PackageInfo)
-        assert(toWF(packageInfo).toWireString === """(:name "name" :info-type package :full-name "fullName")""")
+        assert(toWF(packageInfo).toWireString === """(:info-type package :name "name" :full-name "fullName" :members nil)""")
 
         // toWF(value: CallCompletionInfo)
-        assert(toWF(new CallCompletionInfo(typeInfo, List(paramSectionInfo))).toWireString === """(:result-type (:name "type1" :type-id 7 :full-name "FOO.type1" :decl-as type1 :outer-type-id 8) :param-sections ((:params (("ABC" (:name "type1" :type-id 7 :full-name "FOO.type1" :decl-as type1 :outer-type-id 8))))))""")
+        assert(toWF(new CallCompletionInfo(typeInfo, List(paramSectionInfo))).toWireString === """(:result-type (:arrow-type nil :name "type1" :type-id 7 :decl-as type1 :full-name "FOO.type1" :type-args nil :members nil :pos nil :outer-type-id 8) :param-sections ((:params (("ABC" (:arrow-type nil :name "type1" :type-id 7 :decl-as type1 :full-name "FOO.type1" :type-args nil :members nil :pos nil :outer-type-id 8))) :is-implicit nil)))""")
 
         // toWF(value: InterfaceInfo)
-        assert(toWF(interfaceInfo).toWireString === """(:type (:name "type1" :type-id 7 :full-name "FOO.type1" :decl-as type1 :outer-type-id 8) :via-view "DEF")""")
+        assert(toWF(interfaceInfo).toWireString === """(:type (:arrow-type nil :name "type1" :type-id 7 :decl-as type1 :full-name "FOO.type1" :type-args nil :members nil :pos nil :outer-type-id 8) :via-view "DEF")""")
+
         // toWF(value: TypeInspectInfo)
-        assert(toWF(new TypeInspectInfo(typeInfo, Some(1), List(interfaceInfo))).toWireString === """(:type (:name "type1" :type-id 7 :full-name "FOO.type1" :decl-as type1 :outer-type-id 8) :info-type typeInspect :companion-id 1 :interfaces ((:type (:name "type1" :type-id 7 :full-name "FOO.type1" :decl-as type1 :outer-type-id 8) :via-view "DEF")))""")
+        assert(toWF(new TypeInspectInfo(typeInfo, Some(1), List(interfaceInfo))).toWireString === """(:type (:arrow-type nil :name "type1" :type-id 7 :decl-as type1 :full-name "FOO.type1" :type-args nil :members nil :pos nil :outer-type-id 8) :companion-id 1 :interfaces ((:type (:arrow-type nil :name "type1" :type-id 7 :decl-as type1 :full-name "FOO.type1" :type-args nil :members nil :pos nil :outer-type-id 8) :via-view "DEF")) :info-type typeInspect)""")
 
         // toWF(value: SymbolSearchResults)
-        assert(toWF(new SymbolSearchResults(List(methodSearchRes, typeSearchRes))).toWireString === s"""((:name "abc" :local-name "a" :decl-as abcd :pos (:file $abd_str :line 10) :owner-name "ownerStr") (:name "abc" :local-name "a" :decl-as abcd :pos (:file $abd_str :line 10)))""")
+        assert(toWF(new SymbolSearchResults(List(methodSearchRes, typeSearchRes))).toWireString === s"""((:type method :name "abc" :local-name "a" :decl-as abcd :pos (:type line :file $abd_str :line 10) :owner-name "ownerStr") (:type type :name "abc" :local-name "a" :decl-as abcd :pos (:type line :file $abd_str :line 10)))""")
 
         // toWF(value: ImportSuggestions)
         assert(toWF(new ImportSuggestions(List(List(methodSearchRes, typeSearchRes)))).toWireString ===
-          s"""(((:name "abc" :local-name "a" :decl-as abcd :pos (:file $abd_str :line 10) :owner-name "ownerStr") (:name "abc" :local-name "a" :decl-as abcd :pos (:file $abd_str :line 10))))""")
+          s"""(((:type method :name "abc" :local-name "a" :decl-as abcd :pos (:type line :file $abd_str :line 10) :owner-name "ownerStr") (:type type :name "abc" :local-name "a" :decl-as abcd :pos (:type line :file $abd_str :line 10))))""")
 
         // toWF(value: SymbolSearchResult)
-        assert(toWF(methodSearchRes).toWireString === s"""(:name "abc" :local-name "a" :decl-as abcd :pos (:file $abd_str :line 10) :owner-name "ownerStr")""")
-        assert(toWF(typeSearchRes).toWireString === s"""(:name "abc" :local-name "a" :decl-as abcd :pos (:file $abd_str :line 10))""")
+        assert(toWF(methodSearchRes).toWireString === s"""(:type method :name "abc" :local-name "a" :decl-as abcd :pos (:type line :file $abd_str :line 10) :owner-name "ownerStr")""")
+        assert(toWF(typeSearchRes).toWireString === s"""(:type type :name "abc" :local-name "a" :decl-as abcd :pos (:type line :file $abd_str :line 10))""")
 
         assert(toWF(new ERangePosition(batchSourceFile, 75, 70, 90)).toWireString === """(:file """ + batchSourceFile_str + """ :offset 75 :start 70 :end 90)""")
 
@@ -177,23 +176,22 @@ class SwankProtocolConversionsSpec extends FunSpec with Matchers {
           SymbolDesignation(11, 22, ClassSymbol)
         ))).toWireString === """(:file "/abc" :syms ((varField 7 9) (class 11 22)))""")
 
-        assert(toWF(RefactorFailure(7, "message")).toWireString === """(:procedure-id 7 :status failure :reason "message")""")
+        assert(toWF(RefactorFailure(7, "message")).toWireString === """(:procedure-id 7 :reason "message" :status failure)""")
 
-        assert(toWF(new RefactorEffect(9, 'add, List(TextEdit(file3, 5, 7, "aaa")))).toWireString === """(:procedure-id 9 :refactor-type add :status success :changes ((:file """ + file3_str + """ :text "aaa" :from 5 :to 7)))""")
+        assert(toWF(new RefactorEffect(9, 'add, List(TextEdit(file3, 5, 7, "aaa")))).toWireString === s"""(:procedure-id 9 :refactor-type add :changes ((:type edit :file $file3_str :from 5 :to 7 :text "aaa")) :status success)""")
 
-        assert(toWF(new RefactorResult(7, 'abc, List(file3, file1))).toWireString === """(:procedure-id 7 :refactor-type abc :status success :touched-files (""" + file3_str + " " + file1_str + """))""")
+        assert(toWF(new RefactorResult(7, 'abc, List(file3, file1))).toWireString === s"""(:procedure-id 7 :refactor-type abc :touched-files ($file3_str $file1_str) :status success)""")
 
         assert(toWF(Undo(3, "Undoing stuff", List(
           TextEdit(file3, 5, 7, "aaa"),
           NewFile(file4, "xxxxx"),
           DeleteFile(file5, "zzzz")
-        ))).toWireString === """(:id 3 :changes ((:file """ + file3_str + """ :text "aaa" :from 5 :to 7) (:file """ + file4_str + """ :text "xxxxx" :from 0 :to 4) (:file """ + file5_str + """ :text "zzzz" :from 0 :to 3)) :summary "Undoing stuff")""")
+        ))).toWireString === s"""(:id 3 :summary "Undoing stuff" :changes ((:type edit :file $file3_str :from 5 :to 7 :text "aaa") (:type new :file $file4_str :from 0 :to 4 :text "xxxxx") (:type delete :file $file5_str :from 0 :to 3 :text "zzzz")))""")
 
-        assert(toWF(UndoResult(7, List(file3, file4))).toWireString === """(:id 7 :touched-files (""" + file3_str + """ """ + file4_str + """))""")
+        assert(toWF(UndoResult(7, List(file3, file4))).toWireString === s"""(:id 7 :touched-files ($file3_str $file4_str))""")
 
-        assert(wfNull.toWireString === """nil""")
-        assert(toWF(DebugVmSuccess).toWireString === """(:status "success")""")
-        assert(toWF(DebugVmError(303, "xxxx")).toWireString === """(:status "error" :error-code 303 :details "xxxx")""")
+        assert(toWF(DebugVmSuccess()).toWireString === """(:type success :status "success")""")
+        assert(toWF(DebugVmError(303, "xxxx")).toWireString === """(:type error :error-code 303 :details "xxxx" :status "error")""")
       }
     }
   }

--- a/src/test/scala/org/ensime/server/protocol/swank/SwankTestData.scala
+++ b/src/test/scala/org/ensime/server/protocol/swank/SwankTestData.scala
@@ -3,22 +3,22 @@ package org.ensime.server.protocol.swank
 import java.io.File
 
 import org.ensime.model._
-import org.ensime.core.{ RefactorResult, RefactorEffect, RefactorFailure }
+import org.ensime.core._
 import org.ensime.util._
 import pimpathon.file._
 
 object SwankTestData {
 
   val typeInfo = new BasicTypeInfo("type1", 7, 'type1, "FOO.type1", List(), List(), None, Some(8))
-  val typeInfoStr = """(:name "type1" :type-id 7 :full-name "FOO.type1" :decl-as type1 :outer-type-id 8)"""
+  val typeInfoStr = """(:arrow-type nil :name "type1" :type-id 7 :decl-as type1 :full-name "FOO.type1" :type-args nil :members nil :pos nil :outer-type-id 8)"""
 
   val interfaceInfo = new InterfaceInfo(typeInfo, Some("DEF"))
   val typeInspectInfo = new TypeInspectInfo(typeInfo, Some(1), List(interfaceInfo))
-  val typeInspectInfoStr = """(:type """ + typeInfoStr + """ :info-type typeInspect :companion-id 1 :interfaces ((:type """ + typeInfoStr + """ :via-view "DEF")))"""
+  val typeInspectInfoStr = s"""(:type $typeInfoStr :companion-id 1 :interfaces ((:type """ + typeInfoStr + """ :via-view "DEF")) :info-type typeInspect)"""
 
   val paramSectionInfo = new ParamSectionInfo(List(("ABC", typeInfo)), false)
   val callCompletionInfo = new CallCompletionInfo(typeInfo, List(paramSectionInfo))
-  val callCompletionInfoStr = """(:result-type """ + typeInfoStr + """ :param-sections ((:params (("ABC" """ + typeInfoStr + """)))))"""
+  val callCompletionInfoStr = """(:result-type """ + typeInfoStr + """ :param-sections ((:params (("ABC" """ + typeInfoStr + """)) :is-implicit nil)))"""
 
   val symbolDesignations = SymbolDesignations("/abc",
     List(SymbolDesignation(7, 9, ObjectSymbol),
@@ -26,7 +26,7 @@ object SwankTestData {
   val symbolDesignationsStr = """(:file "/abc" :syms ((object 7 9) (trait 11 22)))"""
 
   val symbolInfo = new SymbolInfo("name", "localName", None, typeInfo, false, Some(2))
-  val symbolInfoStr = """(:name "name" :local-name "localName" :type """ + typeInfoStr + """ :owner-type-id 2)"""
+  val symbolInfoStr = """(:name "name" :local-name "localName" :decl-pos nil :type """ + typeInfoStr + """ :is-callable nil :owner-type-id 2)"""
 
   val batchSourceFile = "/abc"
   val batchSourceFile_str = TestUtil.stringToWireString(batchSourceFile)
@@ -38,19 +38,19 @@ object SwankTestData {
   val rangePos2Str = """(:file """ + batchSourceFile_str + """ :offset 85 :start 80 :end 100)"""
 
   val packageInfo = new PackageInfo("name", "fullName", List())
-  val packageInfoStr = """(:name "name" :info-type package :full-name "fullName")"""
+  val packageInfoStr = """(:info-type package :name "name" :full-name "fullName" :members nil)"""
 
   val completionInfo = new CompletionInfo("name", new CompletionSignature(List(List(("abc", "def"), ("hij", "lmn"))), "ABC"), 88, false, 90, Some("BAZ"))
-  val completionInfoStr = """(:name "name" :type-sig (((("abc" "def") ("hij" "lmn"))) "ABC") :type-id 88 :to-insert "BAZ")"""
+  val completionInfoStr = """(:name "name" :type-sig (((("abc" "def") ("hij" "lmn"))) "ABC") :type-id 88 :is-callable nil :relevance 90 :to-insert "BAZ")"""
 
   val completionInfo2 = new CompletionInfo("name2", new CompletionSignature(List(List(("abc", "def"))), "ABC"), 90, true, 91, None)
-  val completionInfo2Str = """(:name "name2" :type-sig (((("abc" "def"))) "ABC") :type-id 90 :is-callable t)"""
+  val completionInfo2Str = """(:name "name2" :type-sig (((("abc" "def"))) "ABC") :type-id 90 :is-callable t :relevance 91 :to-insert nil)"""
 
   val completionInfoList = List(completionInfo, completionInfo2)
   val completionInfoListStr = "(" + completionInfoStr + " " + completionInfo2Str + ")"
 
   val refactorFailure = RefactorFailure(7, "message")
-  val refactorFailureStr = """(:procedure-id 7 :status failure :reason "message")"""
+  val refactorFailureStr = """(:procedure-id 7 :reason "message" :status failure)"""
 
   val file1 = CanonFile("/abc/def")
   val file1_str = TestUtil.fileToWireString(file1)
@@ -67,32 +67,32 @@ object SwankTestData {
   val refactorEffectStr = """(:procedure-id 9 :refactor-type add :status success :changes ((:file """ + file3_str + """ :text "aaa" :from 5 :to 7)))"""
 
   val refactorResult = new RefactorResult(7, 'abc, List(file3, file1))
-  val refactorResultStr = """(:procedure-id 7 :refactor-type abc :status success :touched-files (""" + file3_str + " " + file1_str + """))"""
+  val refactorResultStr = s"""(:procedure-id 7 :refactor-type abc :touched-files ($file3_str $file1_str) :status success)"""
 
   val sourcePos1 = new LineSourcePosition(file1, 57)
   val sourcePos2 = new LineSourcePosition(file1, 59)
   val sourcePos3 = new EmptySourcePosition()
   val sourcePos4 = new OffsetSourcePosition(file1, 456)
 
-  val breakPoint1 = new Breakpoint(sourcePos1)
-  val breakPoint2 = new Breakpoint(sourcePos2)
+  val breakPoint1 = new Breakpoint(sourcePos1.file, sourcePos1.line)
+  val breakPoint2 = new Breakpoint(sourcePos2.file, sourcePos2.line)
 
   val breakpointList = BreakpointList(List(breakPoint1), List(breakPoint2))
   val breakpointListStr = """(:active ((:file """ + file1_str + """ :line 57)) :pending ((:file """ + file1_str + """ :line 59)))"""
 
-  val debugStackLocal1 = DebugStackLocal(3, "name1", "type1", "summary1")
-  val debugStackLocal2 = DebugStackLocal(4, "name2", "type2", "summary2")
+  val debugStackLocal1 = DebugStackLocal(3, "name1", "summary1", "type1")
+  val debugStackLocal2 = DebugStackLocal(4, "name2", "summary2", "type2")
 
   val debugStackFrame = DebugStackFrame(7, List(debugStackLocal1, debugStackLocal2), 4, "class1", "method1", sourcePos1, 7)
 
-  val debugBacktrace = DebugBacktrace(List(debugStackFrame), 17, "thread1")
-  val debugBacktraceStr = """(:frames ((:index 7 :locals ((:index 3 :name "name1" :summary "summary1" :type-name "type1") (:index 4 :name "name2" :summary "summary2" :type-name "type2")) :num-args 4 :class-name "class1" :method-name "method1" :pc-location (:file """ + file1_str + """ :line 57) :this-object-id "7")) :thread-id "17" :thread-name "thread1")"""
+  val debugBacktrace = DebugBacktrace(List(debugStackFrame), "17", "thread1")
+  val debugBacktraceStr = s"""(:frames ((:index 7 :locals ((:index 3 :name "name1" :summary "summary1" :type-name "type1") (:index 4 :name "name2" :summary "summary2" :type-name "type2")) :num-args 4 :class-name "class1" :method-name "method1" :pc-location (:file ${file1_str} :line 57) :this-object-id 7)) :thread-id "17" :thread-name "thread1")"""
 
   val undoResult = UndoResult(7, List(file3, file4))
   val undoResultStr = """(:id 7 :touched-files (""" + file3_str + """ """ + file4_str + """))"""
 
   val replConfig = new ReplConfig(Set(file1))
-  val replConfigStr = """(:classpath """ + file1_str + """)"""
+  val replConfigStr = """(:classpath (""" + file1_str + """))"""
 
   val analyzerFile = new File("Analyzer.scala")
   val fooFile = new File("Foo.scala")
@@ -104,46 +104,46 @@ object SwankTestData {
   val typeSearchRes = TypeSearchResult("abc", "a", 'abcd, Some(LineSourcePosition(file("abd"), 10)))
 
   val importSuggestions = new ImportSuggestions(List(List(methodSearchRes, typeSearchRes)))
-  val importSuggestionsStr = """(((:name "abc" :local-name "a" :decl-as abcd :pos (:file """ + abd_str + """ :line 10) :owner-name "ownerStr") (:name "abc" :local-name "a" :decl-as abcd :pos (:file """ + abd_str + """ :line 10))))"""
+  val importSuggestionsStr = s"""(((:type method :name "abc" :local-name "a" :decl-as abcd :pos (:type line :file $abd_str :line 10) :owner-name "ownerStr") (:type type :name "abc" :local-name "a" :decl-as abcd :pos (:type line :file $abd_str :line 10))))"""
 
   val symbolSearchResults = new SymbolSearchResults(List(methodSearchRes, typeSearchRes))
-  val symbolSearchResultsStr = """((:name "abc" :local-name "a" :decl-as abcd :pos (:file """ + abd_str + """ :line 10) :owner-name "ownerStr") (:name "abc" :local-name "a" :decl-as abcd :pos (:file """ + abd_str + """ :line 10)))"""
+  val symbolSearchResultsStr = s"""((:type method :name "abc" :local-name "a" :decl-as abcd :pos (:type line :file $abd_str :line 10) :owner-name "ownerStr") (:type type :name "abc" :local-name "a" :decl-as abcd :pos (:type line :file $abd_str :line 10)))"""
 
   val completionInfoCList = CompletionInfoList("fooBar", List(completionInfo))
-  val completionInfoCListStr = """(:prefix "fooBar" :completions (""" + completionInfoStr + """))"""
+  val completionInfoCListStr = s"""(:prefix "fooBar" :completions ($completionInfoStr))"""
 
   val refactorRenameEffect = new RefactorEffect(7, 'rename, List(TextEdit(file3, 5, 7, "aaa")))
-  val refactorRenameEffectStr = """(:procedure-id 7 :refactor-type rename :status success :changes ((:file """ + file3_str + """ :text "aaa" :from 5 :to 7)))"""
+  val refactorRenameEffectStr = s"""(:procedure-id 7 :refactor-type rename :changes ((:type edit :file $file3_str :from 5 :to 7 :text "aaa")) :status success)"""
 
   val fileRange = FileRange("/abc", 7, 9)
   val fileRangeStr = """(:file "/abc" :start 7 :end 9)"""
 
   val debugLocObjectRef: DebugLocation = DebugObjectReference(57L)
-  val debugLocObjectRefStr = """(:type reference :object-id "57")"""
+  val debugLocObjectRefStr = """(:type reference :object-id 57)"""
 
   val debugNullValue = DebugNullValue("typeNameStr")
   val debugNullValueStr = """(:val-type null :type-name "typeNameStr")"""
 
   val debugArrayInstValue = DebugArrayInstance(3, "typeName", "elementType", 5L)
-  val debugArrayInstValueStr = """(:val-type arr :length 3 :type-name "typeName" :element-type-name "elementType" :object-id "5")"""
+  val debugArrayInstValueStr = """(:val-type arr :length 3 :type-name "typeName" :element-type-name "elementType" :object-id 5)"""
 
   val debugPrimitiveValue = DebugPrimitiveValue("summaryStr", "typeNameStr")
   val debugPrimitiveValueStr = """(:val-type prim :summary "summaryStr" :type-name "typeNameStr")"""
 
   val debugClassField = DebugClassField(19, "nameStr", "typeNameStr", "summaryStr")
-  val debugClassFieldStr = """(:index 19 :name "nameStr" :summary "summaryStr" :type-name "typeNameStr")"""
+  val debugClassFieldStr = """(:index 19 :name "nameStr" :type-name "typeNameStr" :summary "summaryStr")"""
 
   val debugStringValue = DebugStringInstance("summaryStr", List(debugClassField), "typeNameStr", 5L)
-  val debugStringValueStr = """(:val-type str :summary "summaryStr" :fields (""" + debugClassFieldStr + """) :type-name "typeNameStr" :object-id "5")"""
+  val debugStringValueStr = s"""(:val-type str :summary "summaryStr" :fields (${debugClassFieldStr}) :type-name "typeNameStr" :object-id 5)"""
 
-  val note1 = new Note("file1", "note1", 2, 23, 33, 19, 8)
-  val note1Str = """(:severity error :msg "note1" :beg 23 :end 33 :line 19 :col 8 :file "file1")"""
-  val note2 = new Note("file1", "note2", 1, 23, 33, 19, 8)
-  val note2Str = """(:severity warn :msg "note2" :beg 23 :end 33 :line 19 :col 8 :file "file1")"""
+  val note1 = new Note("file1", "note1", NoteError, 23, 33, 19, 8)
+  val note1Str = """(:file "file1" :msg "note1" :severity error :beg 23 :end 33 :line 19 :col 8)"""
+  val note2 = new Note("file1", "note2", NoteWarn, 23, 33, 19, 8)
+  val note2Str = """( :file "file1" :msg "note2" :severity warn :beg 23 :end 33 :line 19 :col 8)"""
 
-  val noteList = new NoteList(true, List(note1, note2))
+  val noteList = NewScalaNotesEvent(true, List(note1, note2))
   val noteListStr = "(:is-full t :notes (" + note1Str + " " + note2Str + "))"
 
   val entityInfo: TypeInfo = new ArrowTypeInfo("Arrow1", 8, typeInfo, List(paramSectionInfo))
-  val entityInfoStr = """(:name "Arrow1" :type-id 8 :arrow-type t :result-type (:name "type1" :type-id 7 :full-name "FOO.type1" :decl-as type1 :outer-type-id 8) :param-sections ((:params (("ABC" (:name "type1" :type-id 7 :full-name "FOO.type1" :decl-as type1 :outer-type-id 8))))))"""
+  val entityInfoStr = """(:arrow-type t :name "Arrow1" :type-id 8 :result-type (:arrow-type nil :name "type1" :type-id 7 :decl-as type1 :full-name "FOO.type1" :type-args nil :members nil :pos nil :outer-type-id 8) :param-sections ((:params (("ABC" (:arrow-type nil :name "type1" :type-id 7 :decl-as type1 :full-name "FOO.type1" :type-args nil :members nil :pos nil :outer-type-id 8))) :is-implicit nil)))"""
 }

--- a/src/test/scala/org/ensime/sexp/formats/ExampleAst.scala
+++ b/src/test/scala/org/ensime/sexp/formats/ExampleAst.scala
@@ -5,7 +5,7 @@ package org.ensime.sexp.formats
  */
 object ExampleAst {
   sealed trait Token {
-    val text: String
+    def text: String
   }
 
   sealed trait RawToken extends Token
@@ -28,8 +28,13 @@ object ExampleAst {
   case class Ignored(text: String = "") extends TokenTree
   case class Unclear(text: String = "") extends TokenTree
 
+  object SpecialToken extends TokenTree {
+    // to test case object serialisation
+    def text = ""
+  }
+
   sealed trait Term extends TokenTree {
-    val field: DatabaseField
+    def field: DatabaseField
   }
 
   case class DatabaseField(column: String)

--- a/src/test/scala/org/ensime/sexp/formats/ProductFormatsSpec.scala
+++ b/src/test/scala/org/ensime/sexp/formats/ProductFormatsSpec.scala
@@ -54,7 +54,8 @@ class ProductFormatsSpec extends FormatSpec
       assertFormat(wibble, SexpData(
         SexpSymbol(":thing") -> SexpString("wibble"),
         SexpSymbol(":thong") -> SexpNumber(13),
-        SexpSymbol(":bling") -> SexpList(SexpString("fork"))))
+        SexpSymbol(":bling") -> SexpList(SexpString("fork"))
+      ))
 
       val wobble = Wibble("wibble", 13, None)
 
@@ -62,7 +63,8 @@ class ProductFormatsSpec extends FormatSpec
       assertFormat(wobble, SexpData(
         SexpSymbol(":thing") -> SexpString("wibble"),
         SexpSymbol(":thong") -> SexpNumber(13),
-        SexpSymbol(":bling") -> SexpNil))
+        SexpSymbol(":bling") -> SexpNil
+      ))
 
       // but tolerate missing entries
       assert(SexpData(
@@ -88,5 +90,21 @@ class ProductFormatsSpec extends FormatSpec
       assertFormat(foo, fooexpect)
     }
 
+  }
+}
+
+class CustomisedProductFormatsSpec extends FormatSpec
+    with BasicFormats with StandardFormats with ProductFormats
+    with CamelCaseToDashes {
+
+  case class Foo(AThingyMaBob: Int, HTML: String)
+
+  describe("ProductFormats with overloaded toWireName") {
+    it("should support custom field names") {
+      assertFormat(Foo(13, "foo"), SexpData(
+        SexpSymbol(":a-thingy-ma-bob") -> SexpNumber(13),
+        SexpSymbol(":h-t-m-l") -> SexpString("foo")
+      ))
+    }
   }
 }

--- a/src/test/scala/org/ensime/util/TestUtil.scala
+++ b/src/test/scala/org/ensime/util/TestUtil.scala
@@ -90,7 +90,7 @@ object TestUtil {
     EnsimeConfig(
       base.canon, cacheDir.canon, "simple", scalaVersion,
       compilerArgs, javaSource.toList, List(module),
-      FormattingPreferences(), `source-mode` = false, Nil
+      FormattingPreferences(), sourceMode = false, Nil
     )
   }
 


### PR DESCRIPTION
Step 1 in #390

This should be completely backwards compatible with the emacs client, hence a lot of jiggery pokery in the new `SwankProtocolConversions.scala` file.

I've yet to run this on the emacs integration tests, it would be sooo good if we could get #777 up and running.
