### PR TITLE
Implicit conversion highlighting

### DIFF
--- a/api/src/main/scala/org/ensime/api/incoming.scala
+++ b/api/src/main/scala/org/ensime/api/incoming.scala
@@ -25,6 +25,20 @@ case object ConnectionInfoReq extends RpcStartupRequest
 sealed trait RpcAnalyserRequest extends RpcRequest
 
 /**
+ * Request details about implicit conversions applied inside the given
+ * range.
+ *
+ * Responds with `List[ImplicitInfo]`.
+ *
+ * @param file source.
+ * @param range in the file to inspect.
+ */
+case class ImplicitInfoReq(
+  file: File,
+  range: OffsetRange
+) extends RpcAnalyserRequest
+
+/**
  * Responds with a `VoidResponse`.
  */
 case class RemoveFileReq(file: File) extends RpcAnalyserRequest

--- a/api/src/main/scala/org/ensime/api/incoming.scala
+++ b/api/src/main/scala/org/ensime/api/incoming.scala
@@ -28,7 +28,7 @@ sealed trait RpcAnalyserRequest extends RpcRequest
  * Request details about implicit conversions applied inside the given
  * range.
  *
- * Responds with `List[ImplicitInfo]`.
+ * Responds with `ImplicitInfos`.
  *
  * @param file source.
  * @param range in the file to inspect.

--- a/api/src/main/scala/org/ensime/api/outgoing.scala
+++ b/api/src/main/scala/org/ensime/api/outgoing.scala
@@ -203,7 +203,8 @@ sealed trait EntityInfo {
 object SourceSymbol {
   val allSymbols: List[SourceSymbol] = List(
     ObjectSymbol, ClassSymbol, TraitSymbol, PackageSymbol, ConstructorSymbol, ImportedNameSymbol, TypeParamSymbol,
-    ParamSymbol, VarFieldSymbol, ValFieldSymbol, OperatorFieldSymbol, VarSymbol, ValSymbol, FunctionCallSymbol
+    ParamSymbol, VarFieldSymbol, ValFieldSymbol, OperatorFieldSymbol, VarSymbol, ValSymbol, FunctionCallSymbol,
+    ImplicitConversionSymbol, ImplicitParamsSymbol
   )
 }
 
@@ -223,6 +224,8 @@ case object OperatorFieldSymbol extends SourceSymbol
 case object VarSymbol extends SourceSymbol
 case object ValSymbol extends SourceSymbol
 case object FunctionCallSymbol extends SourceSymbol
+case object ImplicitConversionSymbol extends SourceSymbol
+case object ImplicitParamsSymbol extends SourceSymbol
 
 sealed trait PosNeeded
 case object PosNeededNo extends PosNeeded
@@ -525,5 +528,24 @@ case class EnsimeImplementation(
 case class ConnectionInfo(
   pid: Option[Int] = None,
   implementation: EnsimeImplementation = EnsimeImplementation("ENSIME"),
-  version: String = "0.8.15"
+  version: String = "0.8.16"
 )
+
+sealed trait ImplicitInfo {
+  def start: Int
+  def end: Int
+}
+
+case class ImplicitConversionInfo(
+  start: Int,
+  end: Int,
+  fun: SymbolInfo
+) extends ImplicitInfo
+
+case class ImplicitParamInfo(
+  start: Int,
+  end: Int,
+  fun: SymbolInfo,
+  params: List[SymbolInfo],
+  funIsImplicit: Boolean
+) extends ImplicitInfo

--- a/api/src/main/scala/org/ensime/api/outgoing.scala
+++ b/api/src/main/scala/org/ensime/api/outgoing.scala
@@ -549,3 +549,5 @@ case class ImplicitParamInfo(
   params: List[SymbolInfo],
   funIsImplicit: Boolean
 ) extends ImplicitInfo
+
+case class ImplicitInfos(infos: List[ImplicitInfo])

--- a/api/src/test/scala/org/ensime/api/EnsimeTestData.scala
+++ b/api/src/test/scala/org/ensime/api/EnsimeTestData.scala
@@ -24,6 +24,11 @@ trait EnsimeTestData {
 
   val symbolInfo = new SymbolInfo("name", "localName", None, typeInfo, false, Some(2))
 
+  val implicitInfos = List(
+    ImplicitConversionInfo(5, 6, symbolInfo),
+    ImplicitParamInfo(7, 8, symbolInfo, List(symbolInfo, symbolInfo), true)
+  )
+
   val batchSourceFile = "/abc"
 
   val rangePos1 = new ERangePosition(batchSourceFile, 75, 70, 90)

--- a/core/src/it/scala/org/ensime/core/ImplicitAnalyzerSpec.scala
+++ b/core/src/it/scala/org/ensime/core/ImplicitAnalyzerSpec.scala
@@ -1,0 +1,122 @@
+package org.ensime.core
+
+import org.ensime.fixture._
+import org.ensime.api._
+import org.scalatest._
+
+import scala.reflect.internal.util.{ OffsetPosition, RangePosition }
+
+class ImplicitAnalyzerSpec extends WordSpec with Matchers
+    with IsolatedRichPresentationCompilerFixture
+    with RichPresentationCompilerTestUtils
+    with ReallyRichPresentationCompilerFixture {
+
+  def original = EnsimeConfigFixture.EmptyTestProject
+
+  def getImplicitDetails(cc: RichPresentationCompiler, content: String) = {
+    val file = srcFile(cc.config, "abc.scala", contents(content))
+    cc.askLoadedTyped(file)
+    val pos = new RangePosition(file, 0, 0, file.length)
+    val dets = new ImplicitAnalyzer(cc).implicitDetails(pos)
+    dets.map {
+      case c: ImplicitConversionInfo => (
+        "conversion",
+        content.substring(c.start, c.end),
+        c.fun.name
+      )
+      case c: ImplicitParamInfo => (
+        "param",
+        content.substring(c.start, c.end),
+        c.fun.name,
+        c.params.map { p => p.name },
+        c.funIsImplicit
+      )
+    }
+  }
+
+  "ImplicitAnalyzer" should {
+    "render implicit conversions" in withPresCompiler { (config, cc) =>
+      val dets = getImplicitDetails(
+        cc,
+        """
+            package com.example
+            class Test {}
+            object I {
+              implicit def StringToTest(v: String): Test = new Test
+              val t: Test  = "sample";
+            }
+        """
+      )
+      assert(dets === List(
+        ("conversion", "\"sample\"", "StringToTest")
+      ))
+    }
+
+    "render implicit parameters passed to implicit conversion functions" in withPresCompiler { (config, cc) =>
+      val dets = getImplicitDetails(
+        cc,
+        """
+            package com.example
+            class Test {}
+            class Thing {}
+            object I {
+              implicit def myThing = new Thing
+              implicit def StringToTest(v: String)(implicit th: Thing): Test = new Test
+              val t: Test = "sample"
+            }
+        """
+      )
+      assert(dets === List(
+        ("param", "\"sample\"", "StringToTest", List("myThing"), true),
+        ("conversion", "\"sample\"", "StringToTest")
+      ))
+    }
+
+    "render implicit parameters" in withPresCompiler { (config, cc) =>
+      val dets = getImplicitDetails(
+        cc,
+        """
+            package com.example
+            class Thing {}
+            class Thong {}
+            object I {
+              implicit def myThing = new Thing
+              implicit val myThong = new Thong
+              def zz(u: Int)(v: String)(implicit s: Thing, t: Thong) = u
+              def yy(implicit s: Thing) = s
+              val t = zz(1)("abc")    // Two explicit applications
+              val z = yy              // Zero explicit application
+            }
+        """
+      )
+      assert(dets === List(
+        ("param", "zz(1)(\"abc\")", "zz", List("myThing", "myThong"), false),
+        ("param", "yy", "yy", List("myThing"), false)
+      ))
+    }
+
+    "work with offset positions" in withPresCompiler { (config, cc) =>
+
+      val content = """
+            package com.example
+            class Test {}
+            object I {
+              implicit def StringToTest(v: String): Test = new Test
+              val t: Test  = "sample"/*1*/;
+            }
+        """
+
+      val file = srcFile(cc.config, "abc.scala", content)
+      cc.askLoadedTyped(file)
+      val implicitPos = content.indexOf("/*1*/");
+
+      val pos = new OffsetPosition(file, implicitPos)
+      val dets = new ImplicitAnalyzer(cc).implicitDetails(pos)
+      assert(dets.length === 1)
+
+      val pos1 = new OffsetPosition(file, implicitPos + 1)
+      val dets1 = new ImplicitAnalyzer(cc).implicitDetails(pos1)
+      assert(dets1.length === 0)
+    }
+  }
+}

--- a/core/src/it/scala/org/ensime/core/SemanticHighlightingSpec.scala
+++ b/core/src/it/scala/org/ensime/core/SemanticHighlightingSpec.scala
@@ -392,6 +392,44 @@ class SemanticHighlightingSpec extends WordSpec with Matchers
       ))
     }
 
+    "highlight implicit conversions" in withPresCompiler { (config, cc) =>
+      val sds = getSymbolDesignations(
+        config, cc, """
+            package com.example
+            class Test {}
+            object I {
+              implicit def StringToTest(v: String): Test = new Test
+              val t: Test  = "sample";
+              val u: Test  = StringToTest("y");
+            }
+          """,
+        List(ImplicitConversionSymbol)
+      )
+      assert(sds === List(
+        (ImplicitConversionSymbol, "\"sample\"")
+      ))
+    }
+
+    "highlight implicit parameters" in withPresCompiler { (config, cc) =>
+      val sds = getSymbolDesignations(
+        config, cc, """
+            package com.example
+            class Thing {}
+            class Thong {}
+            object I {
+              implicit def myThing = new Thing
+              implicit val myThong = new Thong
+              def zz(u: Int)(implicit s: Thing, t: Thong) = u
+              val t = zz(1)
+            }
+          """,
+        List(ImplicitParamsSymbol)
+      )
+      assert(sds === List(
+        (ImplicitParamsSymbol, "zz(1)")
+      ))
+    }
+
     "highlight method calls after operators" in withPresCompiler { (config, cc) =>
       val sds = getSymbolDesignations(
         config, cc, """

--- a/core/src/main/scala/org/ensime/core/Analyzer.scala
+++ b/core/src/main/scala/org/ensime/core/Analyzer.scala
@@ -271,6 +271,11 @@ class Analyzer(
           sender ! SymbolDesignations(file(sf.path), List.empty)
         }
       }
+
+    case ImplicitInfoReq(file: File, range: OffsetRange) =>
+      val p = pos(file, range)
+      sender() ! scalaCompiler.askImplicitInfoInRegion(p)
+
     case ExpandSelectionReq(file, start: Int, stop: Int) =>
       sender ! handleExpandselection(file, start, stop)
     case FormatSourceReq(files: List[File]) =>

--- a/core/src/main/scala/org/ensime/core/ImplicitAnalyzer.scala
+++ b/core/src/main/scala/org/ensime/core/ImplicitAnalyzer.scala
@@ -1,0 +1,66 @@
+package org.ensime.core
+
+import java.io.File
+import org.ensime.api._
+import org.slf4j.LoggerFactory
+
+import scala.collection.mutable.ListBuffer
+import scala.reflect.internal.util.RangePosition
+import scala.reflect.io.AbstractFile
+import scala.tools.nsc.symtab.Flags._
+
+class ImplicitAnalyzer(val global: RichPresentationCompiler) {
+
+  import global._
+
+  class ImplicitsTraverser(p: Position) extends Traverser {
+    val log = LoggerFactory.getLogger(getClass)
+    val implicits = new ListBuffer[ImplicitInfo]
+
+    override def traverse(t: Tree): Unit = {
+      val treeP = t.pos
+      if (p.overlaps(treeP) || treeP.includes(p)) {
+        try {
+          t match {
+            case t: ApplyImplicitView =>
+              implicits.append(ImplicitConversionInfo(
+                treeP.start,
+                treeP.end,
+                SymbolInfo(t.fun.symbol)
+              ))
+            case t: ApplyToImplicitArgs =>
+              val funIsImplicit = t.fun match {
+                case tt: ApplyImplicitView => true
+                case _ => false
+              }
+              implicits.append(ImplicitParamInfo(
+                treeP.start,
+                treeP.end,
+                SymbolInfo(t.fun.symbol),
+                t.args.map { a => SymbolInfo(a.symbol) },
+                funIsImplicit
+              ))
+            case _ =>
+          }
+        } catch {
+          case e: Throwable =>
+            log.error("Error in AST traverse:", e)
+        }
+        super.traverse(t)
+      }
+    }
+  }
+
+  def implicitDetails(p: Position): List[ImplicitInfo] = {
+    val typed = new global.Response[global.Tree]
+    global.askLoadedTyped(p.source, keepLoaded = true, typed)
+    typed.get.left.toOption match {
+      case Some(tree) =>
+        val traverser = new ImplicitsTraverser(p)
+        traverser.traverse(tree)
+        traverser.implicits.toList
+      case _ => List.empty
+    }
+  }
+
+}

--- a/core/src/main/scala/org/ensime/core/RichPresentationCompiler.scala
+++ b/core/src/main/scala/org/ensime/core/RichPresentationCompiler.scala
@@ -161,6 +161,11 @@ trait RichCompilerControl extends CompilerControl with RefactoringControl with C
       new SemanticHighlighting(this).symbolDesignationsInRegion(p, tpes)
     ).getOrElse(SymbolDesignations(new File("."), List.empty))
 
+  def askImplicitInfoInRegion(p: Position): List[ImplicitInfo] =
+    askOption(
+      new ImplicitAnalyzer(this).implicitDetails(p)
+    ).getOrElse(List.empty)
+
   def askClearTypeCache(): Unit = clearTypeCache()
 
   def askNotifyWhenReady(): Unit = ask(setNotifyWhenReady)

--- a/core/src/main/scala/org/ensime/core/RichPresentationCompiler.scala
+++ b/core/src/main/scala/org/ensime/core/RichPresentationCompiler.scala
@@ -161,10 +161,12 @@ trait RichCompilerControl extends CompilerControl with RefactoringControl with C
       new SemanticHighlighting(this).symbolDesignationsInRegion(p, tpes)
     ).getOrElse(SymbolDesignations(new File("."), List.empty))
 
-  def askImplicitInfoInRegion(p: Position): List[ImplicitInfo] =
-    askOption(
-      new ImplicitAnalyzer(this).implicitDetails(p)
-    ).getOrElse(List.empty)
+  def askImplicitInfoInRegion(p: Position): ImplicitInfos =
+    ImplicitInfos(
+      askOption(
+        new ImplicitAnalyzer(this).implicitDetails(p)
+      ).getOrElse(List.empty)
+    )
 
   def askClearTypeCache(): Unit = clearTypeCache()
 

--- a/core/src/main/scala/org/ensime/core/SemanticHighlighting.scala
+++ b/core/src/main/scala/org/ensime/core/SemanticHighlighting.scala
@@ -122,6 +122,9 @@ class SemanticHighlighting(val global: RichPresentationCompiler) extends Compile
                 }
               }
 
+            case t: ApplyImplicitView => add(ImplicitConversionSymbol)
+            case t: ApplyToImplicitArgs => add(ImplicitParamsSymbol)
+
             case TypeTree() =>
               if (!qualifySymbol(sym)) {
                 if (t.tpe != null) {
@@ -153,8 +156,8 @@ class SemanticHighlighting(val global: RichPresentationCompiler) extends Compile
     p: RangePosition,
     requestedTypes: List[SourceSymbol]
   ): SymbolDesignations = {
-    val typed = new Response[global.Tree]
-    global.askLoadedTyped(p.source, keepLoaded = true, typed)
+    val typed = new Response[Tree]
+    askLoadedTyped(p.source, keepLoaded = true, typed)
     typed.get.left.toOption match {
       case Some(tree) =>
         val traverser = new SymDesigsTraverser(p, requestedTypes.toSet)
@@ -165,6 +168,6 @@ class SemanticHighlighting(val global: RichPresentationCompiler) extends Compile
     }
   }
 
-  def compilationUnitOfFile(f: AbstractFile): Option[CompilationUnit] = global.unitOfFile.get(f)
+  def compilationUnitOfFile(f: AbstractFile): Option[CompilationUnit] = unitOfFile.get(f)
 
 }

--- a/jerk/src/main/scala/org/ensime/jerk/JerkFormats.scala
+++ b/jerk/src/main/scala/org/ensime/jerk/JerkFormats.scala
@@ -75,6 +75,7 @@ object JerkFormats extends DefaultJsonProtocol with FamilyFormats {
   val RefactorEffectFormat = RootJsonFormat[RefactorEffect]
   val RefactorResultFormat = RootJsonFormat[RefactorResult]
   val ListERangePositionFormat = RootJsonFormat[List[ERangePosition]]
+  val ListImplicitInfoFormat = RootJsonFormat[List[ImplicitInfo]]
 
 }
 
@@ -116,6 +117,7 @@ object JerkEndpoints {
   implicit val RefactorEffectFormat = JerkFormats.RefactorEffectFormat
   implicit val RefactorResultFormat = JerkFormats.RefactorResultFormat
   implicit val ListERangePositionFormat = JerkFormats.ListERangePositionFormat
+  implicit val ListImplicitInfoFormat = JerkFormats.ListImplicitInfoFormat
 
   import JerkFormats.BooleanJsonFormat
   import JerkFormats.StringJsonFormat
@@ -127,6 +129,8 @@ object JerkEndpoints {
     case s: String => s.toJson
     case list: List[_] if list.forall(_.isInstanceOf[ERangePosition]) =>
       list.asInstanceOf[List[ERangePosition]].toJson
+    case list: List[_] if list.forall(_.isInstanceOf[ImplicitInfo]) =>
+      list.asInstanceOf[List[ImplicitInfo]].toJson
 
     case VoidResponse => false.toJson
     case value: ConnectionInfo => value.toJson

--- a/jerk/src/main/scala/org/ensime/jerk/JerkFormats.scala
+++ b/jerk/src/main/scala/org/ensime/jerk/JerkFormats.scala
@@ -75,7 +75,7 @@ object JerkFormats extends DefaultJsonProtocol with FamilyFormats {
   val RefactorEffectFormat = RootJsonFormat[RefactorEffect]
   val RefactorResultFormat = RootJsonFormat[RefactorResult]
   val ListERangePositionFormat = RootJsonFormat[List[ERangePosition]]
-  val ListImplicitInfoFormat = RootJsonFormat[List[ImplicitInfo]]
+  val ImplicitInfosFormat = RootJsonFormat[ImplicitInfos]
 
 }
 
@@ -117,7 +117,7 @@ object JerkEndpoints {
   implicit val RefactorEffectFormat = JerkFormats.RefactorEffectFormat
   implicit val RefactorResultFormat = JerkFormats.RefactorResultFormat
   implicit val ListERangePositionFormat = JerkFormats.ListERangePositionFormat
-  implicit val ListImplicitInfoFormat = JerkFormats.ListImplicitInfoFormat
+  implicit val ImplicitInfosFormat = JerkFormats.ImplicitInfosFormat
 
   import JerkFormats.BooleanJsonFormat
   import JerkFormats.StringJsonFormat
@@ -129,8 +129,6 @@ object JerkEndpoints {
     case s: String => s.toJson
     case list: List[_] if list.forall(_.isInstanceOf[ERangePosition]) =>
       list.asInstanceOf[List[ERangePosition]].toJson
-    case list: List[_] if list.forall(_.isInstanceOf[ImplicitInfo]) =>
-      list.asInstanceOf[List[ImplicitInfo]].toJson
 
     case VoidResponse => false.toJson
     case value: ConnectionInfo => value.toJson
@@ -164,6 +162,7 @@ object JerkEndpoints {
     case value: RefactorFailure => value.toJson
     case value: RefactorEffect => value.toJson
     case value: RefactorResult => value.toJson
+    case value: ImplicitInfos => value.toJson
 
     case _ => throw new IllegalArgumentException(s"$msg is not a valid JERK response")
   }

--- a/jerk/src/test/scala/org/ensime/jerk/JerkFormatsSpec.scala
+++ b/jerk/src/test/scala/org/ensime/jerk/JerkFormatsSpec.scala
@@ -1,5 +1,7 @@
 package org.ensime.jerk
 
+import java.io.File
+
 import org.scalatest._
 
 import org.ensime.api._
@@ -25,6 +27,19 @@ class JerkFormatsSpec extends FlatSpec with Matchers
     json.convertTo[RpcRequestEnvelope].req shouldBe value
   }
 
+  def fileToWireString(file: File) = {
+    val canonStr = file.canon.getAbsolutePath
+    "\"" + canonStr.replace("\\", "\\\\").replace("\"", "\\\"") + "\""
+  }
+
+  val file1_str = fileToWireString(file1)
+  val file2_str = fileToWireString(file2)
+  val file3_str = fileToWireString(file3)
+  val file4_str = fileToWireString(file4)
+  val file5_str = fileToWireString(file5)
+  val abd_str = fileToWireString(abd)
+  val symFile_str = fileToWireString(symFile)
+
   "Jerk Formats" should "roundtrip inbound messages" in {
     roundtrip(
       ConnectionInfoReq: RpcRequest,
@@ -33,17 +48,17 @@ class JerkFormatsSpec extends FlatSpec with Matchers
 
     roundtrip(
       RemoveFileReq(file1): RpcRequest,
-      """{"typehint":"RemoveFileReq","file":"/abc/def"}"""
+      s"""{"typehint":"RemoveFileReq","file":$file1_str}"""
     )
 
     roundtrip(
       TypecheckFileReq(sourceFileInfo): RpcRequest,
-      """{"typehint":"TypecheckFileReq","fileInfo":{"file":"/abc/def","contents":"{/* code here */}","contentsIn":"/test/test"}}"""
+      s"""{"typehint":"TypecheckFileReq","fileInfo":{"file":$file1_str,"contents":"{/* code here */}","contentsIn":$file2_str}}"""
     )
 
     roundtrip(
       TypecheckFilesReq(List(file1, file2)): RpcRequest,
-      """{"typehint":"TypecheckFilesReq","files":["/abc/def","/test/test"]}"""
+      s"""{"typehint":"TypecheckFilesReq","files":[$file1_str,$file2_str]}"""
     )
 
     roundtrip(
@@ -58,12 +73,12 @@ class JerkFormatsSpec extends FlatSpec with Matchers
 
     roundtrip(
       FormatSourceReq(List(file1, file2)): RpcRequest,
-      """{"typehint":"FormatSourceReq","files":["/abc/def","/test/test"]}"""
+      s"""{"typehint":"FormatSourceReq","files":[$file1_str,$file2_str]}"""
     )
 
     roundtrip(
       FormatOneSourceReq(sourceFileInfo): RpcRequest,
-      """{"typehint":"FormatOneSourceReq","file":{"file":"/abc/def","contents":"{/* code here */}","contentsIn":"/test/test"}}"""
+      s"""{"typehint":"FormatOneSourceReq","file":{"file":$file1_str,"contents":"{/* code here */}","contentsIn":$file2_str}}"""
     )
 
     roundtrip(
@@ -73,12 +88,12 @@ class JerkFormatsSpec extends FlatSpec with Matchers
 
     roundtrip(
       ImportSuggestionsReq(file1, 1, List("foo", "bar"), 10): RpcRequest,
-      """{"point":1,"maxResults":10,"names":["foo","bar"],"typehint":"ImportSuggestionsReq","file":"/abc/def"}"""
+      s"""{"point":1,"maxResults":10,"names":["foo","bar"],"typehint":"ImportSuggestionsReq","file":$file1_str}"""
     )
 
     roundtrip(
       DocUriAtPointReq(file1, OffsetRange(1, 10)): RpcRequest,
-      """{"typehint":"DocUriAtPointReq","file":"/abc/def","point":{"from":1,"to":10}}"""
+      s"""{"typehint":"DocUriAtPointReq","file":$file1_str,"point":{"from":1,"to":10}}"""
     )
 
     roundtrip(
@@ -88,7 +103,7 @@ class JerkFormatsSpec extends FlatSpec with Matchers
 
     roundtrip(
       CompletionsReq(sourceFileInfo, 10, 100, true, false): RpcRequest,
-      """{"point":10,"maxResults":100,"typehint":"CompletionsReq","caseSens":true,"fileInfo":{"file":"/abc/def","contents":"{/* code here */}","contentsIn":"/test/test"},"reload":false}"""
+      s"""{"point":10,"maxResults":100,"typehint":"CompletionsReq","caseSens":true,"fileInfo":{"file":$file1_str,"contents":"{/* code here */}","contentsIn":$file2_str},"reload":false}"""
     )
 
     roundtrip(
@@ -103,7 +118,7 @@ class JerkFormatsSpec extends FlatSpec with Matchers
 
     roundtrip(
       UsesOfSymbolAtPointReq(file1, 100): RpcRequest,
-      """{"typehint":"UsesOfSymbolAtPointReq","file":"/abc/def","point":100}"""
+      s"""{"typehint":"UsesOfSymbolAtPointReq","file":$file1_str,"point":100}"""
     )
 
     roundtrip(
@@ -118,17 +133,17 @@ class JerkFormatsSpec extends FlatSpec with Matchers
 
     roundtrip(
       TypeByNameAtPointReq("foo.bar", file1, OffsetRange(1, 10)): RpcRequest,
-      """{"typehint":"TypeByNameAtPointReq","name":"foo.bar","file":"/abc/def","range":{"from":1,"to":10}}"""
+      s"""{"typehint":"TypeByNameAtPointReq","name":"foo.bar","file":$file1_str,"range":{"from":1,"to":10}}"""
     )
 
     roundtrip(
       TypeAtPointReq(file1, OffsetRange(1, 100)): RpcRequest,
-      """{"typehint":"TypeAtPointReq","file":"/abc/def","range":{"from":1,"to":100}}"""
+      s"""{"typehint":"TypeAtPointReq","file":$file1_str,"range":{"from":1,"to":100}}"""
     )
 
     roundtrip(
       InspectTypeAtPointReq(file1, OffsetRange(1, 100)): RpcRequest,
-      """{"typehint":"InspectTypeAtPointReq","file":"/abc/def","range":{"from":1,"to":100}}"""
+      s"""{"typehint":"InspectTypeAtPointReq","file":$file1_str,"range":{"from":1,"to":100}}"""
     )
 
     roundtrip(
@@ -143,7 +158,7 @@ class JerkFormatsSpec extends FlatSpec with Matchers
 
     roundtrip(
       SymbolAtPointReq(file1, 101): RpcRequest,
-      """{"typehint":"SymbolAtPointReq","file":"/abc/def","point":101}"""
+      s"""{"typehint":"SymbolAtPointReq","file":$file1_str,"point":101}"""
     )
 
     roundtrip(
@@ -158,7 +173,7 @@ class JerkFormatsSpec extends FlatSpec with Matchers
 
     roundtrip(
       PrepareRefactorReq(1, 'ignored, RenameRefactorDesc("bar", file1, 1, 100), false): RpcRequest,
-      """{"tpe":"ignored","procId":1,"params":{"newName":"bar","typehint":"RenameRefactorDesc","end":100,"file":"/abc/def","start":1},"typehint":"PrepareRefactorReq","interactive":false}"""
+      s"""{"tpe":"ignored","procId":1,"params":{"newName":"bar","typehint":"RenameRefactorDesc","end":100,"file":$file1_str,"start":1},"typehint":"PrepareRefactorReq","interactive":false}"""
     )
 
     roundtrip(
@@ -176,12 +191,12 @@ class JerkFormatsSpec extends FlatSpec with Matchers
         file1, 1, 100,
         List(ObjectSymbol, ValSymbol)
       ): RpcRequest,
-      """{"requestedTypes":[{"typehint":"ObjectSymbol"},{"typehint":"ValSymbol"}],"typehint":"SymbolDesignationsReq","end":100,"file":"/abc/def","start":1}"""
+      s"""{"requestedTypes":[{"typehint":"ObjectSymbol"},{"typehint":"ValSymbol"}],"typehint":"SymbolDesignationsReq","end":100,"file":$file1_str,"start":1}"""
     )
 
     roundtrip(
       ExpandSelectionReq(file1, 100, 200): RpcRequest,
-      """{"typehint":"ExpandSelectionReq","file":"/abc/def","start":100,"end":200}"""
+      s"""{"typehint":"ExpandSelectionReq","file":$file1_str,"start":100,"end":200}"""
     )
 
     roundtrip(
@@ -206,12 +221,12 @@ class JerkFormatsSpec extends FlatSpec with Matchers
 
     roundtrip(
       DebugSetBreakReq(file1, 13): RpcRequest,
-      """{"typehint":"DebugSetBreakReq","file":"/abc/def","line":13}"""
+      s"""{"typehint":"DebugSetBreakReq","file":$file1_str,"line":13}"""
     )
 
     roundtrip(
       DebugClearBreakReq(file1, 13): RpcRequest,
-      """{"typehint":"DebugClearBreakReq","file":"/abc/def","line":13}"""
+      s"""{"typehint":"DebugClearBreakReq","file":$file1_str,"line":13}"""
     )
 
     roundtrip(
@@ -320,12 +335,12 @@ class JerkFormatsSpec extends FlatSpec with Matchers
     roundtrip(
       DebugStepEvent(DebugThreadId(207), "threadNameStr", sourcePos1.file, sourcePos1.line): EnsimeEvent,
       // why is the typehint not the first entry?
-      """{"line":57,"typehint":"DebugStepEvent","file":"/abc/def","threadName":"threadNameStr","threadId":207}"""
+      s"""{"line":57,"typehint":"DebugStepEvent","file":$file1_str,"threadName":"threadNameStr","threadId":207}"""
     )
 
     roundtrip(
       DebugBreakEvent(DebugThreadId(209), "threadNameStr", sourcePos1.file, sourcePos1.line): EnsimeEvent,
-      """{"line":57,"typehint":"DebugBreakEvent","file":"/abc/def","threadName":"threadNameStr","threadId":209}"""
+      s"""{"line":57,"typehint":"DebugBreakEvent","file":$file1_str,"threadName":"threadNameStr","threadId":209}"""
     )
 
     roundtrip(
@@ -338,7 +353,7 @@ class JerkFormatsSpec extends FlatSpec with Matchers
     )
     roundtrip(
       DebugExceptionEvent(33L, dtid, "threadNameStr", Some(sourcePos1.file), Some(sourcePos1.line)): EnsimeEvent,
-      """{"line":57,"exception":33,"typehint":"DebugExceptionEvent","file":"/abc/def","threadName":"threadNameStr","threadId":13}"""
+      s"""{"line":57,"exception":33,"typehint":"DebugExceptionEvent","file":$file1_str,"threadName":"threadNameStr","threadId":13}"""
     )
     roundtrip(
       DebugExceptionEvent(33L, dtid, "threadNameStr", None, None): EnsimeEvent,
@@ -415,21 +430,21 @@ class JerkFormatsSpec extends FlatSpec with Matchers
 
     roundtrip(
       debugStackFrame: DebugStackFrame,
-      """{"thisObjectId":{"id":7},"methodName":"method1","locals":[{"index":3,"name":"name1","summary":"summary1","typeName":"type1"},{"index":4,"name":"name2","summary":"summary2","typeName":"type2"}],"pcLocation":{"file":"/abc/def","line":57},"className":"class1","numArgs":4,"index":7}"""
+      s"""{"thisObjectId":{"id":7},"methodName":"method1","locals":[{"index":3,"name":"name1","summary":"summary1","typeName":"type1"},{"index":4,"name":"name2","summary":"summary2","typeName":"type2"}],"pcLocation":{"file":$file1_str,"line":57},"className":"class1","numArgs":4,"index":7}"""
     )
 
     roundtrip(
       DebugBacktrace(List(debugStackFrame), dtid, "thread1"): DebugBacktrace,
-      """{"frames":[{"thisObjectId":{"id":7},"methodName":"method1","locals":[{"index":3,"name":"name1","summary":"summary1","typeName":"type1"},{"index":4,"name":"name2","summary":"summary2","typeName":"type2"}],"pcLocation":{"file":"/abc/def","line":57},"className":"class1","numArgs":4,"index":7}],"threadId":13,"threadName":"thread1"}"""
+      s"""{"frames":[{"thisObjectId":{"id":7},"methodName":"method1","locals":[{"index":3,"name":"name1","summary":"summary1","typeName":"type1"},{"index":4,"name":"name2","summary":"summary2","typeName":"type2"}],"pcLocation":{"file":$file1_str,"line":57},"className":"class1","numArgs":4,"index":7}],"threadId":13,"threadName":"thread1"}"""
     )
 
     roundtrip(
       sourcePos1: SourcePosition,
-      """{"typehint":"LineSourcePosition","file":"/abc/def","line":57}"""
+      s"""{"typehint":"LineSourcePosition","file":$file1_str,"line":57}"""
     )
     roundtrip(
       sourcePos2: SourcePosition,
-      """{"typehint":"LineSourcePosition","file":"/abc/def","line":59}"""
+      s"""{"typehint":"LineSourcePosition","file":$file1_str,"line":59}"""
     )
     roundtrip(
       sourcePos3: SourcePosition,
@@ -437,17 +452,17 @@ class JerkFormatsSpec extends FlatSpec with Matchers
     )
     roundtrip(
       sourcePos4: SourcePosition,
-      """{"typehint":"OffsetSourcePosition","file":"/abc/def","offset":456}"""
+      s"""{"typehint":"OffsetSourcePosition","file":$file1_str,"offset":456}"""
     )
 
     roundtrip(
       breakPoint1: Breakpoint,
-      """{"file":"/abc/def","line":57}"""
+      s"""{"file":$file1_str,"line":57}"""
     )
 
     roundtrip(
       BreakpointList(List(breakPoint1), List(breakPoint2)): BreakpointList,
-      """{"active":[{"file":"/abc/def","line":57}],"pending":[{"file":"/abc/def","line":59}]}"""
+      s"""{"active":[{"file":$file1_str,"line":57}],"pending":[{"file":$file1_str,"line":59}]}"""
     )
 
     roundtrip(
@@ -526,34 +541,34 @@ class JerkFormatsSpec extends FlatSpec with Matchers
   it should "support search related responses" in {
     roundtrip(
       new SymbolSearchResults(List(methodSearchRes, typeSearchRes)): SymbolSearchResults,
-      """{"syms":[{"name":"abc","localName":"a","pos":{"typehint":"LineSourcePosition","file":"/abd","line":10},"typehint":"MethodSearchResult","ownerName":"ownerStr","declAs":{"typehint":"Method"}},{"name":"abc","localName":"a","pos":{"typehint":"LineSourcePosition","file":"/abd","line":10},"typehint":"TypeSearchResult","declAs":{"typehint":"Trait"}}]}"""
+      s"""{"syms":[{"name":"abc","localName":"a","pos":{"typehint":"LineSourcePosition","file":$abd_str,"line":10},"typehint":"MethodSearchResult","ownerName":"ownerStr","declAs":{"typehint":"Method"}},{"name":"abc","localName":"a","pos":{"typehint":"LineSourcePosition","file":$abd_str,"line":10},"typehint":"TypeSearchResult","declAs":{"typehint":"Trait"}}]}"""
     )
 
     roundtrip(
       new ImportSuggestions(List(List(methodSearchRes, typeSearchRes))): ImportSuggestions,
-      """{"symLists":[[{"name":"abc","localName":"a","pos":{"typehint":"LineSourcePosition","file":"/abd","line":10},"typehint":"MethodSearchResult","ownerName":"ownerStr","declAs":{"typehint":"Method"}},{"name":"abc","localName":"a","pos":{"typehint":"LineSourcePosition","file":"/abd","line":10},"typehint":"TypeSearchResult","declAs":{"typehint":"Trait"}}]]}"""
+      s"""{"symLists":[[{"name":"abc","localName":"a","pos":{"typehint":"LineSourcePosition","file":$abd_str,"line":10},"typehint":"MethodSearchResult","ownerName":"ownerStr","declAs":{"typehint":"Method"}},{"name":"abc","localName":"a","pos":{"typehint":"LineSourcePosition","file":$abd_str,"line":10},"typehint":"TypeSearchResult","declAs":{"typehint":"Trait"}}]]}"""
     )
 
     roundtrip(
       methodSearchRes: SymbolSearchResult,
-      """{"name":"abc","localName":"a","pos":{"typehint":"LineSourcePosition","file":"/abd","line":10},"typehint":"MethodSearchResult","ownerName":"ownerStr","declAs":{"typehint":"Method"}}"""
+      s"""{"name":"abc","localName":"a","pos":{"typehint":"LineSourcePosition","file":$abd_str,"line":10},"typehint":"MethodSearchResult","ownerName":"ownerStr","declAs":{"typehint":"Method"}}"""
     )
 
     roundtrip(
       typeSearchRes: SymbolSearchResult,
-      """{"name":"abc","localName":"a","pos":{"typehint":"LineSourcePosition","file":"/abd","line":10},"typehint":"TypeSearchResult","declAs":{"typehint":"Trait"}}"""
+      s"""{"name":"abc","localName":"a","pos":{"typehint":"LineSourcePosition","file":$abd_str,"line":10},"typehint":"TypeSearchResult","declAs":{"typehint":"Trait"}}"""
     )
   }
 
   it should "support ranges and semantic highlighting" in {
     roundtrip(
       new ERangePosition(batchSourceFile, 75, 70, 90): ERangePosition,
-      """{"file":"/abc","offset":75,"start":70,"end":90}"""
+      s"""{"file":"/abc","offset":75,"start":70,"end":90}"""
     )
 
     roundtrip(
       FileRange("/abc", 7, 9): FileRange,
-      """{"file":"/abc","start":7,"end":9}"""
+      s"""{"file":"/abc","start":7,"end":9}"""
     )
 
     roundtrip(
@@ -563,7 +578,7 @@ class JerkFormatsSpec extends FlatSpec with Matchers
         SymbolDesignation(11, 22, ClassSymbol)
       )
       ): SymbolDesignations,
-      """{"file":"/abc","syms":[{"start":7,"end":9,"symType":{"typehint":"VarFieldSymbol"}},{"start":11,"end":22,"symType":{"typehint":"ClassSymbol"}}]}"""
+      s"""{"file":$symFile_str,"syms":[{"start":7,"end":9,"symType":{"typehint":"VarFieldSymbol"}},{"start":11,"end":22,"symType":{"typehint":"ClassSymbol"}}]}"""
     )
   }
 
@@ -575,12 +590,12 @@ class JerkFormatsSpec extends FlatSpec with Matchers
 
     roundtrip(
       refactorEffect: RefactorEffect,
-      """{"procedureId":9,"refactorType":{"typehint":"AddImport"},"changes":[{"text":"aaa","typehint":"TextEdit","to":7,"from":5,"file":"/foo/abc"}],"status":"success"}"""
+      s"""{"procedureId":9,"refactorType":{"typehint":"AddImport"},"changes":[{"text":"aaa","typehint":"TextEdit","to":7,"from":5,"file":$file3_str}],"status":"success"}"""
     )
 
     roundtrip(
       refactorResult: RefactorResult,
-      """{"procedureId":7,"refactorType":{"typehint":"AddImport"},"touchedFiles":["/foo/abc","/abc/def"],"status":"success"}"""
+      s"""{"procedureId":7,"refactorType":{"typehint":"AddImport"},"touchedFiles":[$file3_str,$file1_str],"status":"success"}"""
     )
 
   }

--- a/jerk/src/test/scala/org/ensime/jerk/JerkFormatsSpec.scala
+++ b/jerk/src/test/scala/org/ensime/jerk/JerkFormatsSpec.scala
@@ -593,13 +593,13 @@ class JerkFormatsSpec extends FlatSpec with Matchers
     )
 
     roundtrip(
-      List(ImplicitConversionInfo(5, 6, symbolInfo)): List[ImplicitInfo],
-      """[{"typehint":"ImplicitConversionInfo","start":5,"end":6,"fun":{"name":"name","localName":"localName","type":{"name":"type1","fullName":"FOO.type1","typehint":"BasicTypeInfo","typeId":7,"outerTypeId":8,"typeArgs":[],"members":[],"declAs":{"typehint":"Method"}},"isCallable":false,"ownerTypeId":2}}]"""
+      ImplicitInfos(List(ImplicitConversionInfo(5, 6, symbolInfo))): ImplicitInfos,
+      """{"infos":[{"typehint":"ImplicitConversionInfo","start":5,"end":6,"fun":{"name":"name","localName":"localName","type":{"name":"type1","fullName":"FOO.type1","typehint":"BasicTypeInfo","typeId":7,"outerTypeId":8,"typeArgs":[],"members":[],"declAs":{"typehint":"Method"}},"isCallable":false,"ownerTypeId":2}}]}"""
     )
 
     roundtrip(
-      List(ImplicitParamInfo(5, 6, symbolInfo, List(symbolInfo, symbolInfo), true)): List[ImplicitInfo],
-      """[{"params":[{"name":"name","localName":"localName","type":{"name":"type1","fullName":"FOO.type1","typehint":"BasicTypeInfo","typeId":7,"outerTypeId":8,"typeArgs":[],"members":[],"declAs":{"typehint":"Method"}},"isCallable":false,"ownerTypeId":2},{"name":"name","localName":"localName","type":{"name":"type1","fullName":"FOO.type1","typehint":"BasicTypeInfo","typeId":7,"outerTypeId":8,"typeArgs":[],"members":[],"declAs":{"typehint":"Method"}},"isCallable":false,"ownerTypeId":2}],"typehint":"ImplicitParamInfo","fun":{"name":"name","localName":"localName","type":{"name":"type1","fullName":"FOO.type1","typehint":"BasicTypeInfo","typeId":7,"outerTypeId":8,"typeArgs":[],"members":[],"declAs":{"typehint":"Method"}},"isCallable":false,"ownerTypeId":2},"funIsImplicit":true,"end":6,"start":5}]"""
+      ImplicitInfos(List(ImplicitParamInfo(5, 6, symbolInfo, List(symbolInfo, symbolInfo), true))): ImplicitInfos,
+      """{"infos":[{"params":[{"name":"name","localName":"localName","type":{"name":"type1","fullName":"FOO.type1","typehint":"BasicTypeInfo","typeId":7,"outerTypeId":8,"typeArgs":[],"members":[],"declAs":{"typehint":"Method"}},"isCallable":false,"ownerTypeId":2},{"name":"name","localName":"localName","type":{"name":"type1","fullName":"FOO.type1","typehint":"BasicTypeInfo","typeId":7,"outerTypeId":8,"typeArgs":[],"members":[],"declAs":{"typehint":"Method"}},"isCallable":false,"ownerTypeId":2}],"typehint":"ImplicitParamInfo","fun":{"name":"name","localName":"localName","type":{"name":"type1","fullName":"FOO.type1","typehint":"BasicTypeInfo","typeId":7,"outerTypeId":8,"typeArgs":[],"members":[],"declAs":{"typehint":"Method"}},"isCallable":false,"ownerTypeId":2},"funIsImplicit":true,"end":6,"start":5}]}"""
     )
 
   }

--- a/swank/CHANGELOG.md
+++ b/swank/CHANGELOG.md
@@ -1,6 +1,9 @@
 Protocol Version: 0.8.15 (Must match version at ConnectionInfo.protocolVersion)
 
 Protocol Change Log:
+  0.8.16
+    Added swank:implicit-info
+    Added new symbol designation types: "implicitConversion" and "implicitParams"
   0.8.15
     Removed all *undo* requests: they were too unreliable
     Removed all *patch* requests: they were too unreliable

--- a/swank/src/main/scala/org/ensime/server/protocol/swank/SwankFormats.scala
+++ b/swank/src/main/scala/org/ensime/server/protocol/swank/SwankFormats.scala
@@ -82,7 +82,9 @@ object SwankProtocolCommon {
     "operator" -> OperatorFieldSymbol,
     "var" -> VarSymbol,
     "val" -> ValSymbol,
-    "functionCall" -> FunctionCallSymbol
+    "functionCall" -> FunctionCallSymbol,
+    "implicitConversion" -> ImplicitConversionSymbol,
+    "implicitParams" -> ImplicitParamsSymbol
   )
   private val reverseSourceSymbolMap: Map[SourceSymbol, String] =
     sourceSymbolMap.map { case (name, symbol) => symbol -> name }
@@ -469,6 +471,16 @@ object SwankProtocolResponse {
   }
   implicit val SymbolDesignationsFormat = SexpFormat[SymbolDesignations]
 
+  implicit val ImplicitConversionInfoHint = TypeHint[ImplicitConversionInfo](SexpSymbol("conversion"))
+  implicit val ImplicitParamInfoHint = TypeHint[ImplicitParamInfo](SexpSymbol("param"))
+  implicit object ImplicitInfoFormat extends TraitFormatAlt[ImplicitInfo] {
+    def write(i: ImplicitInfo): Sexp = i match {
+      case c: ImplicitConversionInfo => wrap(c)
+      case p: ImplicitParamInfo => wrap(p)
+    }
+    def read(hint: SexpSymbol, sexp: Sexp): ImplicitInfo = ???
+  }
+
   implicit object DebugVmStatusFormat extends TraitFormatAlt[DebugVmStatus] {
     def write(ti: DebugVmStatus): Sexp = ti match {
       case s: DebugVmSuccess => wrap(s)
@@ -488,6 +500,8 @@ object SwankProtocolResponse {
     case s: String => s.toSexp
     case list: List[_] if list.forall(_.isInstanceOf[ERangePosition]) =>
       list.asInstanceOf[List[ERangePosition]].toSexp
+    case list: List[_] if list.forall(_.isInstanceOf[ImplicitInfo]) =>
+      list.asInstanceOf[List[ImplicitInfo]].toSexp
 
     case VoidResponse => false.toSexp
 
@@ -577,6 +591,7 @@ object SwankProtocolRequest {
   implicit val ExecRefactorReqHint = TypeHint[ExecRefactorReq](SexpSymbol("swank:exec-refactor"))
   implicit val CancelRefactorReqHint = TypeHint[CancelRefactorReq](SexpSymbol("swank:cancel-refactor"))
   implicit val SymbolDesignationsReqHint = TypeHint[SymbolDesignationsReq](SexpSymbol("swank:symbol-designations"))
+  implicit val ImplicitInfoReqHint = TypeHint[ImplicitInfoReq](SexpSymbol("swank:implicit-info"))
   implicit val ExpandSelectionReqHint = TypeHint[ExpandSelectionReq](SexpSymbol("swank:expand-selection"))
   implicit val DebugActiveVmReqHint = TypeHint[DebugActiveVmReq.type](SexpSymbol("swank:debug-active-vm"))
   implicit val DebugStartReqHint = TypeHint[DebugStartReq](SexpSymbol("swank:debug-start"))
@@ -726,6 +741,7 @@ object SwankProtocolRequest {
   implicit def ExecRefactorReqFormat = SexpFormat[ExecRefactorReq]
   implicit def CancelRefactorReqFormat = SexpFormat[CancelRefactorReq]
   implicit def SymbolDesignationsReqFormat = SexpFormat[SymbolDesignationsReq]
+  implicit def ImplicitInfoReqFormat = SexpFormat[ImplicitInfoReq]
   implicit def ExpandSelectionReqFormat = SexpFormat[ExpandSelectionReq]
   implicit def DebugStartReqFormat = SexpFormat[DebugStartReq]
   implicit def DebugAttachReqFormat = SexpFormat[DebugAttachReq]
@@ -777,6 +793,7 @@ object SwankProtocolRequest {
           case s if s == ExecRefactorReqHint.hint => value.convertTo[ExecRefactorReq]
           case s if s == CancelRefactorReqHint.hint => value.convertTo[CancelRefactorReq]
           case s if s == SymbolDesignationsReqHint.hint => value.convertTo[SymbolDesignationsReq]
+          case s if s == ImplicitInfoReqHint.hint => value.convertTo[ImplicitInfoReq]
           case s if s == ExpandSelectionReqHint.hint => value.convertTo[ExpandSelectionReq]
           case s if s == DebugActiveVmReqHint.hint => DebugActiveVmReq
           case s if s == DebugStartReqHint.hint => value.convertTo[DebugStartReq]

--- a/swank/src/main/scala/org/ensime/server/protocol/swank/SwankFormats.scala
+++ b/swank/src/main/scala/org/ensime/server/protocol/swank/SwankFormats.scala
@@ -480,6 +480,10 @@ object SwankProtocolResponse {
     }
     def read(hint: SexpSymbol, sexp: Sexp): ImplicitInfo = ???
   }
+  implicit object ImplcitInfosFormat extends SexpFormat[ImplicitInfos] {
+    def write(o: ImplicitInfos): Sexp = o.infos.toSexp
+    def read(sexp: Sexp) = ???
+  }
 
   implicit object DebugVmStatusFormat extends TraitFormatAlt[DebugVmStatus] {
     def write(ti: DebugVmStatus): Sexp = ti match {
@@ -500,8 +504,6 @@ object SwankProtocolResponse {
     case s: String => s.toSexp
     case list: List[_] if list.forall(_.isInstanceOf[ERangePosition]) =>
       list.asInstanceOf[List[ERangePosition]].toSexp
-    case list: List[_] if list.forall(_.isInstanceOf[ImplicitInfo]) =>
-      list.asInstanceOf[List[ImplicitInfo]].toSexp
 
     case VoidResponse => false.toSexp
 
@@ -537,6 +539,7 @@ object SwankProtocolResponse {
     case value: RefactorFailure => value.toSexp
     case value: RefactorEffect => value.toSexp
     case value: RefactorResult => value.toSexp
+    case value: ImplicitInfos => value.toSexp
 
     case _ => throw new IllegalArgumentException(s"$msg is not a valid SWANK response")
   }

--- a/swank/src/test/scala/org/ensime/server/protocol/swank/SwankFormatsSpec.scala
+++ b/swank/src/test/scala/org/ensime/server/protocol/swank/SwankFormatsSpec.scala
@@ -196,6 +196,11 @@ class SwankFormatsSpec extends FlatSpec with Matchers with EnsimeTestData {
       ExpandSelectionReq(file1, 100, 200): RpcRequest
     )
 
+    unmarshal(
+      s"""(swank:implicit-info $file1_str (0 123))""",
+      ImplicitInfoReq(file1, OffsetRange(0, 123))
+    )
+
   }
 
   it should "unmarshal RpcDebugRequests" in {
@@ -579,6 +584,16 @@ class SwankFormatsSpec extends FlatSpec with Matchers with EnsimeTestData {
       ): SymbolDesignations,
       s"""(:file ${fileToWireString(symFile)} :syms ((varField 7 9) (class 11 22)))"""
     )
+
+    marshal(
+      List(ImplicitConversionInfo(5, 6, symbolInfo)): List[ImplicitInfo],
+      s"""((:type conversion :start 5 :end 6 :fun $symbolInfoStr))"""
+    )
+
+    marshal(
+      List(ImplicitParamInfo(5, 6, symbolInfo, List(symbolInfo, symbolInfo), true)): List[ImplicitInfo],
+      s"""((:type param :start 5 :end 6 :fun $symbolInfoStr :params ($symbolInfoStr $symbolInfoStr) :fun-is-implicit t))"""
+    )
   }
 
   it should "marshal refactoring messages" in {
@@ -596,7 +611,6 @@ class SwankFormatsSpec extends FlatSpec with Matchers with EnsimeTestData {
       refactorResult: RefactorResult,
       s"""(:procedure-id 7 :refactor-type addImport :touched-files ($file3_str $file1_str) :status success)"""
     )
-
   }
 
 }

--- a/swank/src/test/scala/org/ensime/server/protocol/swank/SwankFormatsSpec.scala
+++ b/swank/src/test/scala/org/ensime/server/protocol/swank/SwankFormatsSpec.scala
@@ -586,12 +586,12 @@ class SwankFormatsSpec extends FlatSpec with Matchers with EnsimeTestData {
     )
 
     marshal(
-      List(ImplicitConversionInfo(5, 6, symbolInfo)): List[ImplicitInfo],
+      ImplicitInfos(List(ImplicitConversionInfo(5, 6, symbolInfo))): ImplicitInfos,
       s"""((:type conversion :start 5 :end 6 :fun $symbolInfoStr))"""
     )
 
     marshal(
-      List(ImplicitParamInfo(5, 6, symbolInfo, List(symbolInfo, symbolInfo), true)): List[ImplicitInfo],
+      ImplicitInfos(List(ImplicitParamInfo(5, 6, symbolInfo, List(symbolInfo, symbolInfo), true))): ImplicitInfos,
       s"""((:type param :start 5 :end 6 :fun $symbolInfoStr :params ($symbolInfoStr $symbolInfoStr) :fun-is-implicit t))"""
     )
   }

--- a/swank/src/test/scala/org/ensime/server/protocol/swank/SwankTestData.scala
+++ b/swank/src/test/scala/org/ensime/server/protocol/swank/SwankTestData.scala
@@ -25,6 +25,8 @@ object SwankTestData extends EnsimeTestData {
 
   val symbolInfoStr = """(:name "name" :local-name "localName" :decl-pos nil :type """ + typeInfoStr + """ :is-callable nil :owner-type-id 2)"""
 
+  val implicitInfosStr = s"""((:type conversion :start 5 :end 6 :fun $symbolInfoStr) (:type param :start 7 :end 8 :fun $symbolInfoStr :params ($symbolInfoStr $symbolInfoStr) :fun-is-implicit t))"""
+
   val batchSourceFile_str = stringToWireString(batchSourceFile)
 
   val rangePos1Str = """(:file """ + batchSourceFile_str + """ :offset 75 :start 70 :end 90)"""

--- a/swank/src/test/scala/org/ensime/server/protocol/swank/SwankTestData.scala
+++ b/swank/src/test/scala/org/ensime/server/protocol/swank/SwankTestData.scala
@@ -20,7 +20,8 @@ object SwankTestData extends EnsimeTestData {
 
   val callCompletionInfoStr = """(:result-type """ + typeInfoStr + """ :param-sections ((:params (("ABC" """ + typeInfoStr + """)) :is-implicit nil)))"""
 
-  val symbolDesignationsStr = s"""(:file ${fileToWireString(symFile)} :syms ((object 7 9) (trait 11 22)))"""
+  val symFile_str = fileToWireString(symFile)
+  val symbolDesignationsStr = s"""(:file $symFile_str :syms ((object 7 9) (trait 11 22)))"""
 
   val symbolInfoStr = """(:name "name" :local-name "localName" :decl-pos nil :type """ + typeInfoStr + """ :is-callable nil :owner-type-id 2)"""
 


### PR DESCRIPTION
I don't know if this should be merged before or after the giant Akka refactor but I thought I'd create thsi PR for people to try out the UI  (look for the matching one in ensime/ensime-emacs#140).

This change adds two new types of semantic highlighting.  It also adds an API call `implicitInfo` that takes a range and returns all implicit conversions within the range. Among the information it returns is `SymbolInfo` objects that can be used to visit the location where the implicits are declared.

The thing that took me so long was trying to return the implicts' names as they would appear in source code so the editor could expand them. But it's harder than I thought so I'm giving up for now. 