### PR TITLE
do not recreate InputStreamReaders as they can potentially buffer the

### DIFF
--- a/core/src/it/scala/org/ensime/fixture/ProjectFixture.scala
+++ b/core/src/it/scala/org/ensime/fixture/ProjectFixture.scala
@@ -26,6 +26,7 @@ object ProjectFixture extends Matchers {
       // these are too noisy for tests
       case e: SendBackgroundMessageEvent => true
       case e: DebugOutputEvent => true
+      case ClearAllScalaNotesEvent => true
     }
 
     val project = TestActorRef[Project](Project(probe.ref), "project")

--- a/core/src/it/scala/org/ensime/intg/BasicWorkflow.scala
+++ b/core/src/it/scala/org/ensime/intg/BasicWorkflow.scala
@@ -36,10 +36,7 @@ class BasicWorkflow extends WordSpec with Matchers
             project ! TypecheckFilesReq(List(fooFile))
             expectMsg(VoidResponse)
 
-            asyncHelper.receiveN(2) should contain only (
-              ClearAllScalaNotesEvent,
-              FullTypeCheckCompleteEvent
-            )
+            asyncHelper.expectMsg(FullTypeCheckCompleteEvent)
 
             //-----------------------------------------------------------------------------------------------
             // semantic highlighting
@@ -145,10 +142,7 @@ class BasicWorkflow extends WordSpec with Matchers
             project ! TypecheckFilesReq(List(fooFile))
             expectMsg(VoidResponse)
 
-            asyncHelper.receiveN(2) should contain only (
-              ClearAllScalaNotesEvent,
-              FullTypeCheckCompleteEvent
-            )
+            asyncHelper.expectMsg(FullTypeCheckCompleteEvent)
 
             project ! UsesOfSymbolAtPointReq(fooFile, 119) // point on testMethod
             expectMsgPF() {

--- a/server/src/main/scala/org/ensime/server/FramedStringProtocol.scala
+++ b/server/src/main/scala/org/ensime/server/FramedStringProtocol.scala
@@ -24,27 +24,26 @@ trait FramedStringProtocol extends Protocol with SLF4JLogging {
   }
 
   protected def readString(input: InputStream): String = {
-    val reader = new InputStreamReader(input, "UTF-8")
-
-    def fillArray(a: Array[Char]): Unit = {
+    def fillArray(a: Array[Byte]): Unit = {
       var n = 0
       while (n < a.length) {
-        val read = reader.read(a, n, a.length - n)
+        val read = input.read(a, n, a.length - n)
         if (read != -1) n += read
         else throw new EOFException("End of file reached in socket reader.")
       }
     }
 
-    val headerBuf = new Array[Char](6)
+    val headerBuf = new Array[Byte](6)
+
     fillArray(headerBuf)
-    val msgLen = Integer.valueOf(new String(headerBuf), 16).intValue()
+    val msgLen = Integer.valueOf(new String(headerBuf, "UTF-8"), 16).intValue()
     if (msgLen == 0)
       throw new IllegalStateException("Empty message read from socket!")
 
-    val buf: Array[Char] = new Array[Char](msgLen)
+    val buf: Array[Byte] = new Array[Byte](msgLen)
     fillArray(buf)
 
-    val request = new String(buf)
+    val request = new String(buf, "UTF-8")
     if (log.isTraceEnabled) {
       log.trace(request)
     }

--- a/server/src/test/scala/org/ensime/server/FramedStringProtocolSpec.scala
+++ b/server/src/test/scala/org/ensime/server/FramedStringProtocolSpec.scala
@@ -18,6 +18,14 @@ class FramedStringProtocolSpec extends FlatSpec with Matchers
     written shouldBe "000006foobar"
   }
 
+  it should "write multi-byte UTF-8 strings" in {
+    val out = new ByteArrayOutputStream
+    writeString("€", out)
+    val written = new String(out.toByteArray(), "UTF-8")
+
+    written shouldBe "000003€"
+  }
+
   it should "read framed strings" in {
     val in = new ByteArrayInputStream("000006foobar".getBytes("UTF-8"))
     val read = readString(in)
@@ -25,4 +33,10 @@ class FramedStringProtocolSpec extends FlatSpec with Matchers
     read shouldBe "foobar"
   }
 
+  it should "read multi-byte UTF-8 strings" in {
+    val in = new ByteArrayInputStream("000003€".getBytes("UTF-8"))
+    val read = readString(in)
+
+    read shouldBe "€"
+  }
 }

--- a/server/src/test/scala/org/ensime/server/WebServerSpec.scala
+++ b/server/src/test/scala/org/ensime/server/WebServerSpec.scala
@@ -79,7 +79,7 @@ class WebServerSpec extends HttpFlatSpec with WebServer {
       mediaType shouldBe MediaTypes.`text/xml` // hmm
 
       import ScalaXmlSupport._
-      import StreamlinedXml._
+      import StreamlinedXmlEquality._
 
       // err, the Equality[NodeSeq] doesn't seem to work... reformatting breaks it
       responseAs[NodeSeq] shouldEqual
@@ -87,7 +87,14 @@ class WebServerSpec extends HttpFlatSpec with WebServer {
           <head/>
           <body>
             <h1>ENSIME: Your Project's Documention</h1>
-            <ul><li><a href="docs/bar-javadoc.jar/index.html">bar-javadoc.jar</a> </li><li><a href="docs/foo-javadoc.jar/index.html">foo-javadoc.jar</a> </li></ul>
+            <ul>
+              <li>
+                <a href="docs/bar-javadoc.jar/index.html">bar-javadoc.jar</a>
+              </li>
+              <li>
+                <a href="docs/foo-javadoc.jar/index.html">foo-javadoc.jar</a>
+              </li>
+            </ul>
           </body>
         </html>
     }


### PR DESCRIPTION
underlying stream, as discussed in
https://github.com/ensime/ensime-emacs/pull/206