### PR TITLE
Return rpc abort rather than reader error if possible for parsing err…

### DIFF
--- a/server/src/main/scala/org/ensime/core/DocServer.scala
+++ b/server/src/main/scala/org/ensime/core/DocServer.scala
@@ -220,6 +220,7 @@ class DocServer(
           sender ! resolveLocalUri(sig).orElse(resolveWellKnownUri(sig))
         } catch {
           case e: Exception =>
+            // TODO The caller is expecting Option[String] this will generate a secondary error
             log.error(e, "Error handling RPC: " + sig)
             sender ! RPCError(
               ErrExceptionInRPC,

--- a/sexpress/src/main/scala/org/ensime/sexp/formats/package.scala
+++ b/sexpress/src/main/scala/org/ensime/sexp/formats/package.scala
@@ -2,7 +2,8 @@ package org.ensime.sexp
 
 package object formats {
   def deserializationError(got: Sexp) =
-    throw new DeserializationException(s"Didn't expect a $got")
+    throw new DeserializationException(s"Unable to parse $got")
+
   def serializationError(msg: String) = throw new SerializationException(msg)
 }
 

--- a/swank/src/main/scala/org/ensime/server/protocol/swank/SwankProtocol.scala
+++ b/swank/src/main/scala/org/ensime/server/protocol/swank/SwankProtocol.scala
@@ -59,6 +59,8 @@ class SwankProtocol(
             log.error(s"handling ${sexp.compactPrint}", e)
             sendRPCError(ErrExceptionInRPC, e.getMessage, message.callId)
         }
+      case Failure(SwankRPCFormatException(msg, callId, _)) =>
+        sendRPCError(ErrMalformedRPC, msg, callId)
       case Failure(e) =>
         log.error(s"unrecognised input ${sexp.compactPrint}", e)
         sendProtocolError(ErrUnrecognizedForm, sexp.compactPrint)

--- a/swank/src/test/scala/org/ensime/server/protocol/swank/SwankProtocolSpec.scala
+++ b/swank/src/test/scala/org/ensime/server/protocol/swank/SwankProtocolSpec.scala
@@ -435,7 +435,6 @@ class SwankProtocolSpec extends FunSpec with ShouldMatchers with BeforeAndAfterA
         """addImport (qualifiedName "com.bar.Foo" file "SwankProtocol.scala")""",
         AddImportRefactorDesc("com.bar.Foo", file("SwankProtocol.scala").canon)
       )
-
     }
 
     it("should understand swank:exec-refactor - refactor failure") {
@@ -659,25 +658,25 @@ class SwankProtocolSpec extends FunSpec with ShouldMatchers with BeforeAndAfterA
 
     it("should rejected an invalid range expression") {
       testWithResponse("""(swank:type-by-name-at-point "String" "SwankProtocol.scala" (broken range expression))""") { (t, m, id) =>
-        (m.send _).expects(s"""(:reader-error 203 "(:swank-rpc (swank:type-by-name-at-point \\"String\\" \\"SwankProtocol.scala\\" (broken range expression)) $id)")""")
+        (m.send _).expects(s"""(:return (:abort 202 "Invalid rpc request (swank:type-by-name-at-point \\"String\\" \\"SwankProtocol.scala\\" (broken range expression))") $id)""")
       }
     }
 
     it("should rejected an invalid patch expression") {
       testWithResponse("""(swank:patch-source "Analyzer.scala" (("+" 6461 "Inc") ("???" 7127 7128)))""") { (t, m, id) =>
-        (m.send _).expects(s"""(:reader-error 203 "(:swank-rpc (swank:patch-source \\"Analyzer.scala\\" ((\\"+\\" 6461 \\"Inc\\") (\\"???\\" 7127 7128))) $id)")""")
+        (m.send _).expects(s"""(:return (:abort 202 "Invalid rpc request (swank:patch-source \\"Analyzer.scala\\" ((\\"+\\" 6461 \\"Inc\\") (\\"???\\" 7127 7128)))") $id)""")
       }
     }
 
     it("should rejected an invalid symbol list expression") {
       testWithResponse("""(swank:symbol-designations "SwankProtocol.scala" 0 46857 (var "fred"))""") { (t, m, id) =>
-        (m.send _).expects(s"""(:reader-error 203 "(:swank-rpc (swank:symbol-designations \\"SwankProtocol.scala\\" 0 46857 (var \\"fred\\")) $id)")""")
+        (m.send _).expects(s"""(:return (:abort 202 "Invalid rpc request (swank:symbol-designations \\"SwankProtocol.scala\\" 0 46857 (var \\"fred\\"))") $id)""")
       }
     }
 
     it("should rejected an invalid debug location expression") {
       testWithResponse("""(swank:debug-value (:type unknown :object-id "23" :index 2))""") { (t, m, id) =>
-        (m.send _).expects(s"""(:reader-error 203 "(:swank-rpc (swank:debug-value (:type unknown :object-id \\"23\\" :index 2)) $id)")""")
+        (m.send _).expects(s"""(:return (:abort 202 "Invalid rpc request (swank:debug-value (:type unknown :object-id \\"23\\" :index 2))") $id)""")
       }
     }
 
@@ -690,8 +689,15 @@ class SwankProtocolSpec extends FunSpec with ShouldMatchers with BeforeAndAfterA
 
     it("should return error for unknown refactor") {
       testWithResponse("""(swank:prepare-refactor 9 unknownRefactor (foo bar) t)""") { (t, m, id) =>
-        (m.send _).expects(s"""(:reader-error 203 "(:swank-rpc (swank:prepare-refactor 9 unknownRefactor (foo bar) t) $id)")""")
+        (m.send _).expects(s"""(:return (:abort 202 "Invalid rpc request (swank:prepare-refactor 9 unknownRefactor (foo bar) t)") $id)""")
       }
     }
+
+    it("should handle parse fails gracefully") {
+      testWithResponse("(swank:debug-value nil)") { (t, m, id) =>
+        (m.send _).expects(s"""(:return (:abort 202 "Invalid rpc request (swank:debug-value nil)") $id)""")
+      }
+    }
+
   }
 }


### PR DESCRIPTION
…ors.

Parse failures of RPC messages result in protocol errors rather than rpc abort which updates Emacs.
So if we can work out the rpc call id return an rpc-abort rather than a reader error (otherwise fall
back to a reader error: