### PR TITLE
@deprecated methods/apis use strikethrough face #363

### DIFF
--- a/api/src/main/scala/org/ensime/api/outgoing.scala
+++ b/api/src/main/scala/org/ensime/api/outgoing.scala
@@ -204,7 +204,7 @@ object SourceSymbol {
   val allSymbols: List[SourceSymbol] = List(
     ObjectSymbol, ClassSymbol, TraitSymbol, PackageSymbol, ConstructorSymbol, ImportedNameSymbol, TypeParamSymbol,
     ParamSymbol, VarFieldSymbol, ValFieldSymbol, OperatorFieldSymbol, VarSymbol, ValSymbol, FunctionCallSymbol,
-    ImplicitConversionSymbol, ImplicitParamsSymbol
+    ImplicitConversionSymbol, ImplicitParamsSymbol, DeprecatedSymbol
   )
 }
 
@@ -226,6 +226,7 @@ case object ValSymbol extends SourceSymbol
 case object FunctionCallSymbol extends SourceSymbol
 case object ImplicitConversionSymbol extends SourceSymbol
 case object ImplicitParamsSymbol extends SourceSymbol
+case object DeprecatedSymbol extends SourceSymbol
 
 sealed trait PosNeeded
 case object PosNeededNo extends PosNeeded
@@ -528,7 +529,7 @@ case class EnsimeImplementation(
 case class ConnectionInfo(
   pid: Option[Int] = None,
   implementation: EnsimeImplementation = EnsimeImplementation("ENSIME"),
-  version: String = "0.8.16"
+  version: String = "0.8.17"
 )
 
 sealed trait ImplicitInfo {

--- a/core/src/it/scala/org/ensime/core/SemanticHighlightingSpec.scala
+++ b/core/src/it/scala/org/ensime/core/SemanticHighlightingSpec.scala
@@ -106,6 +106,43 @@ class SemanticHighlightingSpec extends WordSpec with Matchers
       ))
     }
 
+    "highlight deprecated symbols" in withPresCompiler { (config, cc) =>
+      val sds = getSymbolDesignations(
+        config, cc, """
+            package com.example
+            class Test {
+              @deprecated("bad trait", "1.0")
+              trait BadTrait
+              class BadSubclass extends BadTrait
+              @deprecated("bad class", "1.0")
+              class BadClass(val data: String)
+              @deprecated("bad object", "1.0")
+              object BadObject
+              @deprecated("bad method", "1.0")
+              def foo(x: String) = { x + " foo" }
+              @deprecated("bad val", "1.0")
+              val badVal = 42
+              @deprecated("bad var", "1.0")
+              var badVar = 42
+              val a = new BadClass("someData")
+              val b = BadObject
+              val c = foo("a")
+              val d = badVal
+              val e = badVar
+            }
+          """,
+        List(DeprecatedSymbol)
+      )
+      assert(sds == List(
+        (DeprecatedSymbol, "BadTrait"),
+        (DeprecatedSymbol, "BadClass"),
+        (DeprecatedSymbol, "BadObject"),
+        (DeprecatedSymbol, "foo"),
+        (DeprecatedSymbol, "badVal"),
+        (DeprecatedSymbol, "badVar")
+      ))
+    }
+
     "highlight imported names" in withPresCompiler { (config, cc) =>
       val sds = getSymbolDesignations(
         config, cc, """

--- a/core/src/main/scala/org/ensime/core/SemanticHighlighting.scala
+++ b/core/src/main/scala/org/ensime/core/SemanticHighlighting.scala
@@ -50,36 +50,41 @@ class SemanticHighlighting(val global: RichPresentationCompiler) extends Compile
           add(TypeParamSymbol)
         } else if (sym.hasFlag(PARAM)) {
           add(ParamSymbol)
-        } else if (sym.hasFlag(ACCESSOR)) {
-          val under = sym.accessed
-          if (under.isVariable) {
-            add(VarFieldSymbol)
-          } else if (under.isValue) {
-            add(ValFieldSymbol)
+        } else {
+          if (sym.isDeprecated) {
+            add(DeprecatedSymbol)
+          }
+          if (sym.hasFlag(ACCESSOR)) {
+            val under = sym.accessed
+            if (under.isVariable) {
+              add(VarFieldSymbol)
+            } else if (under.isValue) {
+              add(ValFieldSymbol)
+            } else {
+              false
+            }
+          } else if (sym.isMethod) {
+            if (sym.nameString == "apply" || sym.nameString == "update") { true }
+            else if (sym.name.isOperatorName) {
+              add(OperatorFieldSymbol)
+            } else {
+              add(FunctionCallSymbol)
+            }
+          } else if (sym.isVariable && sym.isLocalToBlock) {
+            add(VarSymbol)
+          } else if (sym.isValue && sym.isLocalToBlock) {
+            add(ValSymbol)
+          } else if (sym.hasPackageFlag) {
+            add(PackageSymbol)
+          } else if (sym.isTrait) {
+            add(TraitSymbol)
+          } else if (sym.isClass) {
+            add(ClassSymbol)
+          } else if (sym.isModule) {
+            add(ObjectSymbol)
           } else {
             false
           }
-        } else if (sym.isMethod) {
-          if (sym.nameString == "apply" || sym.nameString == "update") { true }
-          else if (sym.name.isOperatorName) {
-            add(OperatorFieldSymbol)
-          } else {
-            add(FunctionCallSymbol)
-          }
-        } else if (sym.isVariable && sym.isLocalToBlock) {
-          add(VarSymbol)
-        } else if (sym.isValue && sym.isLocalToBlock) {
-          add(ValSymbol)
-        } else if (sym.hasPackageFlag) {
-          add(PackageSymbol)
-        } else if (sym.isTrait) {
-          add(TraitSymbol)
-        } else if (sym.isClass) {
-          add(ClassSymbol)
-        } else if (sym.isModule) {
-          add(ObjectSymbol)
-        } else {
-          false
         }
       }
 

--- a/swank/CHANGELOG.md
+++ b/swank/CHANGELOG.md
@@ -1,6 +1,8 @@
-Protocol Version: 0.8.15 (Must match version at ConnectionInfo.protocolVersion)
+Protocol Version: 0.8.17 (Must match version at ConnectionInfo.protocolVersion)
 
 Protocol Change Log:
+  0.8.17
+    Added new symbol designation type: "deprecated"
   0.8.16
     Added swank:implicit-info
     Added new symbol designation types: "implicitConversion" and "implicitParams"

--- a/swank/src/main/scala/org/ensime/server/protocol/swank/SwankFormats.scala
+++ b/swank/src/main/scala/org/ensime/server/protocol/swank/SwankFormats.scala
@@ -84,7 +84,8 @@ object SwankProtocolCommon {
     "val" -> ValSymbol,
     "functionCall" -> FunctionCallSymbol,
     "implicitConversion" -> ImplicitConversionSymbol,
-    "implicitParams" -> ImplicitParamsSymbol
+    "implicitParams" -> ImplicitParamsSymbol,
+    "deprecated" -> DeprecatedSymbol
   )
   private val reverseSourceSymbolMap: Map[SourceSymbol, String] =
     sourceSymbolMap.map { case (name, symbol) => symbol -> name }


### PR DESCRIPTION
For the moment, highlights deprecated classes, traits, objects and function calls. I would appreciate some hints to integrate it to the method completion dropdown.