### PR TITLE
Fix spark package parsing issue

### DIFF
--- a/core/src/main/scala/org/ensime/indexer/DescriptorParser.scala
+++ b/core/src/main/scala/org/ensime/indexer/DescriptorParser.scala
@@ -38,7 +38,7 @@ object DescriptorParser extends ParboiledParser[Descriptor] {
   } ~~> { (p, n) => ClassName(p, n) }
 
   private lazy val Package: Rule1[PackageName] = rule("Package") {
-    zeroOrMore(oneOrMore("a" - "z" | "A" - "Z" | "_" | "0" - "9").save ~ "/")
+    zeroOrMore(oneOrMore("a" - "z" | "A" - "Z" | "_" | "-" | "0" - "9").save ~ "/")
   } ~~> { PackageName.apply }
 
   private lazy val Name: Rule1[String] = rule("Name") {

--- a/core/src/test/scala/org/ensime/indexer/DescriptorParserSpec.scala
+++ b/core/src/test/scala/org/ensime/indexer/DescriptorParserSpec.scala
@@ -64,6 +64,10 @@ class DescriptorParserSpec extends FunSpec with Matchers with SLF4JLogging {
 
       // of course, SUN break their own rules for package names (capitals)
       assert(Try(parseType("Lcom/sun/tools/corba/se/idl/toJavaPortable/NameModifierImpl;")).isSuccess)
+
+      // hmmm, apache, what???? dashes in package names????
+      assert(Try(parseType("Lorg/spark-project/guava/annotations/VisibleForTesting;")).isSuccess)
+
     }
 
     it("should be invertible") {


### PR DESCRIPTION
Spark does some weird packaging in their jars, creating invalid package names containing dashes.
For now allow them so people can open spark projects.

See https://github.com/ensime/ensime-server/issues/1031
