### PR TITLE
Fix escaping of files in Swank protocol tests

### DIFF
--- a/swank/src/test/scala/org/ensime/server/protocol/swank/SwankProtocolConversionsSpec.scala
+++ b/swank/src/test/scala/org/ensime/server/protocol/swank/SwankProtocolConversionsSpec.scala
@@ -198,7 +198,7 @@ class SwankProtocolConversionsSpec extends FunSpec with Matchers {
         assert(toWF(SymbolDesignations(symFile, List(
           SymbolDesignation(7, 9, VarFieldSymbol),
           SymbolDesignation(11, 22, ClassSymbol)
-        ))).toWireString === s"""(:file "${symFile.getPath}" :syms ((varField 7 9) (class 11 22)))""")
+        ))).toWireString === s"""(:file ${fileToWireString(symFile)} :syms ((varField 7 9) (class 11 22)))""")
 
         assert(toWF(RefactorFailure(7, "message")).toWireString === """(:procedure-id 7 :reason "message" :status failure)""")
 

--- a/swank/src/test/scala/org/ensime/server/protocol/swank/SwankProtocolSpec.scala
+++ b/swank/src/test/scala/org/ensime/server/protocol/swank/SwankProtocolSpec.scala
@@ -199,7 +199,7 @@ class SwankProtocolSpec extends FunSpec with ShouldMatchers with BeforeAndAfterA
     it("should understand swank:completions with SourceFileInfo") {
       val f = file("ensime/src/main/scala/org/ensime/protocol/SwankProtocol.scala").canon
       testWithResponse(
-        s"""(swank:completions (:file "${f.getPath}") 22626 0 t t)"""
+        s"""(swank:completions (:file ${fileToWireString(f)}) 22626 0 t t)"""
       ) { (t, m, id) =>
           (t.rpcCompletionsAtPoint _).expects(
             SourceFileInfo(f), 22626, 0, true, true
@@ -211,7 +211,7 @@ class SwankProtocolSpec extends FunSpec with ShouldMatchers with BeforeAndAfterA
     it("should understand swank:completions with ContentsSourceFileInfo") {
       val f = file("ensime/src/main/scala/org/ensime/protocol/SwankProtocol.scala").canon
       testWithResponse(
-        s"""(swank:completions (:file "${f.getPath}" :contents "zz") 22626 0 t t)"""
+        s"""(swank:completions (:file ${fileToWireString(f)} :contents "zz") 22626 0 t t)"""
       ) { (t, m, id) =>
           (t.rpcCompletionsAtPoint _).expects(
             ContentsSourceFileInfo(f, "zz"), 22626, 0, true, true
@@ -223,7 +223,7 @@ class SwankProtocolSpec extends FunSpec with ShouldMatchers with BeforeAndAfterA
     it("should understand swank:completions with ContentsInSourceFileInfo") {
       val f = file("ensime/src/main/scala/org/ensime/protocol/SwankProtocol.scala").canon
       testWithResponse(
-        s"""(swank:completions (:file "${f.getPath}" :contents-in "Foo.scala") 22626 0 t t)"""
+        s"""(swank:completions (:file ${fileToWireString(f)} :contents-in "Foo.scala") 22626 0 t t)"""
       ) { (t, m, id) =>
           (t.rpcCompletionsAtPoint _).expects(
             ContentsInSourceFileInfo(f, fooFile), 22626, 0, true, true

--- a/swank/src/test/scala/org/ensime/server/protocol/swank/SwankTestData.scala
+++ b/swank/src/test/scala/org/ensime/server/protocol/swank/SwankTestData.scala
@@ -32,7 +32,7 @@ object SwankTestData {
       SymbolDesignation(11, 22, TraitSymbol)
     )
   )
-  val symbolDesignationsStr = s"""(:file "${symFile.getPath}" :syms ((object 7 9) (trait 11 22)))"""
+  val symbolDesignationsStr = s"""(:file ${fileToWireString(symFile)} :syms ((object 7 9) (trait 11 22)))"""
 
   val symbolInfo = new SymbolInfo("name", "localName", None, typeInfo, false, Some(2))
   val symbolInfoStr = """(:name "name" :local-name "localName" :decl-pos nil :type """ + typeInfoStr + """ :is-callable nil :owner-type-id 2)"""


### PR DESCRIPTION
This fixes a few Windows test failures. The thing to remember is to always use `fileToWireString` when hard-coding protocol messages  (canonizes and escapes backslashes)
