### PR TITLE
Typed debug thread ids + logic seperation

### DIFF
--- a/api/src/main/scala/org/ensime/model/Model.scala
+++ b/api/src/main/scala/org/ensime/model/Model.scala
@@ -2,9 +2,6 @@ package org.ensime.model
 
 import java.io.File
 import org.ensime.util.FileEdit
-import scala.collection.mutable
-
-import org.ensime.config._
 
 sealed trait EntityInfo {
   def name: String
@@ -162,7 +159,23 @@ sealed trait DebugLocation
 
 case class DebugObjectReference(objectId: Long) extends DebugLocation
 
-case class DebugStackSlot(threadId: String, frame: Int, offset: Int) extends DebugLocation
+/**
+ * A debugger thread id.
+ */
+case class DebugThreadId(id: Long)
+
+object DebugThreadId {
+  /**
+   * Create a ThreadId from a String representation
+   * @param s A Long encoded as a string
+   * @return A ThreadId
+   */
+  def apply(s: String): DebugThreadId = {
+    new DebugThreadId(s.toLong)
+  }
+}
+
+case class DebugStackSlot(threadId: DebugThreadId, frame: Int, offset: Int) extends DebugLocation
 
 case class DebugArrayElement(objectId: Long, index: Int) extends DebugLocation
 

--- a/api/src/main/scala/org/ensime/model/Model.scala
+++ b/api/src/main/scala/org/ensime/model/Model.scala
@@ -155,10 +155,6 @@ object OffsetRange {
   def apply(fromTo: Int): OffsetRange = new OffsetRange(fromTo, fromTo)
 }
 
-sealed trait DebugLocation
-
-case class DebugObjectReference(objectId: Long) extends DebugLocation
-
 /**
  * A debugger thread id.
  */
@@ -175,11 +171,32 @@ object DebugThreadId {
   }
 }
 
+case class DebugObjectId(id: Long)
+
+object DebugObjectId {
+  /**
+   * Create a DebugObjectId from a String representation
+   * @param s A Long encoded as a string
+   * @return A DebugObjectId
+   */
+  def apply(s: String): DebugObjectId = {
+    new DebugObjectId(s.toLong)
+  }
+}
+
+sealed trait DebugLocation
+
+case class DebugObjectReference(objectId: DebugObjectId) extends DebugLocation
+
+object DebugObjectReference {
+  def apply(objId: Long): DebugObjectReference = new DebugObjectReference(DebugObjectId(objId))
+}
+
 case class DebugStackSlot(threadId: DebugThreadId, frame: Int, offset: Int) extends DebugLocation
 
-case class DebugArrayElement(objectId: Long, index: Int) extends DebugLocation
+case class DebugArrayElement(objectId: DebugObjectId, index: Int) extends DebugLocation
 
-case class DebugObjectField(objectId: Long, field: String) extends DebugLocation
+case class DebugObjectField(objectId: DebugObjectId, field: String) extends DebugLocation
 
 sealed trait DebugValue {
   def typeName: String
@@ -196,19 +213,19 @@ case class DebugObjectInstance(
   summary: String,
   fields: List[DebugClassField],
   typeName: String,
-  objectId: Long) extends DebugValue
+  objectId: DebugObjectId) extends DebugValue
 
 case class DebugStringInstance(
   summary: String,
   fields: List[DebugClassField],
   typeName: String,
-  objectId: Long) extends DebugValue
+  objectId: DebugObjectId) extends DebugValue
 
 case class DebugArrayInstance(
   length: Int,
   typeName: String,
   elementTypeName: String,
-  objectId: Long) extends DebugValue
+  objectId: DebugObjectId) extends DebugValue
 
 case class DebugClassField(
   index: Int,
@@ -229,7 +246,7 @@ case class DebugStackFrame(
   className: String,
   methodName: String,
   pcLocation: LineSourcePosition,
-  thisObjectId: Long)
+  thisObjectId: DebugObjectId)
 
 case class DebugBacktrace(
   frames: List[DebugStackFrame],

--- a/server/src/it/scala/org/ensime/fixture/ServerFixture.scala
+++ b/server/src/it/scala/org/ensime/fixture/ServerFixture.scala
@@ -78,7 +78,7 @@ class AsyncMsgHelper(actorSystem: ActorSystem) {
 
   private class AsyncMsgHelperActor extends Actor with ActorLogging {
     // ListMap instead of HashMap to avoid hashCode nonsense
-    private var asyncMsgs = ListMap[EnsimeEvent, Int]() withDefaultValue(0)
+    private var asyncMsgs = ListMap[EnsimeEvent, Int]() withDefaultValue (0)
 
     private var outstandingAsyncs = Vector[(EnsimeEvent, ActorRef)]()
 

--- a/server/src/it/scala/org/ensime/fixture/ServerFixture.scala
+++ b/server/src/it/scala/org/ensime/fixture/ServerFixture.scala
@@ -24,8 +24,6 @@ object ServerFixture {
     assert(connInfo.pid == None)
     assert(connInfo.implementation.name == "ENSIME")
 
-    server.project.rpcNotifyClientReady()
-
     val asyncHelper = new AsyncMsgHelper(sys)
 
     server.project.rpcSubscribeAsync(event => { asyncHelper.asyncReceived(event) })
@@ -80,7 +78,7 @@ class AsyncMsgHelper(actorSystem: ActorSystem) {
 
   private class AsyncMsgHelperActor extends Actor with ActorLogging {
     // ListMap instead of HashMap to avoid hashCode nonsense
-    private var asyncMsgs = ListMap[EnsimeEvent, Int]() withDefaultValue (0)
+    private var asyncMsgs = ListMap[EnsimeEvent, Int]() withDefaultValue(0)
 
     private var outstandingAsyncs = Vector[(EnsimeEvent, ActorRef)]()
 

--- a/server/src/it/scala/org/ensime/intg/BasicWorkflow.scala
+++ b/server/src/it/scala/org/ensime/intg/BasicWorkflow.scala
@@ -208,7 +208,7 @@ class BasicWorkflow extends WordSpec with Matchers
 
       val peekUndoRes = project.rpcPeekUndo()
       val undoId = peekUndoRes match {
-        case Right(Undo(undoIdVal, "Refactoring of type: 'rename", List(TextEdit(`fooFile`, 214, 217, "foo"), TextEdit(`fooFile`, 252, 255, "foo"), TextEdit(`fooFile`, 269, 272, "foo")))) =>
+        case Some(Undo(undoIdVal, "Refactoring of type: 'rename", List(TextEdit(`fooFile`, 214, 217, "foo"), TextEdit(`fooFile`, 252, 255, "foo"), TextEdit(`fooFile`, 269, 272, "foo")))) =>
           undoIdVal
         case _ =>
           fail("unexpected peek undo result: " + peekUndoRes)

--- a/server/src/it/scala/org/ensime/intg/DebugTest.scala
+++ b/server/src/it/scala/org/ensime/intg/DebugTest.scala
@@ -33,7 +33,7 @@ class DebugTest extends WordSpec with Matchers with Inside
     ) { (server, _, _) =>
         implicit val s = server
         checkTopStackFrame("stepping.ForComprehensionListString$", "main", 9)
-        server.project.rpcDebugNext("1")
+        server.project.rpcDebugNext(DebugThreadId(1))
         checkTopStackFrame("stepping.ForComprehensionListString$$anonfun$main$1", "apply", 10)
       }
   }
@@ -48,7 +48,7 @@ class DebugTest extends WordSpec with Matchers with Inside
         val project = server.project
         val breakpointsPath = breakpointsFile.getAbsolutePath
 
-        project.rpcDebugBacktrace("1", 0, 3) should matchPattern {
+        project.rpcDebugBacktrace(DebugThreadId(1), 0, 3) should matchPattern {
           case DebugBacktrace(List(
             DebugStackFrame(0, List(), 0, "breakpoints.Breakpoints", "mainTest",
               LineSourcePosition(`breakpointsFile`, 32), _),
@@ -71,23 +71,23 @@ class DebugTest extends WordSpec with Matchers with Inside
           //              session.resumetoSuspension()
           //              session.checkStackFrame(BP_TYPENAME, "simple1()V", 11)
 
-          project.rpcDebugContinue("1")
-          asyncHelper.expectAsync(60 seconds, DebugBreakEvent("1", "main", breakpointsFile, 11))
+          project.rpcDebugContinue(DebugThreadId(1))
+          asyncHelper.expectAsync(60 seconds, DebugBreakEvent(DebugThreadId(1), "main", breakpointsFile, 11))
 
           //              session.resumetoSuspension()
           //              session.checkStackFrame(BP_TYPENAME, "simple1()V", 13)
 
-          project.rpcDebugContinue("1")
-          asyncHelper.expectAsync(60 seconds, DebugBreakEvent("1", "main", breakpointsFile, 13))
+          project.rpcDebugContinue(DebugThreadId(1))
+          asyncHelper.expectAsync(60 seconds, DebugBreakEvent(DebugThreadId(1), "main", breakpointsFile, 13))
 
           //              bp11.setEnabled(false)
           project.rpcDebugClearBreakpoint(breakpointsPath, 11)
           //              session.waitForBreakpointsToBeDisabled(bp11)
           //
           //              session.resumetoSuspension()
-          project.rpcDebugContinue("1")
+          project.rpcDebugContinue(DebugThreadId(1))
           //              session.checkStackFrame(BP_TYPENAME, "simple1()V", 13)
-          asyncHelper.expectAsync(60 seconds, DebugBreakEvent("1", "main", breakpointsFile, 13))
+          asyncHelper.expectAsync(60 seconds, DebugBreakEvent(DebugThreadId(1), "main", breakpointsFile, 13))
           //
           //              bp11.setEnabled(true); bp13.setEnabled(false)
           project.rpcDebugSetBreakpoint(breakpointsPath, 11)
@@ -98,15 +98,15 @@ class DebugTest extends WordSpec with Matchers with Inside
           //
           //              session.resumetoSuspension()
           //              session.checkStackFrame(BP_TYPENAME, "simple1()V", 11)
-          project.rpcDebugContinue("1")
-          asyncHelper.expectAsync(60 seconds, DebugBreakEvent("1", "main", breakpointsFile, 11))
+          project.rpcDebugContinue(DebugThreadId(1))
+          asyncHelper.expectAsync(60 seconds, DebugBreakEvent(DebugThreadId(1), "main", breakpointsFile, 11))
           //
           //              session.resumetoSuspension()
           //              session.checkStackFrame(BP_TYPENAME, "simple1()V", 11)
-          project.rpcDebugContinue("1")
-          asyncHelper.expectAsync(60 seconds, DebugBreakEvent("1", "main", breakpointsFile, 11))
+          project.rpcDebugContinue(DebugThreadId(1))
+          asyncHelper.expectAsync(60 seconds, DebugBreakEvent(DebugThreadId(1), "main", breakpointsFile, 11))
           //
-          project.rpcDebugContinue("1")
+          project.rpcDebugContinue(DebugThreadId(1))
           //asyncHelper.expectAsync(60 seconds, DebugVMDisconnectEvent)
           //              session.resumeToCompletion()
         } finally {
@@ -164,42 +164,42 @@ class DebugTest extends WordSpec with Matchers with Inside
         (server, asyncHelper, variablesFile) =>
           implicit val s = server
           // boolean local
-          getVariableValue("1", "a") should matchPattern {
+          getVariableValue(DebugThreadId(1), "a") should matchPattern {
             case DebugPrimitiveValue("true", "boolean") =>
           }
 
           // char local
-          getVariableValue("1", "b") should matchPattern {
+          getVariableValue(DebugThreadId(1), "b") should matchPattern {
             case DebugPrimitiveValue("'c'", "char") =>
           }
 
           // short local
-          getVariableValue("1", "c") should matchPattern {
+          getVariableValue(DebugThreadId(1), "c") should matchPattern {
             case DebugPrimitiveValue("3", "short") =>
           }
 
           // int local
-          getVariableValue("1", "d") should matchPattern {
+          getVariableValue(DebugThreadId(1), "d") should matchPattern {
             case DebugPrimitiveValue("4", "int") =>
           }
 
           // long local
-          getVariableValue("1", "e") should matchPattern {
+          getVariableValue(DebugThreadId(1), "e") should matchPattern {
             case DebugPrimitiveValue("5", "long") =>
           }
 
           // float local
-          getVariableValue("1", "f") should matchPattern {
+          getVariableValue(DebugThreadId(1), "f") should matchPattern {
             case DebugPrimitiveValue("1.0", "float") =>
           }
 
           // double local
-          getVariableValue("1", "g") should matchPattern {
+          getVariableValue(DebugThreadId(1), "g") should matchPattern {
             case DebugPrimitiveValue("2.0", "double") =>
           }
 
           // String local
-          inside(getVariableValue("1", "h")) {
+          inside(getVariableValue(DebugThreadId(1), "h")) {
             case DebugStringInstance("\"test\"", debugFields, "java.lang.String", _) =>
               exactly(1, debugFields) should matchPattern {
                 case DebugClassField(_, "value", "char[]", "Array['t', 'e', 's',...]") =>
@@ -207,12 +207,12 @@ class DebugTest extends WordSpec with Matchers with Inside
           }
 
           // primitive array local
-          getVariableValue("1", "i") should matchPattern {
+          getVariableValue(DebugThreadId(1), "i") should matchPattern {
             case DebugArrayInstance(3, "int[]", "int", _) =>
           }
 
           // type local
-          inside(getVariableValue("1", "j")) {
+          inside(getVariableValue(DebugThreadId(1), "j")) {
             case DebugObjectInstance("Instance of $colon$colon", debugFields, "scala.collection.immutable.$colon$colon", _) =>
               exactly(1, debugFields) should matchPattern {
                 case DebugClassField(_, "head", "java.lang.Object", "Instance of Integer") =>
@@ -220,7 +220,7 @@ class DebugTest extends WordSpec with Matchers with Inside
           }
 
           // object array local
-          getVariableValue("1", "k") should matchPattern {
+          getVariableValue(DebugThreadId(1), "k") should matchPattern {
             case DebugArrayInstance(3, "java.lang.Object[]", "java.lang.Object", _) =>
           }
       }
@@ -249,7 +249,7 @@ trait DebugTestUtils {
     val startStatus = project.rpcDebugStartVM(className)
     assert(startStatus == DebugVmSuccess())
 
-    val expect = DebugBreakEvent("1", "main", resolvedFile, breakLine)
+    val expect = DebugBreakEvent(DebugThreadId(1), "main", resolvedFile, breakLine)
     asyncHelper.expectAsync(10 seconds, expect)
     project.rpcDebugClearBreakpoint(fileName, breakLine)
 
@@ -260,14 +260,14 @@ trait DebugTestUtils {
 
       // no way to await the stopped condition so we let the app run
       // its course on the main thread
-      project.rpcDebugContinue("1")
+      project.rpcDebugContinue(DebugThreadId(1))
       project.rpcDebugStopVM()
 
       //asyncHelper.expectAsync(30 seconds, DebugVMDisconnectEvent)
     }
   }
 
-  def getVariableValue(threadId: String, variableName: String)(implicit server: Server): DebugValue = {
+  def getVariableValue(threadId: DebugThreadId, variableName: String)(implicit server: Server): DebugValue = {
     val project = server.project
     val vLocOpt = project.rpcDebugLocateName(threadId, variableName)
     val vLoc = vLocOpt.getOrThrow(
@@ -280,7 +280,7 @@ trait DebugTestUtils {
   }
 
   def checkTopStackFrame(className: String, method: String, line: Int)(implicit server: Server): Unit = {
-    server.project.rpcDebugBacktrace("1", 0, 1) should matchPattern {
+    server.project.rpcDebugBacktrace(DebugThreadId(1), 0, 1) should matchPattern {
       case DebugBacktrace(List(DebugStackFrame(0, _, 1, `className`, `method`,
         LineSourcePosition(_, `line`), _)),
         "1", "main") =>

--- a/server/src/main/scala/org/ensime/EnsimeApi.scala
+++ b/server/src/main/scala/org/ensime/EnsimeApi.scala
@@ -9,7 +9,6 @@ trait EnsimeApi {
 
   def rpcConnectionInfo(): ConnectionInfo
   def rpcShutdownServer(): Unit
-  def rpcNotifyClientReady(): Unit
 
   /**
    * Subscribe to async events from the project, replaying previously seen events if requested.
@@ -18,8 +17,15 @@ trait EnsimeApi {
    * @return True if caller is first subscriber, False otherwise
    */
   def rpcSubscribeAsync(handler: EnsimeEvent => Unit): Boolean
-  def rpcPeekUndo(): Either[String, Undo]
+
+  /**
+   * Return the details of the latest Undo operation on the undo stack.
+   * @return The latest Undo information (if it exists) or None
+   */
+  def rpcPeekUndo(): Option[Undo]
+
   def rpcExecUndo(undoId: Int): Either[String, UndoResult]
+
   def rpcReplConfig(): ReplConfig
 
   /**
@@ -93,9 +99,11 @@ trait EnsimeApi {
   def rpcUsesOfSymAtPoint(f: String, point: Int): List[ERangePosition]
   def rpcTypeAtPoint(f: String, range: OffsetRange): Option[TypeInfo]
   def rpcInspectPackageByPath(path: String): Option[PackageInfo]
+
   def rpcPrepareRefactor(procId: Int, refactorDesc: RefactorDesc): Either[RefactorFailure, RefactorEffect]
   def rpcExecRefactor(procId: Int, refactorType: Symbol): Either[RefactorFailure, RefactorResult]
   def rpcCancelRefactor(procId: Int): Unit
+
   def rpcExpandSelection(filename: String, start: Int, stop: Int): FileRange
   def rpcFormatFiles(filenames: List[String]): Unit
   def rpcFormatFile(fileInfo: SourceFileInfo): String
@@ -104,19 +112,19 @@ trait EnsimeApi {
   def rpcDebugAttachVM(hostname: String, port: String): DebugVmStatus
   def rpcDebugStopVM(): Boolean
   def rpcDebugRun(): Boolean
-  def rpcDebugContinue(threadId: String): Boolean
+  def rpcDebugContinue(threadId: DebugThreadId): Boolean
   def rpcDebugSetBreakpoint(file: String, line: Int): Unit
   def rpcDebugClearBreakpoint(file: String, line: Int): Unit
   def rpcDebugClearAllBreakpoints(): Unit
   def rpcDebugListBreakpoints(): BreakpointList
-  def rpcDebugNext(threadId: String): Boolean
-  def rpcDebugStep(threadId: String): Boolean
-  def rpcDebugStepOut(threadId: String): Boolean
-  def rpcDebugLocateName(threadId: String, name: String): Option[DebugLocation]
+  def rpcDebugNext(threadId: DebugThreadId): Boolean
+  def rpcDebugStep(threadId: DebugThreadId): Boolean
+  def rpcDebugStepOut(threadId: DebugThreadId): Boolean
+  def rpcDebugLocateName(threadId: DebugThreadId, name: String): Option[DebugLocation]
   def rpcDebugValue(loc: DebugLocation): Option[DebugValue]
-  def rpcDebugToString(threadId: String, loc: DebugLocation): Option[String]
+  def rpcDebugToString(threadId: DebugThreadId, loc: DebugLocation): Option[String]
   def rpcDebugSetValue(loc: DebugLocation, newValue: String): Boolean
-  def rpcDebugBacktrace(threadId: String, index: Int, count: Int): DebugBacktrace
+  def rpcDebugBacktrace(threadId: DebugThreadId, index: Int, count: Int): DebugBacktrace
   def rpcDebugActiveVM(): Boolean
 }
 

--- a/server/src/main/scala/org/ensime/core/DebugManager.scala
+++ b/server/src/main/scala/org/ensime/core/DebugManager.scala
@@ -21,15 +21,15 @@ case class DebugStartVMReq(commandLine: String) extends RPCRequest
 case class DebugAttachVMReq(hostname: String, port: String) extends RPCRequest
 case object DebugStopVMReq extends RPCRequest
 case object DebugRunReq extends RPCRequest
-case class DebugContinueReq(threadId: String) extends RPCRequest
-case class DebugNextReq(threadId: String) extends RPCRequest
-case class DebugStepReq(threadId: String) extends RPCRequest
-case class DebugStepOutReq(threadId: String) extends RPCRequest
-case class DebugLocateNameReq(threadId: String, name: String) extends RPCRequest
+case class DebugContinueReq(threadId: DebugThreadId) extends RPCRequest
+case class DebugNextReq(threadId: DebugThreadId) extends RPCRequest
+case class DebugStepReq(threadId: DebugThreadId) extends RPCRequest
+case class DebugStepOutReq(threadId: DebugThreadId) extends RPCRequest
+case class DebugLocateNameReq(threadId: DebugThreadId, name: String) extends RPCRequest
 case class DebugValueReq(loc: DebugLocation) extends RPCRequest
-case class DebugToStringReq(threadId: String, loc: DebugLocation) extends RPCRequest
+case class DebugToStringReq(threadId: DebugThreadId, loc: DebugLocation) extends RPCRequest
 case class DebugSetValueReq(loc: DebugLocation, newValue: String) extends RPCRequest
-case class DebugBacktraceReq(threadId: String, index: Int, count: Int) extends RPCRequest
+case class DebugBacktraceReq(threadId: DebugThreadId, index: Int, count: Int) extends RPCRequest
 case object DebugActiveVMReq extends RPCRequest
 case class DebugSetBreakpointReq(file: String, line: Int) extends RPCRequest
 case class DebugClearBreakpointReq(file: String, line: Int) extends RPCRequest
@@ -188,7 +188,7 @@ class DebugManager(
     }
   }
 
-  private def handleRPCWithVMAndThread(threadId: String)(action: ((VM, ThreadReference) => Unit)) = {
+  private def handleRPCWithVMAndThread(threadId: DebugThreadId)(action: ((VM, ThreadReference) => Unit)) = {
     withVM { vm =>
       (for (thread <- vm.threadById(threadId)) yield {
         action(vm, thread)
@@ -237,13 +237,13 @@ class DebugManager(
           case e: VMDisconnectEvent => disconnectDebugVM()
           case e: StepEvent =>
             (for (pos <- locToPos(e.location())) yield {
-              project ! AsyncEvent(DebugStepEvent(e.thread().uniqueID().toString, e.thread().name, pos.file, pos.line))
+              project ! AsyncEvent(DebugStepEvent(DebugThreadId(e.thread().uniqueID()), e.thread().name, pos.file, pos.line))
             }) getOrElse {
               log.warning("Step position not found: " + e.location().sourceName() + " : " + e.location().lineNumber())
             }
           case e: BreakpointEvent =>
             (for (pos <- locToPos(e.location())) yield {
-              project ! AsyncEvent(DebugBreakEvent(e.thread().uniqueID().toString, e.thread().name, pos.file, pos.line))
+              project ! AsyncEvent(DebugBreakEvent(DebugThreadId(e.thread().uniqueID()), e.thread().name, pos.file, pos.line))
             }) getOrElse {
               log.warning("Break position not found: " + e.location().sourceName() + " : " + e.location().lineNumber())
             }
@@ -351,7 +351,7 @@ class DebugManager(
               val breaks = BreakpointList(activeBreakpoints.toList, pendingBreakpoints)
               sender ! breaks
 
-            case DebugNextReq(threadId: String) =>
+            case DebugNextReq(threadId: DebugThreadId) =>
               handleRPCWithVMAndThread(threadId) {
                 (vm, thread) =>
                   vm.newStepRequest(thread,
@@ -360,7 +360,7 @@ class DebugManager(
                   sender ! true
               }
 
-            case DebugStepReq(threadId: String) =>
+            case DebugStepReq(threadId: DebugThreadId) =>
               handleRPCWithVMAndThread(threadId) {
                 (vm, thread) =>
                   vm.newStepRequest(thread,
@@ -369,7 +369,7 @@ class DebugManager(
                   sender ! true
               }
 
-            case DebugStepOutReq(threadId: String) =>
+            case DebugStepOutReq(threadId: DebugThreadId) =>
               handleRPCWithVMAndThread(threadId) {
                 (vm, thread) =>
                   vm.newStepRequest(thread,
@@ -378,12 +378,12 @@ class DebugManager(
                   sender ! true
               }
 
-            case DebugLocateNameReq(threadId: String, name: String) =>
+            case DebugLocateNameReq(threadId: DebugThreadId, name: String) =>
               handleRPCWithVMAndThread(threadId) {
                 (vm, thread) =>
                   sender ! vm.locationForName(thread, name)
               }
-            case DebugBacktraceReq(threadId: String, index: Int, count: Int) =>
+            case DebugBacktraceReq(threadId: DebugThreadId, index: Int, count: Int) =>
               handleRPCWithVMAndThread(threadId) { (vm, thread) =>
                 val bt = vm.backtrace(thread, index, count)
                 sender ! bt
@@ -627,8 +627,8 @@ class DebugManager(
       buf.map(_.loc).toSet
     }
 
-    def threadById(id: String): Option[ThreadReference] = {
-      vm.allThreads().find(t => t.uniqueID.toString == id)
+    def threadById(id: DebugThreadId): Option[ThreadReference] = {
+      vm.allThreads().find(t => t.uniqueID == id.id)
     }
 
     // Helper as Value.toString doesn't give
@@ -758,7 +758,7 @@ class DebugManager(
         Some(DebugObjectReference(remember(objRef).uniqueID))
       } else {
         stackSlotForName(thread, name).map({ slot =>
-          DebugStackSlot(thread.uniqueID.toString, slot._1, slot._2)
+          DebugStackSlot(DebugThreadId(thread.uniqueID), slot._1, slot._2)
         }).orElse(
           fieldByName(objRef, name).flatMap { f =>
             Some(DebugObjectField(objRef.uniqueID, f.name))
@@ -805,7 +805,7 @@ class DebugManager(
       }
     }
 
-    def debugValueAtLocationToString(threadId: String, location: DebugLocation): Option[String] = {
+    def debugValueAtLocationToString(threadId: DebugThreadId, location: DebugLocation): Option[String] = {
       valueAtLocation(location) match {
         case Some(arr: ArrayReference) =>
           val quantifier = if (arr.length == 1) "element" else "elements" // TODO: replace with something less naive

--- a/server/src/main/scala/org/ensime/core/EnsimeEvent.scala
+++ b/server/src/main/scala/org/ensime/core/EnsimeEvent.scala
@@ -2,6 +2,7 @@ package org.ensime.core
 
 import java.io.File
 
+import org.ensime.model.DebugThreadId$
 import org.ensime.util.Note
 
 /** Asynchronous swank protocol event */
@@ -34,14 +35,14 @@ case class NewScalaNotesEvent(
 
 /** The debugged VM has stepped to a new location and is now paused awaiting control. */
 case class DebugStepEvent(
-  threadId: String,
+  threadId: DebugThreadId,
   threadName: String,
   file: File,
   line: Int) extends DebugEvent
 
 /** The debugged VM has stopped at a breakpoint. */
 case class DebugBreakEvent(
-  threadId: String,
+  threadId: DebugThreadId,
   threadName: String,
   file: File,
   line: Int) extends DebugEvent

--- a/server/src/main/scala/org/ensime/core/EnsimeEvent.scala
+++ b/server/src/main/scala/org/ensime/core/EnsimeEvent.scala
@@ -2,7 +2,7 @@ package org.ensime.core
 
 import java.io.File
 
-import org.ensime.model.DebugThreadId$
+import org.ensime.model.DebugThreadId
 import org.ensime.util.Note
 
 /** Asynchronous swank protocol event */

--- a/server/src/main/scala/org/ensime/core/Project.scala
+++ b/server/src/main/scala/org/ensime/core/Project.scala
@@ -58,8 +58,6 @@ case class SymbolByNameReq(typeFullName: String, memberName: Option[String], sig
 
 case class SubscribeAsync(handler: EnsimeEvent => Unit) extends RPCRequest
 
-case object ClientReadyEvent
-
 class Project(
     val config: EnsimeConfig,
     actorSystem: ActorSystem) extends ProjectEnsimeApiImpl {
@@ -151,7 +149,6 @@ class Project(
     }
 
     private val waiting: Receive = {
-      case ClientReadyEvent =>
       case SubscribeAsync(handler) =>
         asyncListeners ::= handler
         asyncEvents.foreach { event => handler(event) }
@@ -168,11 +165,8 @@ class Project(
     undos(undoCounter) = Undo(undoCounter, sum, changes.toList)
   }
 
-  protected def peekUndo(): Either[String, Undo] = {
-    undos.lastOption match {
-      case Some(u) => Right(u._2)
-      case _ => Left("No such undo.")
-    }
+  protected def peekUndo(): Option[Undo] = {
+    undos.lastOption.map(_._2)
   }
 
   protected def execUndo(undoId: Int): Either[String, UndoResult] = {

--- a/server/src/main/scala/org/ensime/core/ProjectEnsimeApiImpl.scala
+++ b/server/src/main/scala/org/ensime/core/ProjectEnsimeApiImpl.scala
@@ -50,15 +50,11 @@ trait ProjectEnsimeApiImpl extends EnsimeApi { self: Project =>
     shutdownServer()
   }
 
-  override def rpcNotifyClientReady(): Unit = {
-    actor ! ClientReadyEvent
-  }
-
   override def rpcSubscribeAsync(handler: EnsimeEvent => Unit): Boolean = {
     callRPC[Boolean](actor, SubscribeAsync(handler))
   }
 
-  override def rpcPeekUndo(): Either[String, Undo] = {
+  override def rpcPeekUndo(): Option[Undo] = {
     peekUndo()
   }
 
@@ -92,7 +88,7 @@ trait ProjectEnsimeApiImpl extends EnsimeApi { self: Project =>
     callRPC[Boolean](acquireDebugger, DebugRunReq)
   }
 
-  override def rpcDebugContinue(threadId: String): Boolean = {
+  override def rpcDebugContinue(threadId: DebugThreadId): Boolean = {
     callRPC[Boolean](acquireDebugger, DebugContinueReq(threadId))
   }
 
@@ -112,19 +108,19 @@ trait ProjectEnsimeApiImpl extends EnsimeApi { self: Project =>
     callRPC[BreakpointList](acquireDebugger, DebugListBreakpointsReq)
   }
 
-  override def rpcDebugNext(threadId: String): Boolean = {
+  override def rpcDebugNext(threadId: DebugThreadId): Boolean = {
     callRPC[Boolean](acquireDebugger, DebugNextReq(threadId))
   }
 
-  override def rpcDebugStep(threadId: String): Boolean = {
+  override def rpcDebugStep(threadId: DebugThreadId): Boolean = {
     callRPC[Boolean](acquireDebugger, DebugStepReq(threadId))
   }
 
-  override def rpcDebugStepOut(threadId: String): Boolean = {
+  override def rpcDebugStepOut(threadId: DebugThreadId): Boolean = {
     callRPC[Boolean](acquireDebugger, DebugStepOutReq(threadId))
   }
 
-  override def rpcDebugLocateName(threadId: String, name: String): Option[DebugLocation] = {
+  override def rpcDebugLocateName(threadId: DebugThreadId, name: String): Option[DebugLocation] = {
     callRPC[Option[DebugLocation]](acquireDebugger, DebugLocateNameReq(threadId, name))
   }
 
@@ -132,7 +128,7 @@ trait ProjectEnsimeApiImpl extends EnsimeApi { self: Project =>
     callRPC[Option[DebugValue]](acquireDebugger, DebugValueReq(loc))
   }
 
-  override def rpcDebugToString(threadId: String, loc: DebugLocation): Option[String] = {
+  override def rpcDebugToString(threadId: DebugThreadId, loc: DebugLocation): Option[String] = {
     callRPC[Option[String]](acquireDebugger, DebugToStringReq(threadId, loc))
   }
 
@@ -140,7 +136,7 @@ trait ProjectEnsimeApiImpl extends EnsimeApi { self: Project =>
     callRPC[Boolean](acquireDebugger, DebugSetValueReq(loc, newValue))
   }
 
-  override def rpcDebugBacktrace(threadId: String, index: Int, count: Int): DebugBacktrace = {
+  override def rpcDebugBacktrace(threadId: DebugThreadId, index: Int, count: Int): DebugBacktrace = {
     callRPC[DebugBacktrace](acquireDebugger, DebugBacktraceReq(threadId, index, count))
   }
 

--- a/server/src/main/scala/org/ensime/server/protocol/swank/SwankProtocol.scala
+++ b/server/src/main/scala/org/ensime/server/protocol/swank/SwankProtocol.scala
@@ -1847,14 +1847,14 @@ object SwankProtocol {
             StringAtom(id) <- m.get(key(":object-id"));
             StringAtom(field) <- m.get(key(":field"))
           ) yield {
-            DebugObjectField(id.toLong, field)
+            DebugObjectField(DebugObjectId(id.toLong), field)
           }
         case SymbolAtom("element") =>
           for (
             StringAtom(id) <- m.get(key(":object-id"));
             IntAtom(index) <- m.get(key(":index"))
           ) yield {
-            DebugArrayElement(id.toLong, index)
+            DebugArrayElement(DebugObjectId(id.toLong), index)
           }
         case SymbolAtom("slot") =>
           for (

--- a/server/src/main/scala/org/ensime/server/protocol/swank/SwankProtocolConversions.scala
+++ b/server/src/main/scala/org/ensime/server/protocol/swank/SwankProtocolConversions.scala
@@ -108,9 +108,14 @@ object SwankProtocolConversions {
   implicit val DebugVMStartEventFormat = singletonFormat[DebugVMStartEvent.type]
   implicit val DebugVMDisconnectEventFormat = singletonFormat[DebugVMDisconnectEvent.type]
 
-  implicit val ThreadIdFormat: SexpFormat[DebugThreadId] = viaString(new ViaString[DebugThreadId] {
+  implicit val DebugThreadIdFormat: SexpFormat[DebugThreadId] = viaString(new ViaString[DebugThreadId] {
     def toSexpString(uuid: DebugThreadId) = uuid.id.toString
     def fromSexpString(s: String) = DebugThreadId(s)
+  })
+
+  implicit val DebugObjectIdFormat: SexpFormat[DebugObjectId] = viaString(new ViaString[DebugObjectId] {
+    def toSexpString(uuid: DebugObjectId) = uuid.id.toString
+    def fromSexpString(s: String) = DebugObjectId(s)
   })
 
   /**

--- a/server/src/main/scala/org/ensime/server/protocol/swank/SwankProtocolConversions.scala
+++ b/server/src/main/scala/org/ensime/server/protocol/swank/SwankProtocolConversions.scala
@@ -108,6 +108,11 @@ object SwankProtocolConversions {
   implicit val DebugVMStartEventFormat = singletonFormat[DebugVMStartEvent.type]
   implicit val DebugVMDisconnectEventFormat = singletonFormat[DebugVMDisconnectEvent.type]
 
+  implicit val ThreadIdFormat: SexpFormat[DebugThreadId] = viaString(new ViaString[DebugThreadId] {
+    def toSexpString(uuid: DebugThreadId) = uuid.id.toString
+    def fromSexpString(s: String) = DebugThreadId(s)
+  })
+
   /**
    * These implicit vals are actually optional - S-Express doesn't
    * *need* them - and exist only to help the compiler to resolve

--- a/server/src/test/scala/org/ensime/server/protocol/swank/SwankProtocolConversionsSpec.scala
+++ b/server/src/test/scala/org/ensime/server/protocol/swank/SwankProtocolConversionsSpec.scala
@@ -48,11 +48,11 @@ class SwankProtocolConversionsSpec extends FunSpec with Matchers {
 
         // toWF(obj: DebugLocation)
         assert(toWF(DebugObjectReference(57L).asInstanceOf[DebugLocation]).toWireString ===
-          """(:type reference :object-id 57)""")
-        assert(toWF(DebugArrayElement(58L, 2).asInstanceOf[DebugLocation]).toWireString ===
-          """(:type element :object-id 58 :index 2)""")
-        assert(toWF(DebugObjectField(58L, "fieldName").asInstanceOf[DebugLocation]).toWireString ===
-          """(:type field :object-id 58 :field "fieldName")""")
+          """(:type reference :object-id "57")""")
+        assert(toWF(DebugArrayElement(DebugObjectId(58L), 2).asInstanceOf[DebugLocation]).toWireString ===
+          """(:type element :object-id "58" :index 2)""")
+        assert(toWF(DebugObjectField(DebugObjectId(58L), "fieldName").asInstanceOf[DebugLocation]).toWireString ===
+          """(:type field :object-id "58" :field "fieldName")""")
         assert(toWF(DebugStackSlot(DebugThreadId(27), 12, 23).asInstanceOf[DebugLocation]).toWireString ===
           """(:type slot :thread-id "27" :frame 12 :offset 23)""")
 
@@ -66,29 +66,29 @@ class SwankProtocolConversionsSpec extends FunSpec with Matchers {
         assert(toWF(debugClassField).toWireString === """(:index 19 :name "nameStr" :type-name "typeNameStr" :summary "summaryStr")""")
 
         // toWF(obj: DebugStringInstance)
-        assert(toWF(DebugStringInstance("summaryStr", List(debugClassField), "typeNameStr", 5L).asInstanceOf[DebugValue]).toWireString ===
-          """(:val-type str :summary "summaryStr" :fields ((:index 19 :name "nameStr" :type-name "typeNameStr" :summary "summaryStr")) :type-name "typeNameStr" :object-id 5)""")
+        assert(toWF(DebugStringInstance("summaryStr", List(debugClassField), "typeNameStr", DebugObjectId(5L)).asInstanceOf[DebugValue]).toWireString ===
+          """(:val-type str :summary "summaryStr" :fields ((:index 19 :name "nameStr" :type-name "typeNameStr" :summary "summaryStr")) :type-name "typeNameStr" :object-id "5")""")
 
         // toWF(evt: DebugObjectInstance)
-        assert(toWF(DebugObjectInstance("summaryStr", List(debugClassField), "typeNameStr", 5L).asInstanceOf[DebugValue]).toWireString ===
-          """(:val-type obj :summary "summaryStr" :fields ((:index 19 :name "nameStr" :type-name "typeNameStr" :summary "summaryStr")) :type-name "typeNameStr" :object-id 5)""")
+        assert(toWF(DebugObjectInstance("summaryStr", List(debugClassField), "typeNameStr", DebugObjectId(5L)).asInstanceOf[DebugValue]).toWireString ===
+          """(:val-type obj :summary "summaryStr" :fields ((:index 19 :name "nameStr" :type-name "typeNameStr" :summary "summaryStr")) :type-name "typeNameStr" :object-id "5")""")
 
         // toWF(evt: DebugNullValue)
         assert(toWF(DebugNullValue("typeNameStr").asInstanceOf[DebugValue]).toWireString ===
           """(:val-type null :type-name "typeNameStr")""")
 
         // toWF(evt: DebugArrayInstance)
-        assert(toWF(DebugArrayInstance(3, "typeName", "elementType", 5L).asInstanceOf[DebugValue]).toWireString ===
-          """(:val-type arr :length 3 :type-name "typeName" :element-type-name "elementType" :object-id 5)""")
+        assert(toWF(DebugArrayInstance(3, "typeName", "elementType", DebugObjectId(5L)).asInstanceOf[DebugValue]).toWireString ===
+          """(:val-type arr :length 3 :type-name "typeName" :element-type-name "elementType" :object-id "5")""")
 
         // toWF(evt: DebugStackLocal)
         assert(toWF(debugStackLocal1).toWireString === """(:index 3 :name "name1" :summary "summary1" :type-name "type1")""")
 
         // toWF(evt: DebugStackFrame)
-        assert(toWF(debugStackFrame).toWireString === s"""(:index 7 :locals ((:index 3 :name "name1" :summary "summary1" :type-name "type1") (:index 4 :name "name2" :summary "summary2" :type-name "type2")) :num-args 4 :class-name "class1" :method-name "method1" :pc-location (:file $file1_str :line 57) :this-object-id 7)""")
+        assert(toWF(debugStackFrame).toWireString === s"""(:index 7 :locals ((:index 3 :name "name1" :summary "summary1" :type-name "type1") (:index 4 :name "name2" :summary "summary2" :type-name "type2")) :num-args 4 :class-name "class1" :method-name "method1" :pc-location (:file $file1_str :line 57) :this-object-id "7")""")
 
         // toWF(evt: DebugBacktrace)
-        assert(toWF(DebugBacktrace(List(debugStackFrame), "17", "thread1")).toWireString === s"""(:frames ((:index 7 :locals ((:index 3 :name "name1" :summary "summary1" :type-name "type1") (:index 4 :name "name2" :summary "summary2" :type-name "type2")) :num-args 4 :class-name "class1" :method-name "method1" :pc-location (:file $file1_str :line 57) :this-object-id 7)) :thread-id "17" :thread-name "thread1")""")
+        assert(toWF(DebugBacktrace(List(debugStackFrame), "17", "thread1")).toWireString === s"""(:frames ((:index 7 :locals ((:index 3 :name "name1" :summary "summary1" :type-name "type1") (:index 4 :name "name2" :summary "summary2" :type-name "type2")) :num-args 4 :class-name "class1" :method-name "method1" :pc-location (:file $file1_str :line 57) :this-object-id "7")) :thread-id "17" :thread-name "thread1")""")
 
         // toWF(pos: LineSourcePosition)
         assert(toWF(sourcePos1).toWireString === s"""(:file $file1_str :line 57)""")

--- a/server/src/test/scala/org/ensime/server/protocol/swank/SwankProtocolConversionsSpec.scala
+++ b/server/src/test/scala/org/ensime/server/protocol/swank/SwankProtocolConversionsSpec.scala
@@ -30,9 +30,9 @@ class SwankProtocolConversionsSpec extends FunSpec with Matchers {
 
         // toWF(evt: DebugEvent): WireFormat
         assert(toWF(DebugOutputEvent("XXX")).toWireString === """(:debug-event (:type output :body "XXX"))""")
-        assert(toWF(DebugStepEvent("207", "threadNameStr", sourcePos1.file, sourcePos1.line)).toWireString ===
+        assert(toWF(DebugStepEvent(DebugThreadId(207), "threadNameStr", sourcePos1.file, sourcePos1.line)).toWireString ===
           s"""(:debug-event (:type step :thread-id "207" :thread-name "threadNameStr" :file $file1_str :line 57))""")
-        assert(toWF(DebugBreakEvent("209", "threadNameStr", sourcePos1.file, sourcePos1.line)).toWireString ===
+        assert(toWF(DebugBreakEvent(DebugThreadId(209), "threadNameStr", sourcePos1.file, sourcePos1.line)).toWireString ===
           s"""(:debug-event (:type breakpoint :thread-id "209" :thread-name "threadNameStr" :file $file1_str :line 57))""")
         assert(toWF(DebugVMStartEvent).toWireString === """(:debug-event (:type start))""")
         assert(toWF(DebugVMDisconnectEvent).toWireString === """(:debug-event (:type disconnect))""")
@@ -53,7 +53,7 @@ class SwankProtocolConversionsSpec extends FunSpec with Matchers {
           """(:type element :object-id 58 :index 2)""")
         assert(toWF(DebugObjectField(58L, "fieldName").asInstanceOf[DebugLocation]).toWireString ===
           """(:type field :object-id 58 :field "fieldName")""")
-        assert(toWF(DebugStackSlot("27", 12, 23).asInstanceOf[DebugLocation]).toWireString ===
+        assert(toWF(DebugStackSlot(DebugThreadId(27), 12, 23).asInstanceOf[DebugLocation]).toWireString ===
           """(:type slot :thread-id "27" :frame 12 :offset 23)""")
 
         // toWF(obj: DebugValue)
@@ -114,8 +114,8 @@ class SwankProtocolConversionsSpec extends FunSpec with Matchers {
         assert(toWF(new ReplConfig(Set(file1))).toWireString === s"""(:classpath ($file1_str))""")
 
         // toWF(value: Boolean)
-        assert(toWF(true).toWireString === """t""")
-        assert(toWF(false).toWireString === """nil""")
+        assert(toWF(value = true).toWireString === """t""")
+        assert(toWF(value = false).toWireString === """nil""")
 
         // toWF(value: String)
         assert(toWF("ABC").toWireString === """"ABC"""")

--- a/server/src/test/scala/org/ensime/server/protocol/swank/SwankProtocolSpec.scala
+++ b/server/src/test/scala/org/ensime/server/protocol/swank/SwankProtocolSpec.scala
@@ -88,15 +88,15 @@ class SwankProtocolSpec extends FunSpec with ShouldMatchers with BeforeAndAfterA
       val file3_str = fileToWireString(file3)
 
       testWithResponse("""(swank:peek-undo)""") { (t, m, id) =>
-        (t.rpcPeekUndo _).expects().returns(Right(Undo(3, "Undoing stuff", List(TextEdit(file3, 5, 7, "aaa")))))
+        (t.rpcPeekUndo _).expects().returns(Some(Undo(3, "Undoing stuff", List(TextEdit(file3, 5, 7, "aaa")))))
         (m.send _).expects(s"""(:return (:ok (:id 3 :summary "Undoing stuff" :changes ((:type edit :file $file3_str :from 5 :to 7 :text "aaa")))) $id)""")
       }
     }
 
     it("should understand swank:peek-undo - fail") {
       testWithResponse("""(swank:peek-undo)""") { (t, m, id) =>
-        (t.rpcPeekUndo _).expects().returns(Left("ErrorError"))
-        (m.send _).expects(s"""(:return (:abort 206 "ErrorError") $id)""")
+        (t.rpcPeekUndo _).expects().returns(None)
+        (m.send _).expects(s"""(:return (:abort 206 "No such undo.") $id)""")
       }
     }
 
@@ -588,35 +588,35 @@ class SwankProtocolSpec extends FunSpec with ShouldMatchers with BeforeAndAfterA
 
     it("should understand swank:debug-continue") {
       testWithResponse("""(swank:debug-continue "1")""") { (t, m, id) =>
-        (t.rpcDebugContinue _).expects("1").returns(true)
+        (t.rpcDebugContinue _).expects(DebugThreadId(1)).returns(true)
         (m.send _).expects(s"""(:return (:ok t) $id)""")
       }
     }
 
     it("should understand swank:debug-step") {
       testWithResponse("""(swank:debug-step "982398123")""") { (t, m, id) =>
-        (t.rpcDebugStep _).expects("982398123").returns(true)
+        (t.rpcDebugStep _).expects(DebugThreadId(982398123)).returns(true)
         (m.send _).expects(s"""(:return (:ok t) $id)""")
       }
     }
 
     it("should understand swank:debug-next") {
       testWithResponse("""(swank:debug-next "982398123")""") { (t, m, id) =>
-        (t.rpcDebugNext _).expects("982398123").returns(true)
+        (t.rpcDebugNext _).expects(DebugThreadId(982398123)).returns(true)
         (m.send _).expects(s"""(:return (:ok t) $id)""")
       }
     }
 
     it("should understand swank:debug-step-out") {
       testWithResponse("""(swank:debug-step-out "982398123")""") { (t, m, id) =>
-        (t.rpcDebugStepOut _).expects("982398123").returns(true)
+        (t.rpcDebugStepOut _).expects(DebugThreadId(982398123)).returns(true)
         (m.send _).expects(s"""(:return (:ok t) $id)""")
       }
     }
 
     it("should understand swank:debug-locate-name") {
       testWithResponse("""(swank:debug-locate-name "7" "apple")""") { (t, m, id) =>
-        (t.rpcDebugLocateName _).expects("7", "apple").returns(Some(debugLocObjectRef))
+        (t.rpcDebugLocateName _).expects(DebugThreadId(7), "apple").returns(Some(debugLocObjectRef))
         (m.send _).expects("(:return (:ok " + debugLocObjectRefStr + ") " + id + ")")
       }
     }
@@ -644,14 +644,14 @@ class SwankProtocolSpec extends FunSpec with ShouldMatchers with BeforeAndAfterA
 
     it("should understand swank:debug-value - stack slot") {
       testWithResponse("""(swank:debug-value (:type slot :thread-id "23" :frame 7 :offset 25))""") { (t, m, id) =>
-        (t.rpcDebugValue _).expects(DebugStackSlot("23", 7, 25)).returns(Some(debugStringValue))
+        (t.rpcDebugValue _).expects(DebugStackSlot(DebugThreadId(23), 7, 25)).returns(Some(debugStringValue))
         (m.send _).expects("(:return (:ok " + debugStringValueStr + ") " + id + ")")
       }
     }
 
     it("should understand swank:debug-to-string - array element") {
       testWithResponse("""(swank:debug-to-string "2" (:type element :object-id "23" :index 2))""") { (t, m, id) =>
-        (t.rpcDebugToString _).expects("2", DebugArrayElement(23L, 2)).returns(Some("null"))
+        (t.rpcDebugToString _).expects(DebugThreadId(2), DebugArrayElement(23L, 2)).returns(Some("null"))
         (m.send _).expects("(:return (:ok \"null\") " + id + ")")
       }
     }
@@ -665,7 +665,7 @@ class SwankProtocolSpec extends FunSpec with ShouldMatchers with BeforeAndAfterA
 
     it("should understand swank:debug-backtrace") {
       testWithResponse("""(swank:debug-backtrace "23" 0 2)""") { (t, m, id) =>
-        (t.rpcDebugBacktrace _).expects("23", 0, 2).returns(debugBacktrace)
+        (t.rpcDebugBacktrace _).expects(DebugThreadId(23), 0, 2).returns(debugBacktrace)
         (m.send _).expects("(:return (:ok " + debugBacktraceStr + ") " + id + ")")
       }
     }

--- a/server/src/test/scala/org/ensime/server/protocol/swank/SwankProtocolSpec.scala
+++ b/server/src/test/scala/org/ensime/server/protocol/swank/SwankProtocolSpec.scala
@@ -623,7 +623,7 @@ class SwankProtocolSpec extends FunSpec with ShouldMatchers with BeforeAndAfterA
 
     it("should understand swank:debug-value - array") {
       testWithResponse("""(swank:debug-value (:type element :object-id "23" :index 2))""") { (t, m, id) =>
-        (t.rpcDebugValue _).expects(DebugArrayElement(23L, 2)).returns(Some(debugNullValue))
+        (t.rpcDebugValue _).expects(DebugArrayElement(DebugObjectId(23L), 2)).returns(Some(debugNullValue))
         (m.send _).expects("(:return (:ok " + debugNullValueStr + ") " + id + ")")
       }
     }
@@ -637,7 +637,7 @@ class SwankProtocolSpec extends FunSpec with ShouldMatchers with BeforeAndAfterA
 
     it("should understand swank:debug-value - object field") {
       testWithResponse("""(swank:debug-value (:type field :object-id "23" :field "fred"))""") { (t, m, id) =>
-        (t.rpcDebugValue _).expects(DebugObjectField(23L, "fred")).returns(Some(debugPrimitiveValue))
+        (t.rpcDebugValue _).expects(DebugObjectField(DebugObjectId(23L), "fred")).returns(Some(debugPrimitiveValue))
         (m.send _).expects("(:return (:ok " + debugPrimitiveValueStr + ") " + id + ")")
       }
     }
@@ -651,14 +651,14 @@ class SwankProtocolSpec extends FunSpec with ShouldMatchers with BeforeAndAfterA
 
     it("should understand swank:debug-to-string - array element") {
       testWithResponse("""(swank:debug-to-string "2" (:type element :object-id "23" :index 2))""") { (t, m, id) =>
-        (t.rpcDebugToString _).expects(DebugThreadId(2), DebugArrayElement(23L, 2)).returns(Some("null"))
+        (t.rpcDebugToString _).expects(DebugThreadId(2), DebugArrayElement(DebugObjectId(23L), 2)).returns(Some("null"))
         (m.send _).expects("(:return (:ok \"null\") " + id + ")")
       }
     }
 
     it("should understand swank:debug-set-value - array element") {
       testWithResponse("""(swank:debug-set-value (:type element :object-id "23" :index 2) "1")""") { (t, m, id) =>
-        (t.rpcDebugSetValue _).expects(DebugArrayElement(23L, 2), "1").returns(true)
+        (t.rpcDebugSetValue _).expects(DebugArrayElement(DebugObjectId(23L), 2), "1").returns(true)
         (m.send _).expects("(:return (:ok t) " + id + ")")
       }
     }

--- a/server/src/test/scala/org/ensime/server/protocol/swank/SwankTestData.scala
+++ b/server/src/test/scala/org/ensime/server/protocol/swank/SwankTestData.scala
@@ -85,10 +85,10 @@ object SwankTestData {
   val debugStackLocal1 = DebugStackLocal(3, "name1", "summary1", "type1")
   val debugStackLocal2 = DebugStackLocal(4, "name2", "summary2", "type2")
 
-  val debugStackFrame = DebugStackFrame(7, List(debugStackLocal1, debugStackLocal2), 4, "class1", "method1", sourcePos1, 7)
+  val debugStackFrame = DebugStackFrame(7, List(debugStackLocal1, debugStackLocal2), 4, "class1", "method1", sourcePos1, DebugObjectId(7))
 
   val debugBacktrace = DebugBacktrace(List(debugStackFrame), "17", "thread1")
-  val debugBacktraceStr = s"""(:frames ((:index 7 :locals ((:index 3 :name "name1" :summary "summary1" :type-name "type1") (:index 4 :name "name2" :summary "summary2" :type-name "type2")) :num-args 4 :class-name "class1" :method-name "method1" :pc-location (:file $file1_str :line 57) :this-object-id 7)) :thread-id "17" :thread-name "thread1")"""
+  val debugBacktraceStr = s"""(:frames ((:index 7 :locals ((:index 3 :name "name1" :summary "summary1" :type-name "type1") (:index 4 :name "name2" :summary "summary2" :type-name "type2")) :num-args 4 :class-name "class1" :method-name "method1" :pc-location (:file $file1_str :line 57) :this-object-id "7")) :thread-id "17" :thread-name "thread1")"""
 
   val undoResult = UndoResult(7, List(file3, file4))
   val undoResultStr = """(:id 7 :touched-files (""" + file3_str + """ """ + file4_str + """))"""
@@ -121,13 +121,13 @@ object SwankTestData {
   val fileRangeStr = """(:file "/abc" :start 7 :end 9)"""
 
   val debugLocObjectRef: DebugLocation = DebugObjectReference(57L)
-  val debugLocObjectRefStr = """(:type reference :object-id 57)"""
+  val debugLocObjectRefStr = """(:type reference :object-id "57")"""
 
   val debugNullValue = DebugNullValue("typeNameStr")
   val debugNullValueStr = """(:val-type null :type-name "typeNameStr")"""
 
-  val debugArrayInstValue = DebugArrayInstance(3, "typeName", "elementType", 5L)
-  val debugArrayInstValueStr = """(:val-type arr :length 3 :type-name "typeName" :element-type-name "elementType" :object-id 5)"""
+  val debugArrayInstValue = DebugArrayInstance(3, "typeName", "elementType", DebugObjectId(5L))
+  val debugArrayInstValueStr = """(:val-type arr :length 3 :type-name "typeName" :element-type-name "elementType" :object-id "5")"""
 
   val debugPrimitiveValue = DebugPrimitiveValue("summaryStr", "typeNameStr")
   val debugPrimitiveValueStr = """(:val-type prim :summary "summaryStr" :type-name "typeNameStr")"""
@@ -135,8 +135,8 @@ object SwankTestData {
   val debugClassField = DebugClassField(19, "nameStr", "typeNameStr", "summaryStr")
   val debugClassFieldStr = """(:index 19 :name "nameStr" :type-name "typeNameStr" :summary "summaryStr")"""
 
-  val debugStringValue = DebugStringInstance("summaryStr", List(debugClassField), "typeNameStr", 5L)
-  val debugStringValueStr = s"""(:val-type str :summary "summaryStr" :fields ($debugClassFieldStr) :type-name "typeNameStr" :object-id 5)"""
+  val debugStringValue = DebugStringInstance("summaryStr", List(debugClassField), "typeNameStr", DebugObjectId(6L))
+  val debugStringValueStr = s"""(:val-type str :summary "summaryStr" :fields ($debugClassFieldStr) :type-name "typeNameStr" :object-id "6")"""
 
   val note1 = new Note("file1", "note1", NoteError, 23, 33, 19, 8)
   val note1Str = """(:file "file1" :msg "note1" :severity error :beg 23 :end 33 :line 19 :col 8)"""

--- a/sexpress/src/test/scala/org/ensime/sexp/SexpSpec.scala
+++ b/sexpress/src/test/scala/org/ensime/sexp/SexpSpec.scala
@@ -29,14 +29,14 @@ class SexpSpec extends FunSpec with Matchers {
     it("should match lists") {
       SexpCons(foosym, SexpNil) match {
         case SexpList(els) if els == List(foosym) =>
-        case _ => fail
+        case _ => fail()
       }
       SexpCons(foosym, SexpCons(barsym, SexpNil)) match {
         case SexpList(els) if els == List(foosym, barsym) =>
-        case _ => fail
+        case _ => fail()
       }
       SexpNil match {
-        case SexpList(_) => fail
+        case SexpList(_) => fail()
         case _ =>
       }
     }
@@ -71,11 +71,11 @@ class SexpSpec extends FunSpec with Matchers {
             barkey, SexpCons(
               foosym, SexpNil)))) match {
           case SexpData(kvs) if kvs.size == 2 =>
-          case _ => fail
+          case _ => fail()
         }
 
       SexpNil match {
-        case SexpData(_) => fail
+        case SexpData(_) => fail()
         case _ =>
       }
     }


### PR DESCRIPTION
Two changes for the price of one:

1. Move from ints encoded as strings for debug threadIds (its been a bugbear of mine for a while).
2. Finish the work to have a startup future (needed for the ensime as API changes.

Part of (2) included moving the message backlog and replay logic out of the Project class into the protocol layer for clarity.

Also moved rpcPeekUndo() to be option rather then Either where the error case was a protocol string.