### PR TITLE
Don't try to complete with the symbol we're typing.

### DIFF
--- a/src/main/scala/org/ensime/core/Completion.scala
+++ b/src/main/scala/org/ensime/core/Completion.scala
@@ -222,7 +222,9 @@ trait CompletionControl {
       for (m <- filtered) {
         m match {
           case m @ ScopeMember(sym, tpe, accessible, viaView) =>
-            if (!sym.isConstructor) {
+            val p = sym.pos
+            val inSymbol = p.isRange && (context.offset >= p.start && context.offset <= p.end)
+            if (!sym.isConstructor && !inSymbol) {
               buff ++= toCompletionInfo(context, sym, tpe, inherited = false, NoSymbol)
             }
           case m @ TypeMember(sym, tpe, accessible, inherited, viaView) =>

--- a/src/test/scala/org/ensime/core/RichPresentationCompilerSpec.scala
+++ b/src/test/scala/org/ensime/core/RichPresentationCompilerSpec.scala
@@ -116,8 +116,17 @@ class RichPresentationCompilerSpec extends FunSpec with Matchers with SLF4JLoggi
         "object Abc { def aMethod(a: Int) = a }",
         "object B { val x = Ab@@ }") { (p, _, cc) =>
           val result = cc.completionsAt(p, 10, caseSens = false)
-          assert(result.completions.length > 1)
+          assert(result.completions.length > 0)
           assert(result.completions.head.name == "Abc")
+        }
+    }
+
+    it("won't try to complete the declaration containing point") {
+      Helpers.forPosInCompiledSource(
+        "package com.example",
+        "object Ab@@c {}") { (p, _, cc) =>
+          val result = cc.completionsAt(p, 10, caseSens = false)
+          assert(!result.completions.exists(_.name == "Abc"))
         }
     }
 


### PR DESCRIPTION
Resolves #828. When editing a declaration, the declaration itself was being thrown into the completion list.