### PR TITLE
Fix prescomp race from #1052

### DIFF
--- a/.jvmopts
+++ b/.jvmopts
@@ -1,0 +1,4 @@
+-XX:MaxPermSize=256m
+-Xss2m
+-Xmx2g
+

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -18,8 +18,8 @@ install:
   - cmd: SET JDK_HOME=C:\Program Files\Java\jdk1.7.0
   - cmd: SET JAVA_HOME=C:\Program Files\Java\jdk1.7.0
   - cmd: SET PATH=C:\sbt\sbt\bin;%JDK_HOME%\bin;%PATH%
-  - cmd: SET SBT_OPTS=-XX:MaxPermSize=2g -Xmx4g -Xss2m
-  - cmd: SET AKKA_TEST_TIMEFACTOR=3
+  - cmd: SET SBT_OPTS=-XX:MaxPermSize=256m -Xss2m -Xmx2g
+  - cmd: SET AKKA_TEST_TIMEFACTOR=10
   - cmd: mkdir .ensime_cache
 build_script:
   - sbt clean compile test:compile it:compile

--- a/core/src/it/scala/org/ensime/fixture/ProjectFixture.scala
+++ b/core/src/it/scala/org/ensime/fixture/ProjectFixture.scala
@@ -22,16 +22,16 @@ object ProjectFixture extends Matchers {
     import testkit._
 
     val probe = TestProbe()
-    val project = TestActorRef[Project](Project(probe.ref), "project")
-
-    project ! ConnectionInfoReq
-    expectMsg(ConnectionInfo())
-
     probe.ignoreMsg {
       // these are too noisy for tests
       case e: SendBackgroundMessageEvent => true
       case e: DebugOutputEvent => true
     }
+
+    val project = TestActorRef[Project](Project(probe.ref), "project")
+
+    project ! ConnectionInfoReq
+    expectMsg(ConnectionInfo())
 
     probe.receiveN(3) should contain only (
       Broadcaster.Persist(AnalyzerReadyEvent),

--- a/core/src/main/scala/org/ensime/core/ImplicitAnalyzer.scala
+++ b/core/src/main/scala/org/ensime/core/ImplicitAnalyzer.scala
@@ -49,6 +49,7 @@ class ImplicitAnalyzer(val global: RichPresentationCompiler) {
 
   def implicitDetails(p: Position): List[ImplicitInfo] = {
     val typed = new global.Response[global.Tree]
+    // AskLoadedTyped below doesn't wait, since this code should run in the pres. compiler thread.
     global.askLoadedTyped(p.source, keepLoaded = true, typed)
     typed.get.left.toOption match {
       case Some(tree) =>

--- a/core/src/main/scala/org/ensime/core/RichPresentationCompiler.scala
+++ b/core/src/main/scala/org/ensime/core/RichPresentationCompiler.scala
@@ -110,7 +110,7 @@ trait RichCompilerControl extends CompilerControl with RefactoringControl with C
 
   def askLoadedTyped(f: SourceFile): Either[Tree, Throwable] = {
     val x = new Response[Tree]()
-    askLoadedTyped(f, x)
+    askLoadedTyped(f, true, x)
     x.get
   }
 

--- a/core/src/main/scala/org/ensime/core/SemanticHighlighting.scala
+++ b/core/src/main/scala/org/ensime/core/SemanticHighlighting.scala
@@ -162,6 +162,7 @@ class SemanticHighlighting(val global: RichPresentationCompiler) extends Compile
     requestedTypes: List[SourceSymbol]
   ): SymbolDesignations = {
     val typed = new Response[Tree]
+    // AskLoadedTyped below doesn't wait, since this code should run in the pres. compiler thread.
     askLoadedTyped(p.source, keepLoaded = true, typed)
     typed.get.left.toOption match {
       case Some(tree) =>

--- a/project/EnsimeBuild.scala
+++ b/project/EnsimeBuild.scala
@@ -64,7 +64,7 @@ object EnsimeBuild extends Build with JdkResolver {
     fork := true,
     parallelExecution in Test := true,
     testForkedParallel in Test := true,
-    javaOptions ++= Seq("-XX:MaxPermSize=256m", "-Xmx2g", "-XX:+UseConcMarkSweepGC"),
+    javaOptions := Seq("-Xss2m", "-XX:MaxPermSize=256m", "-Xmx2g"),
     javaOptions in run ++= yourkitAgent,
     javaOptions in Test += "-Dlogback.configurationFile=../logback-test.xml",
     testOptions in Test ++= noColorIfEmacs,


### PR DESCRIPTION
Fixes #1052

I think I got it right. I removed the Analyzer state that stashes all requests, it's simpler to rely on the locking provided by the pres compiler. This should keep operations from waiting for longer than they have to.

I checked the test case that @smarter mentioned and it's looking good.
