### PR TITLE
Add symbol-by-name call. 

### DIFF
--- a/api/src/main/scala/org/ensime/model/Model.scala
+++ b/api/src/main/scala/org/ensime/model/Model.scala
@@ -227,6 +227,7 @@ case class NamedTypeMemberInfo(
     name: String,
     `type`: TypeInfo,
     pos: Option[SourcePosition],
+    signatureString: Option[String],
     declAs: scala.Symbol) extends EntityInfo {
   override def members = List.empty
   def tpe = `type`

--- a/server/src/main/scala/org/ensime/EnsimeApi.scala
+++ b/server/src/main/scala/org/ensime/EnsimeApi.scala
@@ -73,16 +73,22 @@ trait EnsimeApi {
 
   def rpcSymbolAtPoint(fileName: String, point: Int): Option[SymbolInfo]
 
-  def rpcMemberByName(typeFullName: String, memberName: String, memberIsType: Boolean): Option[SymbolInfo]
+  /**
+   * Lookup a detailed symbol description.
+   * @param fullyQualifiedName The fully qualified name of a type, object or package.
+   * @param memberName The short name of a member symbol of the qualified symbol.
+   * @return signatureString An optional signature to disambiguate overloaded methods.
+   */
+  def rpcSymbolByName(fullyQualifiedName: String, memberName: Option[String], signatureString: Option[String]): Option[SymbolInfo]
   def rpcTypeById(id: Int): Option[TypeInfo]
   def rpcTypeByName(name: String): Option[TypeInfo]
   def rpcTypeByNameAtPoint(name: String, f: String, range: OffsetRange): Option[TypeInfo]
   def rpcCallCompletion(id: Int): Option[CallCompletionInfo]
   def rpcImportSuggestions(f: String, point: Int, names: List[String], maxResults: Int): ImportSuggestions
   def rpcDocSignatureAtPoint(f: String, point: OffsetRange): Option[DocSigPair]
-  def rpcDocSignatureForSymbol(typeFullName: String, memberName: Option[String], memberTypeId: Option[Int]): Option[DocSigPair]
+  def rpcDocSignatureForSymbol(typeFullName: String, memberName: Option[String], signatureString: Option[String]): Option[DocSigPair]
   def rpcDocUriAtPoint(f: String, point: OffsetRange): Option[String]
-  def rpcDocUriForSymbol(typeFullName: String, memberName: Option[String], memberTypeId: Option[Int]): Option[String]
+  def rpcDocUriForSymbol(typeFullName: String, memberName: Option[String], signatureString: Option[String]): Option[String]
   def rpcPublicSymbolSearch(names: List[String], maxResults: Int): SymbolSearchResults
   def rpcUsesOfSymAtPoint(f: String, point: Int): List[ERangePosition]
   def rpcTypeAtPoint(f: String, range: OffsetRange): Option[TypeInfo]

--- a/server/src/main/scala/org/ensime/core/Analyzer.scala
+++ b/server/src/main/scala/org/ensime/core/Analyzer.scala
@@ -202,11 +202,13 @@ class Analyzer(
               case SymbolAtPointReq(file: File, point: Int) =>
                 val p = pos(file, point)
                 sender ! scalaCompiler.askSymbolInfoAt(p)
+              case SymbolByNameReq(typeFullName: String, memberName: Option[String], signatureString: Option[String]) =>
+                sender ! scalaCompiler.askSymbolByName(typeFullName, memberName, signatureString)
               case DocSignatureAtPointReq(file: File, range: OffsetRange) =>
                 val p = pos(file, range)
                 sender ! scalaCompiler.askDocSignatureAtPoint(p)
-              case DocSignatureForSymbolReq(typeFullName: String, memberName: Option[String], memberTypeId: Option[Int]) =>
-                sender ! scalaCompiler.askDocSignatureForSymbol(typeFullName, memberName, memberTypeId)
+              case DocSignatureForSymbolReq(typeFullName: String, memberName: Option[String], signatureString: Option[String]) =>
+                sender ! scalaCompiler.askDocSignatureForSymbol(typeFullName, memberName, signatureString)
               case InspectPackageByPathReq(path: String) =>
                 sender ! scalaCompiler.askPackageByPath(path)
               case TypeAtPointReq(file: File, range: OffsetRange) =>
@@ -214,8 +216,6 @@ class Analyzer(
                 sender ! scalaCompiler.askTypeInfoAt(p)
               case TypeByIdReq(id: Int) =>
                 sender ! scalaCompiler.askTypeInfoById(id)
-              case MemberByNameReq(typeName: String, memberName: String, memberIsType: Boolean) =>
-                sender ! scalaCompiler.askMemberInfoByName(typeName, memberName, memberIsType)
               case TypeByNameReq(name: String) =>
                 sender ! scalaCompiler.askTypeInfoByName(name)
               case TypeByNameAtPointReq(name: String, file: File, range: OffsetRange) =>

--- a/server/src/main/scala/org/ensime/core/Project.scala
+++ b/server/src/main/scala/org/ensime/core/Project.scala
@@ -42,7 +42,6 @@ case class InspectTypeByIdReq(id: Int) extends RPCRequest
 case class InspectTypeByNameReq(name: String) extends RPCRequest
 case class InspectPackageByPathReq(path: String) extends RPCRequest
 case class TypeByIdReq(id: Int) extends RPCRequest
-case class MemberByNameReq(typeFullName: String, memberName: String, memberIsType: Boolean) extends RPCRequest
 case class TypeByNameReq(name: String) extends RPCRequest
 case class TypeByNameAtPointReq(name: String, file: File, range: OffsetRange) extends RPCRequest
 case class CallCompletionReq(id: Int) extends RPCRequest
@@ -54,7 +53,8 @@ case class FormatFileReq(fileInfo: SourceFileInfo) extends RPCRequest
 case class ExpandSelectionReq(filename: String, start: Int, stop: Int) extends RPCRequest
 case class DocUriReq(sig: DocSigPair) extends RPCRequest
 case class DocSignatureAtPointReq(file: File, range: OffsetRange) extends RPCRequest
-case class DocSignatureForSymbolReq(typeFullName: String, memberName: Option[String], memberTypeId: Option[Int]) extends RPCRequest
+case class DocSignatureForSymbolReq(typeFullName: String, memberName: Option[String], signatureString: Option[String]) extends RPCRequest
+case class SymbolByNameReq(typeFullName: String, memberName: Option[String], signatureString: Option[String]) extends RPCRequest
 
 case class SubscribeAsync(handler: EnsimeEvent => Unit) extends RPCRequest
 

--- a/server/src/main/scala/org/ensime/core/ProjectEnsimeApiImpl.scala
+++ b/server/src/main/scala/org/ensime/core/ProjectEnsimeApiImpl.scala
@@ -196,10 +196,6 @@ trait ProjectEnsimeApiImpl extends EnsimeApi { self: Project =>
     callRPC[Option[SymbolInfo]](getAnalyzer, SymbolAtPointReq(new File(fileName), point))
   }
 
-  override def rpcMemberByName(typeFullName: String, memberName: String, memberIsType: Boolean): Option[SymbolInfo] = {
-    callRPC[Option[SymbolInfo]](getAnalyzer, MemberByNameReq(typeFullName, memberName, memberIsType))
-  }
-
   override def rpcTypeById(typeId: Int): Option[TypeInfo] = {
     callRPC[Option[TypeInfo]](getAnalyzer, TypeByIdReq(typeId))
   }
@@ -224,16 +220,20 @@ trait ProjectEnsimeApiImpl extends EnsimeApi { self: Project =>
     callRPC[Option[DocSigPair]](getAnalyzer, DocSignatureAtPointReq(new File(f), range))
   }
 
-  override def rpcDocSignatureForSymbol(typeFullName: String, memberName: Option[String], memberTypeId: Option[Int]): Option[DocSigPair] = {
-    callRPC[Option[DocSigPair]](getAnalyzer, DocSignatureForSymbolReq(typeFullName, memberName, memberTypeId))
+  override def rpcDocSignatureForSymbol(typeFullName: String, memberName: Option[String], signatureString: Option[String]): Option[DocSigPair] = {
+    callRPC[Option[DocSigPair]](getAnalyzer, DocSignatureForSymbolReq(typeFullName, memberName, signatureString))
+  }
+
+  override def rpcSymbolByName(typeFullName: String, memberName: Option[String], signatureString: Option[String]): Option[SymbolInfo] = {
+    callRPC[Option[SymbolInfo]](getAnalyzer, SymbolByNameReq(typeFullName, memberName, signatureString))
   }
 
   override def rpcDocUriAtPoint(f: String, range: OffsetRange): Option[String] = {
     rpcDocSignatureAtPoint(f, range).flatMap { sig => callRPC[Option[String]](docServer, DocUriReq(sig)) }
   }
 
-  override def rpcDocUriForSymbol(typeFullName: String, memberName: Option[String], memberTypeId: Option[Int]): Option[String] = {
-    rpcDocSignatureForSymbol(typeFullName, memberName, memberTypeId).flatMap { sig => callRPC[Option[String]](docServer, DocUriReq(sig)) }
+  override def rpcDocUriForSymbol(typeFullName: String, memberName: Option[String], signatureString: Option[String]): Option[String] = {
+    rpcDocSignatureForSymbol(typeFullName, memberName, signatureString).flatMap { sig => callRPC[Option[String]](docServer, DocUriReq(sig)) }
   }
 
   override def rpcPublicSymbolSearch(names: List[String], maxResults: Int): SymbolSearchResults = {

--- a/server/src/main/scala/org/ensime/model/ModelBuilders.scala
+++ b/server/src/main/scala/org/ensime/model/ModelBuilders.scala
@@ -191,9 +191,8 @@ trait ModelBuilders { self: RichPresentationCompiler =>
       }
       def basicTypeInfo(tpe: Type): BasicTypeInfo = {
         val typeSym = tpe.typeSymbol
-        val sym = if (typeSym.isModuleClass)
-          typeSym.sourceModule else typeSym
-        val symPos = locateSymbolPos(sym, needPos)
+        val symPos = locateSymbolPos(
+          if (typeSym.isModuleClass) typeSym.sourceModule else typeSym, needPos)
         val outerTypeId = outerClass(typeSym).map(s => cacheType(s.tpe))
         new BasicTypeInfo(
           typeShortName(tpe),
@@ -255,13 +254,13 @@ trait ModelBuilders { self: RichPresentationCompiler =>
         case None => NoType
         case Some(t) => t
       }
-      val name = if (sym.isClass || sym.isTrait || sym.isModule ||
+      val nameString = sym.nameString
+      val (name, localName) = if (sym.isClass || sym.isTrait || sym.isModule ||
         sym.isModuleClass || sym.isPackageClass) {
-        typeFullName(tpe)
+        (typeFullName(tpe), nameString)
       } else {
-        sym.nameString
+        (nameString, nameString)
       }
-      val localName = sym.nameString
       val ownerTpe = if (sym.owner != NoSymbol && sym.owner.tpe != NoType) {
         Some(sym.owner.tpe)
       } else None
@@ -305,7 +304,8 @@ trait ModelBuilders { self: RichPresentationCompiler =>
     def apply(m: TypeMember): NamedTypeMemberInfo = {
       val decl = declaredAs(m.sym)
       val pos = if (m.sym.pos == NoPosition) None else Some(EmptySourcePosition())
-      new NamedTypeMemberInfo(m.sym.nameString, TypeInfo(m.tpe), pos, decl)
+      val signatureString = if (decl == 'method) Some(m.sym.signatureString) else None
+      new NamedTypeMemberInfo(m.sym.nameString, TypeInfo(m.tpe), pos, signatureString, decl)
     }
   }
 

--- a/server/src/main/scala/org/ensime/server/ConnectionInfo.scala
+++ b/server/src/main/scala/org/ensime/server/ConnectionInfo.scala
@@ -6,4 +6,4 @@ case class ConnectionInfo(
   pid: Option[Int] = None,
   implementation: EnsimeImplementation = EnsimeImplementation("ENSIME"),
   // Please also update changelog in SwankProtocol.scala
-  version: String = "0.8.13")
+  version: String = "0.8.14")

--- a/server/src/main/scala/org/ensime/server/Server.scala
+++ b/server/src/main/scala/org/ensime/server/Server.scala
@@ -146,6 +146,7 @@ class SocketReader(socket: Socket, protocol: Protocol, handler: ActorRef) extend
       while (true) {
         val msg: WireFormat = protocol.readMessage(reader)
         handler ! IncomingMessageEvent(msg)
+
       }
     } catch {
       case e: IOException =>

--- a/server/src/test/scala/org/ensime/server/protocol/swank/SwankProtocolConversionsSpec.scala
+++ b/server/src/test/scala/org/ensime/server/protocol/swank/SwankProtocolConversionsSpec.scala
@@ -137,7 +137,7 @@ class SwankProtocolConversionsSpec extends FunSpec with Matchers {
         assert(toWF(new SymbolInfo("name", "localName", None, typeInfo, false, Some(2))).toWireString === """(:name "name" :local-name "localName" :decl-pos nil :type (:arrow-type nil :name "type1" :type-id 7 :decl-as type1 :full-name "FOO.type1" :type-args nil :members nil :pos nil :outer-type-id 8) :is-callable nil :owner-type-id 2)""")
 
         // toWF(value: NamedTypeMemberInfo)
-        assert(toWF(new NamedTypeMemberInfo("typeX", typeInfo, None, 'abcd)).toWireString === """(:name "typeX" :type (:arrow-type nil :name "type1" :type-id 7 :decl-as type1 :full-name "FOO.type1" :type-args nil :members nil :pos nil :outer-type-id 8) :pos nil :decl-as abcd)""")
+        assert(toWF(new NamedTypeMemberInfo("typeX", typeInfo, None, None, 'abcd)).toWireString === """(:name "typeX" :type (:arrow-type nil :name "type1" :type-id 7 :decl-as type1 :full-name "FOO.type1" :type-args nil :members nil :pos nil :outer-type-id 8) :pos nil :signature-string nil :decl-as abcd)""")
 
         // toWF(value: EntityInfo)
         assert(toWF(entityInfo).toWireString === entityInfoStr)

--- a/server/src/test/scala/org/ensime/server/protocol/swank/SwankProtocolSpec.scala
+++ b/server/src/test/scala/org/ensime/server/protocol/swank/SwankProtocolSpec.scala
@@ -111,7 +111,7 @@ class SwankProtocolSpec extends FunSpec with ShouldMatchers with BeforeAndAfterA
     it("should understand connection-info request") {
       testWithResponse("(swank:connection-info)") { (t, m, id) =>
         (t.rpcConnectionInfo _).expects().returns(new ConnectionInfo())
-        (m.send _).expects(s"""(:return (:ok (:pid nil :implementation (:name "ENSIME") :version "0.8.13")) $id)""")
+        (m.send _).expects(s"""(:return (:ok (:pid nil :implementation (:name "ENSIME") :version "0.8.14")) $id)""")
       }
     }
 
@@ -288,9 +288,9 @@ class SwankProtocolSpec extends FunSpec with ShouldMatchers with BeforeAndAfterA
       }
     }
 
-    it("should understand swank:member-by-name") {
-      testWithResponse("""(swank:member-by-name "org.example.A" "x" t)""") { (t, m, id) =>
-        (t.rpcMemberByName _).expects("org.example.A", "x", true).returns(Some(symbolInfo))
+    it("should understand swank:symbol-by-name") {
+      testWithResponse("""(swank:symbol-by-name "org.example.A" "x" nil)""") { (t, m, id) =>
+        (t.rpcSymbolByName _).expects("org.example.A", Some("x"), None).returns(Some(symbolInfo))
         (m.send _).expects(s"""(:return (:ok $symbolInfoStr) $id)""")
       }
     }


### PR DESCRIPTION
Subsumes member-by-name call. 
This call and doc-uri-for-symbol, now using the symbol signatureString to disambiguate overloaded methods.

Why?
* Gives us an unambiguous way to refer to symbols which we can immediately use in the type inspector to fix jumping to source for method overloads.
* Reduces reliance on type ids.