### PR TITLE
HACK: Avoid keeping stale symbols when reloading a single file

### DIFF
--- a/core/src/main/scala/org/ensime/core/Analyzer.scala
+++ b/core/src/main/scala/org/ensime/core/Analyzer.scala
@@ -197,7 +197,7 @@ class Analyzer(
       }
       sender ! VoidResponse
     case TypecheckFileReq(fileInfo) =>
-      handleReloadFiles(List(fileInfo), async = true)
+      handleReloadFiles(List(fileInfo), async = false)
       sender ! VoidResponse
     case TypecheckFilesReq(files) =>
       handleReloadFiles(files.map(SourceFileInfo(_)), async = false)


### PR DESCRIPTION
This hack fixes #1052 for me, but I don't pretend to understand why since this is my first time looking at this code and at the presentation compiler. Basically, I noticed that [`Global#reload`](https://github.com/scala/scala/blob/2.11.x/src/interactive/scala/tools/nsc/interactive/Global.scala#L763-L769) (which is indirectly called in Ensime using `askReload`) does not remove the symbols corresponding to a previous loading of the current coding units, this is only done by [`Global#syncTopLevelSyms`](https://github.com/scala/scala/blob/2.11.x/src/interactive/scala/tools/nsc/interactive/Global.scala#L673-L689) which is called indirectly by [`Global#typedTree`](https://github.com/scala/scala/blob/2.11.x/src/interactive/scala/tools/nsc/interactive/Global.scala#L664-L671) which is itself called by [`Global#waitLoadedTyped`](https://github.com/scala/scala/blob/2.11.x/src/interactive/scala/tools/nsc/interactive/Global.scala#L1150-L1174) which happens to be called by Ensime when `async = false`(I have no idea what is supposed to be asynchronous or why that matters): https://github.com/ensime/ensime-server/blob/master/core/src/main/scala/org/ensime/core/Analyzer.scala#L300-L301

Anyway, this is surely not the right solution but I hope it can lead to someone figuring out what should be done exactly.