### PR TITLE
Add protocol support for looking up a doc by fully qualified name.

### DIFF
--- a/api/src/main/scala/org/ensime/model/Model.scala
+++ b/api/src/main/scala/org/ensime/model/Model.scala
@@ -305,7 +305,13 @@ case class ERangePosition(file: String, offset: Int, start: Int, end: Int)
  * Information necessary to create a javadoc or scaladoc URI for a
  * particular type or type member.
  */
-case class DocSig(fqn: String, member: Option[String])
+case class DocFqn(pack: String, typeName: String) {
+  def mkString: String = if (pack.isEmpty) typeName else pack + "." + typeName
+  def inPackage(prefix: String): Boolean = pack == prefix || pack.startsWith(prefix + ".")
+  def javaStdLib: Boolean = inPackage("java") || inPackage("javax")
+  def scalaStdLib: Boolean = inPackage("scala")
+}
+case class DocSig(fqn: DocFqn, member: Option[String])
 
 /**
  * We generate DocSigs for java and scala at the same time, since we

--- a/project/EnsimeBuild.scala
+++ b/project/EnsimeBuild.scala
@@ -175,6 +175,9 @@ object EnsimeBuild extends Build with JdkResolver {
       "org.scala-refactoring" %% "org.scala-refactoring.library" % "0.6.2",
       "commons-lang" % "commons-lang" % "2.6",
       "io.spray" %% "spray-can" % "1.3.2",
+      // Included for testing purposes, as an example of javadoc 1.8 output.
+      "com.github.dvdme" %  "ForecastIOLib" % "1.5.1"  % "test,it",
+      "com.google.guava" % "guava" % "18.0" % "test,it",
       "commons-io" % "commons-io" % "2.4" % "test,it"
     ) ++ testLibs(scalaVersion.value, "it,test")
   )

--- a/server/src/it/scala/org/ensime/core/DocServerSpec.scala
+++ b/server/src/it/scala/org/ensime/core/DocServerSpec.scala
@@ -44,19 +44,9 @@ class DocServerSpec extends WordSpec with Matchers with SLF4JLogging
     testCode: (Map[String, ActorRef], EnsimeConfig, RichPresentationCompiler) => Any): Any = withRichPresentationCompiler {
     (testkit: TestKitFix, config: EnsimeConfig, pc: RichPresentationCompiler) =>
       import testkit._
-      val docs = config.allDocJars.filter { f =>
-        List(
-          "scalap-",
-          "jul-to-slf4j",
-          "scalac-scoverage",
-          "scala-library-",
-          "guava-"
-        ).exists(f.getName.startsWith(_))
-      }
       val servers = javaVersions.map { javaVersion =>
         (javaVersion, system.actorOf(Props(new DocServer(config, false, Some(javaVersion)))))
       }.toMap
-
       testCode(servers, config, pc)
   }
 
@@ -66,6 +56,16 @@ class DocServerSpec extends WordSpec with Matchers with SLF4JLogging
     ) { (servers, config, cc) =>
         val serv = servers("1.6")
         val serv8 = servers("1.8")
+
+        val docs = config.allDocJars.filter { f =>
+          List(
+            "scalap-",
+            "jul-to-slf4j",
+            "scala-library-",
+            "ForecastIOLib", // Javadoc 1.8
+            "guava-"
+          ).exists(f.getName.startsWith(_))
+        }
 
         def getUri(serv: ActorRef, sig: DocSig): Option[String] = {
           Await.result(Patterns.ask(serv, DocUriReq(DocSigPair(sig, sig)), Timeout(5.second)),
@@ -122,7 +122,7 @@ class DocServerSpec extends WordSpec with Matchers with SLF4JLogging
 
         def checkJava(sig: DocSigPair, expectedSig: DocSig) {
           assert(sig.java == expectedSig)
-          if (!sig.java.fqn.startsWith("java.")) {
+          if (!sig.java.fqn.javaStdLib) {
             assert(findsContentFor(serv, expectedSig, true))
           }
         }
@@ -175,71 +175,77 @@ class DocServerSpec extends WordSpec with Matchers with SLF4JLogging
           "}") { (p, label, cc) =>
             val sig = cc.askDocSignatureAtPoint(p).get
             label match {
-              case "0" => checkScala(sig, DocSig("scala.Some", Some("map[B](f:A=>B):Option[B]")))
-              case "0.5" => checkScala(sig, DocSig("scala.Boolean", None))
-              case "1" => checkScala(sig, DocSig("scala.Option", Some("isDefined:Boolean")))
-              case "2" => checkScala(sig, DocSig("scala.Some", Some("flatMap[B](f:A=>Option[B]):Option[B]")))
-              case "3" => checkScala(sig, DocSig("scala.Some", Some("flatten[B](implicitev:<:<[A,Option[B]]):Option[B]")))
-              case "4" => checkScala(sig, DocSig("scala.Some", Some("fold[B](ifEmpty:=>B)(f:A=>B):B")))
-              case "5" => checkScala(sig, DocSig("scala.Some", Some("mkString(start:String,sep:String,end:String):String")))
-              case "6" => checkScala(sig, DocSig("scala.Some", Some("mkString:String")))
-              case "7" => checkScala(sig, DocSig("scala.Some", Some("mkString(sep:String):String")))
-              case "8" => checkScala(sig, DocSig("scala.Some", Some("getOrElse[B>:A](default:=>B):B")))
-              case "9" => checkScala(sig, DocSig("scala.Some", Some("grouped(size:Int):Iterator[Repr]")))
-              case "10" => checkScala(sig, DocSig("scala.collection.immutable.List$", Some("empty[A]:List[A]")))
-              case "11" => checkJava(sig, DocSig("com.google.common.io.Files", Some("move(java.io.File, java.io.File)")))
-              case "12" => checkJava(sig, DocSig("com.google.common.io.Files", Some("asByteSource(java.io.File)")))
-              case "13" => checkJava(sig, DocSig("com.google.common.io.Files", Some("map(java.io.File, java.nio.channels.FileChannel.MapMode)")))
-              case "14" => checkJava(sig, DocSig("com.google.common.io.Files", Some("map(java.io.File, java.nio.channels.FileChannel.MapMode, long)")))
-              case "15" => checkJava(sig, DocSig("com.google.common.io.Files", Some("write(byte[], java.io.File)")))
+              case "0" => checkScala(sig, DocSig(DocFqn("scala", "Some"), Some("map[B](f:A=>B):Option[B]")))
+              case "0.5" => checkScala(sig, DocSig(DocFqn("scala", "Boolean"), None))
+              case "1" => checkScala(sig, DocSig(DocFqn("scala", "Option"), Some("isDefined:Boolean")))
+              case "2" => checkScala(sig, DocSig(DocFqn("scala", "Some"), Some("flatMap[B](f:A=>Option[B]):Option[B]")))
+              case "3" => checkScala(sig, DocSig(DocFqn("scala", "Some"), Some("flatten[B](implicitev:<:<[A,Option[B]]):Option[B]")))
+              case "4" => checkScala(sig, DocSig(DocFqn("scala", "Some"), Some("fold[B](ifEmpty:=>B)(f:A=>B):B")))
+              case "5" => checkScala(sig, DocSig(DocFqn("scala", "Some"), Some("mkString(start:String,sep:String,end:String):String")))
+              case "6" => checkScala(sig, DocSig(DocFqn("scala", "Some"), Some("mkString:String")))
+              case "7" => checkScala(sig, DocSig(DocFqn("scala", "Some"), Some("mkString(sep:String):String")))
+              case "8" => checkScala(sig, DocSig(DocFqn("scala", "Some"), Some("getOrElse[B>:A](default:=>B):B")))
+              case "9" => checkScala(sig, DocSig(DocFqn("scala", "Some"), Some("grouped(size:Int):Iterator[Repr]")))
+              case "10" => checkScala(sig, DocSig(DocFqn("scala.collection.immutable", "List$"), Some("empty[A]:List[A]")))
+              case "11" => checkJava(sig, DocSig(DocFqn("com.google.common.io", "Files"), Some("move(java.io.File, java.io.File)")))
+              case "12" => checkJava(sig, DocSig(DocFqn("com.google.common.io", "Files"), Some("asByteSource(java.io.File)")))
+              case "13" => checkJava(sig, DocSig(DocFqn("com.google.common.io", "Files"), Some("map(java.io.File, java.nio.channels.FileChannel.MapMode)")))
+              case "14" => checkJava(sig, DocSig(DocFqn("com.google.common.io", "Files"), Some("map(java.io.File, java.nio.channels.FileChannel.MapMode, long)")))
+              case "15" => checkJava(sig, DocSig(DocFqn("com.google.common.io", "Files"), Some("write(byte[], java.io.File)")))
               // TODO(fix this hack) - just goes to the class itself if companion
               // constructor is requested.
-              case "16" => checkJava(sig, DocSig("scala.Some", None))
-              case "17" => checkJava(sig, DocSig("java.lang.String", None))
-              case "18" => checkScala(sig, DocSig("scala.Int", None))
-              case "20" => checkJava(sig, DocSig("java.io.File", None))
-              case "21" => checkJava(sig, DocSig("java.lang.Class", Some("isInstance(java.lang.Object)")))
-              case "22" => checkScala(sig, DocSig("scala.Predef$$DummyImplicit$", None))
-              case "23" => checkJava(sig, DocSig("java.util.HashMap", None))
-              case "24" => checkJava(sig, DocSig("java.util.HashMap", Some("entrySet()")))
-              case "25" => checkJava(sig, DocSig("java.util.Map.Entry", None))
-              case "26" => checkJava(sig, DocSig("java.util.package", None))
-              case "27" => checkJava(sig, DocSig("scala.collection.package", None))
+              case "16" => checkJava(sig, DocSig(DocFqn("scala", "Some"), None))
+              case "17" => checkJava(sig, DocSig(DocFqn("java.lang", "String"), None))
+              case "18" => checkScala(sig, DocSig(DocFqn("scala", "Int"), None))
+              case "20" => checkJava(sig, DocSig(DocFqn("java.io", "File"), None))
+              case "21" => checkJava(sig, DocSig(DocFqn("java.lang", "Class"), Some("isInstance(java.lang.Object)")))
+              case "22" => checkScala(sig, DocSig(DocFqn("scala", "Predef$$DummyImplicit$"), None))
+              case "23" => checkJava(sig, DocSig(DocFqn("java.util", "HashMap"), None))
+              case "24" => checkJava(sig, DocSig(DocFqn("java.util", "HashMap"), Some("entrySet()")))
+              case "25" => checkJava(sig, DocSig(DocFqn("java.util", "Map.Entry"), None))
+              case "26" => checkJava(sig, DocSig(DocFqn("java.util", "package"), None))
+              case "27" => checkJava(sig, DocSig(DocFqn("scala.collection", "package"), None))
               // TODO: Would be nice to be able to inspect a particular constructor. The problem is that
               // symbolAt returns the type itself when point is in 'File', and it's not totally clear
               // that's wrong.
               //            case "28" => checkJava(sig, DocSig("java.io.File", Some("File(java.lang.String, java.lang.String)"))
-              case "28" => checkScala(sig, DocSig("scala.package", Some("Exception=Exception")))
+              case "28" => checkScala(sig, DocSig(DocFqn("scala", "package"), Some("Exception=Exception")))
 
               // Check @usecase handling.
-              case "29" => checkScala(sig, DocSig("scala.Some", Some("++[B>:A,That](that:scala.collection.GenTraversableOnce[B])(implicitbf:scala.collection.generic.CanBuildFrom[Repr,B,That]):That")))
-              case "30" => checkScala(sig, DocSig("scala.collection.immutable.List", Some("flatMap[B,That](f:A=>scala.collection.GenTraversableOnce[B])(implicitbf:scala.collection.generic.CanBuildFrom[List[A],B,That]):That")))
-              case "31" => checkScala(sig, DocSig("scala.collection.immutable.List", Some("collect[B,That](pf:PartialFunction[A,B])(implicitbf:scala.collection.generic.CanBuildFrom[List[A],B,That]):That")))
+              case "29" => checkScala(sig, DocSig(DocFqn("scala", "Some"), Some("++[B>:A,That](that:scala.collection.GenTraversableOnce[B])(implicitbf:scala.collection.generic.CanBuildFrom[Repr,B,That]):That")))
+              case "30" => checkScala(sig, DocSig(DocFqn("scala.collection.immutable", "List"), Some("flatMap[B,That](f:A=>scala.collection.GenTraversableOnce[B])(implicitbf:scala.collection.generic.CanBuildFrom[List[A],B,That]):That")))
+              case "31" => checkScala(sig, DocSig(DocFqn("scala.collection.immutable", "List"), Some("collect[B,That](pf:PartialFunction[A,B])(implicitbf:scala.collection.generic.CanBuildFrom[List[A],B,That]):That")))
             }
+            checkJava(cc.askDocSignatureForSymbol("com.google.common.io.Files$", Some("simplifyPath"), None).get,
+              DocSig(DocFqn("com.google.common.io", "Files"), Some("simplifyPath(java.lang.String)")))
           }
 
-        val libdoc = config.allDocJars.find { f => f.getName.startsWith("scala-library") }.get
-        //val sdoc = config.allDocJars.find { f => f.getName.startsWith("scalac-scoverage") }.get
-
-        //assert(getUri(serv, DocSig("scoverage.Invoker$", None)) ==
-        //  Some("http://localhost:0/" + sdoc.getName + "/index.html#scoverage.Invoker$"))
-        //assert(getUri(serv, DocSig("scoverage.Invoker$", Some("fakeMethod(default:=>B):B"))) ==
-        //  Some("http://localhost:0/" + sdoc.getName + "/index.html#scoverage.Invoker$@fakeMethod%28default%3A%3D%3EB%29%3AB"))
-        assert(getUri(serv, DocSig("java.io.File", None)) ==
+        val libdoc = docs.find { f => f.getName.startsWith("scala-library") }.get
+        val java8doc = docs.find { f => f.getName.startsWith("ForecastIOLib") }.get
+        assert(getUri(serv, DocSig(DocFqn("scala", "Some"), None)) ==
+          Some("http://localhost:0/" + libdoc.getName + "/index.html#scala.Some"))
+        assert(getUri(serv, DocSig(DocFqn("scala", "Some"), Some("mkString(sep:String):String"))) ==
+          Some("http://localhost:0/" + libdoc.getName + "/index.html#scala.Some@mkString%28sep%3AString%29%3AString"))
+        assert(getUri(serv, DocSig(DocFqn("java.io", "File"), None)) ==
           Some("http://docs.oracle.com/javase/6/docs/api/java/io/File.html"))
-        assert(getUri(serv, DocSig("java.util.Map.Entry", None)) ==
+        assert(getUri(serv, DocSig(DocFqn("java.util", "Map.Entry"), None)) ==
           Some("http://docs.oracle.com/javase/6/docs/api/java/util/Map.Entry.html"))
-        assert(getUri(serv, DocSig("java.util.package", None)) ==
+        assert(getUri(serv, DocSig(DocFqn("java.util", "package"), None)) ==
           Some("http://docs.oracle.com/javase/6/docs/api/java/util/package-summary.html"))
-        assert(getUri(serv, DocSig("scala.collection.immutable.package", None)).getOrElse("")
+        assert(getUri(serv, DocSig(DocFqn("scala.collection.immutable", "package"), None)).getOrElse("")
           .endsWith("/index.html#scala.collection.immutable.package"))
 
-        assert(getUri(serv8, DocSig("java.io.File", Some("delete()"))) ==
+        assert(getUri(serv, DocSig(DocFqn("com.github.dvdme.ForecastIOLib", "ForecastIO"), Some("getForecast(com.eclipsesource.json.JsonObject)"))) ==
+          Some("http://localhost:0/" + java8doc.getName +
+            "/com/github/dvdme/ForecastIOLib/ForecastIO.html#getForecast-com.eclipsesource.json.JsonObject-"))
+
+        assert(getUri(serv8, DocSig(DocFqn("java.io", "File"), Some("delete()"))) ==
           Some("http://docs.oracle.com/javase/8/docs/api/java/io/File.html#delete--"))
-        assert(getUri(serv8, DocSig("java.lang.Math", Some("max(int, int)"))) ==
+        assert(getUri(serv8, DocSig(DocFqn("java.lang", "Math"), Some("max(int, int)"))) ==
           Some("http://docs.oracle.com/javase/8/docs/api/java/lang/Math.html#max-int-int-"))
-        assert(getUri(serv8, DocSig("java.util.Arrays", Some("binarySearch(int[], int)"))) ==
+        assert(getUri(serv8, DocSig(DocFqn("java.util", "Arrays"), Some("binarySearch(int[], int)"))) ==
           Some("http://docs.oracle.com/javase/8/docs/api/java/util/Arrays.html#binarySearch-int%3AA-int-"))
+
       }
   }
 }

--- a/server/src/it/scala/org/ensime/intg/BasicWorkflow.scala
+++ b/server/src/it/scala/org/ensime/intg/BasicWorkflow.scala
@@ -168,12 +168,12 @@ class BasicWorkflow extends WordSpec with Matchers
       val insPacByPathResOpt = project.rpcInspectPackageByPath("org.example")
       insPacByPathResOpt match {
         case Some(PackageInfo("example", "org.example", List(
-          BasicTypeInfo("Bloo", 136, 'class, "org.example.Bloo", List(), List(), Some(EmptySourcePosition()), None),
-          BasicTypeInfo("Bloo$", 135, 'object, "org.example.Bloo$", List(), List(), Some(EmptySourcePosition()), None),
-          BasicTypeInfo("CaseClassWithCamelCaseName", 138, 'class, "org.example.CaseClassWithCamelCaseName", List(), List(), Some(EmptySourcePosition()), None),
-          BasicTypeInfo("CaseClassWithCamelCaseName$", 137, 'object, "org.example.CaseClassWithCamelCaseName$", List(), List(), Some(EmptySourcePosition()), None),
-          BasicTypeInfo("Foo", 3, 'class, "org.example.Foo", List(), List(), Some(EmptySourcePosition()), None),
-          BasicTypeInfo("Foo$", 4, 'object, "org.example.Foo$", List(), List(), Some(EmptySourcePosition()), None)))) =>
+          BasicTypeInfo("Bloo", _: Int, 'class, "org.example.Bloo", List(), List(), Some(EmptySourcePosition()), None),
+          BasicTypeInfo("Bloo$", _: Int, 'object, "org.example.Bloo$", List(), List(), Some(EmptySourcePosition()), None),
+          BasicTypeInfo("CaseClassWithCamelCaseName", _: Int, 'class, "org.example.CaseClassWithCamelCaseName", List(), List(), Some(EmptySourcePosition()), None),
+          BasicTypeInfo("CaseClassWithCamelCaseName$", _: Int, 'object, "org.example.CaseClassWithCamelCaseName$", List(), List(), Some(EmptySourcePosition()), None),
+          BasicTypeInfo("Foo", _: Int, 'class, "org.example.Foo", List(), List(), Some(EmptySourcePosition()), None),
+          BasicTypeInfo("Foo$", _: Int, 'object, "org.example.Foo$", List(), List(), Some(EmptySourcePosition()), None)))) =>
         case _ =>
           fail("inspect package by path failed, got: " + insPacByPathResOpt)
       }

--- a/server/src/main/scala/org/ensime/EnsimeApi.scala
+++ b/server/src/main/scala/org/ensime/EnsimeApi.scala
@@ -59,7 +59,9 @@ trait EnsimeApi {
   def rpcCallCompletion(id: Int): Option[CallCompletionInfo]
   def rpcImportSuggestions(f: String, point: Int, names: List[String], maxResults: Int): ImportSuggestions
   def rpcDocSignatureAtPoint(f: String, point: OffsetRange): Option[DocSigPair]
+  def rpcDocSignatureForSymbol(typeFullName: String, memberName: Option[String], memberTypeId: Option[Int]): Option[DocSigPair]
   def rpcDocUriAtPoint(f: String, point: OffsetRange): Option[String]
+  def rpcDocUriForSymbol(typeFullName: String, memberName: Option[String], memberTypeId: Option[Int]): Option[String]
   def rpcPublicSymbolSearch(names: List[String], maxResults: Int): SymbolSearchResults
   def rpcUsesOfSymAtPoint(f: String, point: Int): List[ERangePosition]
   def rpcTypeAtPoint(f: String, range: OffsetRange): Option[TypeInfo]

--- a/server/src/main/scala/org/ensime/core/Analyzer.scala
+++ b/server/src/main/scala/org/ensime/core/Analyzer.scala
@@ -203,6 +203,8 @@ class Analyzer(
               case DocSignatureAtPointReq(file: File, range: OffsetRange) =>
                 val p = pos(file, range)
                 sender ! scalaCompiler.askDocSignatureAtPoint(p)
+              case DocSignatureForSymbolReq(typeFullName: String, memberName: Option[String], memberTypeId: Option[Int]) =>
+                sender ! scalaCompiler.askDocSignatureForSymbol(typeFullName, memberName, memberTypeId)
               case InspectPackageByPathReq(path: String) =>
                 sender ! scalaCompiler.askPackageByPath(path)
               case TypeAtPointReq(file: File, range: OffsetRange) =>

--- a/server/src/main/scala/org/ensime/core/DocFinding.scala
+++ b/server/src/main/scala/org/ensime/core/DocFinding.scala
@@ -19,65 +19,65 @@ trait DocFinding { self: RichPresentationCompiler =>
   private def fullTypeName(sym: Symbol, nestedTypeSep: String, nameString: (Symbol => String)): String =
     sym.ownerChain.takeWhile(!_.hasPackageFlag).reverse.map(nameString(_)).mkString(nestedTypeSep)
 
-  private val ScalaPrim = """^scala\.(Boolean|Byte|Char|Double|Float|Int|Long|Short)$""".r
-  private val ScalaAny = """^scala\.(Any|AnyVal|AnyRef)$""".r
-  private def javaFqn(tpe: Type): String = {
+  private val ScalaPrim = """^(Boolean|Byte|Char|Double|Float|Int|Long|Short)$""".r
+  private val ScalaAny = """^(Any|AnyVal|AnyRef)$""".r
+  private def javaFqn(tpe: Type): DocFqn = {
     def nameString(sym: Symbol) = sym.nameString.replace("$", "")
     val sym = tpe.typeSymbol
     val s = if (sym.hasPackageFlag) {
-      fullPackage(sym) + ".package"
+      DocFqn(fullPackage(sym), "package")
     } else {
-      fullPackage(sym) + "." + fullTypeName(sym, ".", nameString)
+      DocFqn(fullPackage(sym), fullTypeName(sym, ".", nameString))
     }
     s match {
-      case ScalaPrim(datatype) => datatype.toLowerCase()
-      case ScalaAny(datatype) => "java.lang.Object"
-      case "scala.Array" => {
-        tpe.typeArgs.headOption.map { tpe => javaFqn(tpe) + "[]" }.getOrElse(s)
+      case DocFqn("scala", ScalaPrim(datatype)) => DocFqn("", datatype.toLowerCase())
+      case DocFqn("scala", ScalaAny(datatype)) => DocFqn("java.lang", "Object")
+      case DocFqn("scala", "Array") => {
+        tpe.typeArgs.headOption.map { tpe =>
+          val fqn = javaFqn(tpe)
+          fqn.copy(typeName = fqn.typeName + "[]")
+        }.getOrElse(s)
       }
       case _ => s
     }
   }
 
-  protected def scalaFqn(sym: Symbol): String = {
+  protected def scalaFqn(sym: Symbol): DocFqn = {
     def nameString(s: Symbol) = s.nameString + (if ((s.isModule || s.isModuleClass) && !s.hasPackageFlag) "$" else "")
     if (sym.isPackageObjectOrClass) {
-      fullPackage(sym.owner) + ".package"
+      DocFqn(fullPackage(sym.owner), "package")
     } else if (sym.hasPackageFlag) {
-      fullPackage(sym) + ".package"
+      DocFqn(fullPackage(sym), ".package")
     } else {
-      fullPackage(sym) + "." + fullTypeName(sym, "$", nameString)
+      DocFqn(fullPackage(sym), fullTypeName(sym, "$", nameString))
     }
   }
 
-  private def linkName(sym: Symbol, java: Boolean): String = {
+  private def linkName(sym: Symbol, java: Boolean): DocFqn = {
     if (java) javaFqn(sym.tpe) else scalaFqn(sym)
   }
 
   private def signatureString(sym: Symbol, java: Boolean): String = {
     sym.nameString + (if (java) {
       if (sym.paramLists.isEmpty) ""
-      else sym.paramLists.flatMap(_.map { sym => javaFqn(sym.tpe) }).mkString("(", ", ", ")")
+      else sym.paramLists.flatMap(_.map { sym => javaFqn(sym.tpe).mkString }).mkString("(", ", ", ")")
     } else sym.signatureString.replaceAll("[\\s]", ""))
   }
 
-  def docSignatureAt(p: Position): Option[DocSigPair] = {
-    symbolAt(p).orElse(typeAt(p).map(_.typeSymbol)).flatMap {
-      sym =>
-        def docSig(java: Boolean) = {
-          val owner = sym.owner
-          if (sym.isCaseApplyOrUnapply) {
-            DocSig(linkName(owner.companionClass, java), None)
-          } else if (sym.isClass || sym.isModule || sym.isTrait || sym.hasPackageFlag)
-            DocSig(linkName(sym, java), None)
-          else if (owner.isClass || owner.isModule || owner.isTrait || owner.hasPackageFlag) {
-            val ownerAtSite = specificOwnerOfsymbolAt(p).getOrElse(owner)
-            DocSig(linkName(ownerAtSite, java), Some(signatureString(sym, java)))
-          } else
-            DocSig(linkName(sym.tpe.typeSymbol, java), None)
-        }
-        Some(DocSigPair(docSig(false), docSig(true)))
+  def docSignature(sym: Symbol, pos: Option[Position]): Option[DocSigPair] = {
+    def docSig(java: Boolean) = {
+      val owner = sym.owner
+      if (sym.isCaseApplyOrUnapply) {
+        DocSig(linkName(owner.companionClass, java), None)
+      } else if (sym.isClass || sym.isModule || sym.isTrait || sym.hasPackageFlag)
+        DocSig(linkName(sym, java), None)
+      else if (owner.isClass || owner.isModule || owner.isTrait || owner.hasPackageFlag) {
+        val ownerAtSite = pos.flatMap(specificOwnerOfSymbolAt(_)).getOrElse(owner)
+        DocSig(linkName(ownerAtSite, java), Some(signatureString(sym, java)))
+      } else
+        DocSig(linkName(sym.tpe.typeSymbol, java), None)
     }
+    Some(DocSigPair(docSig(false), docSig(true)))
   }
 
 }

--- a/server/src/main/scala/org/ensime/core/DocUsecaseHandling.scala
+++ b/server/src/main/scala/org/ensime/core/DocUsecaseHandling.scala
@@ -22,7 +22,7 @@ trait DocUsecaseHandling { self: DocServer =>
 
   val PrefixRegexp = """^([A-Za-z:_\+-]+).*""".r
   protected def maybeReplaceWithUsecase(jar: File, sig: DocSig): DocSig = {
-    if (sig.fqn.startsWith("scala.")) {
+    if (sig.fqn.scalaStdLib) {
       sig.member match {
         case Some(PrefixRegexp(prefix)) if UseCasePrefixes.contains(prefix) => {
           try {

--- a/server/src/main/scala/org/ensime/core/Project.scala
+++ b/server/src/main/scala/org/ensime/core/Project.scala
@@ -51,6 +51,7 @@ case class FormatFileReq(fileInfo: SourceFileInfo) extends RPCRequest
 case class ExpandSelectionReq(filename: String, start: Int, stop: Int) extends RPCRequest
 case class DocUriReq(sig: DocSigPair) extends RPCRequest
 case class DocSignatureAtPointReq(file: File, range: OffsetRange) extends RPCRequest
+case class DocSignatureForSymbolReq(typeFullName: String, memberName: Option[String], memberTypeId: Option[Int]) extends RPCRequest
 
 case class SubscribeAsync(handler: EnsimeEvent => Unit) extends RPCRequest
 

--- a/server/src/main/scala/org/ensime/core/ProjectEnsimeApiImpl.scala
+++ b/server/src/main/scala/org/ensime/core/ProjectEnsimeApiImpl.scala
@@ -223,8 +223,16 @@ trait ProjectEnsimeApiImpl extends EnsimeApi { self: Project =>
     callRPC[Option[DocSigPair]](getAnalyzer, DocSignatureAtPointReq(new File(f), range))
   }
 
+  override def rpcDocSignatureForSymbol(typeFullName: String, memberName: Option[String], memberTypeId: Option[Int]): Option[DocSigPair] = {
+    callRPC[Option[DocSigPair]](getAnalyzer, DocSignatureForSymbolReq(typeFullName, memberName, memberTypeId))
+  }
+
   override def rpcDocUriAtPoint(f: String, range: OffsetRange): Option[String] = {
     rpcDocSignatureAtPoint(f, range).flatMap { sig => callRPC[Option[String]](docServer, DocUriReq(sig)) }
+  }
+
+  override def rpcDocUriForSymbol(typeFullName: String, memberName: Option[String], memberTypeId: Option[Int]): Option[String] = {
+    rpcDocSignatureForSymbol(typeFullName, memberName, memberTypeId).flatMap { sig => callRPC[Option[String]](docServer, DocUriReq(sig)) }
   }
 
   override def rpcPublicSymbolSearch(names: List[String], maxResults: Int): SymbolSearchResults = {

--- a/server/src/main/scala/org/ensime/server/ConnectionInfo.scala
+++ b/server/src/main/scala/org/ensime/server/ConnectionInfo.scala
@@ -6,4 +6,4 @@ case class ConnectionInfo(
   pid: Option[Int] = None,
   implementation: EnsimeImplementation = EnsimeImplementation("ENSIME"),
   // Please also update changelog in SwankProtocol.scala
-  version: String = "0.8.12")
+  version: String = "0.8.13")

--- a/server/src/test/scala/org/ensime/server/protocol/swank/SwankProtocolSpec.scala
+++ b/server/src/test/scala/org/ensime/server/protocol/swank/SwankProtocolSpec.scala
@@ -113,7 +113,7 @@ class SwankProtocolSpec extends FunSpec with ShouldMatchers with BeforeAndAfterA
     it("should understand connection-info request") {
       testWithResponse("(swank:connection-info)") { (t, m, id) =>
         (t.rpcConnectionInfo _).expects().returns(new ConnectionInfo())
-        (m.send _).expects(s"""(:return (:ok (:pid nil :implementation (:name "ENSIME") :version "0.8.12")) $id)""")
+        (m.send _).expects(s"""(:return (:ok (:pid nil :implementation (:name "ENSIME") :version "0.8.13")) $id)""")
       }
     }
 


### PR DESCRIPTION
See corresponding PR in ensime-emacs.
I may follow up with a PR to clean up the protocol a bit, as there are other places that accept different arguments to select a symbol.
May need tests. Let's see what coverage jerk says : ) 