### PR TITLE
Encode symbols when looking them up in indexer

### DIFF
--- a/core/src/main/scala/org/ensime/model/Helpers.scala
+++ b/core/src/main/scala/org/ensime/model/Helpers.scala
@@ -94,11 +94,11 @@ trait Helpers { self: Global =>
     def typeIndexerName(sym: Symbol): String = {
       val owner = sym.owner
       if (owner.isRoot || owner.isRootPackage) {
-        sym.nameString
+        sym.encodedName
       } else if (owner.hasPackageFlag) {
-        owner.fullName + "." + sym.nameString
+        owner.fullName + "." + sym.encodedName
       } else {
-        typeIndexerName(owner) + "$" + sym.nameString
+        typeIndexerName(owner) + "$" + sym.encodedName
       }
     }
 
@@ -107,7 +107,7 @@ trait Helpers { self: Global =>
     } else if (sym.isModule) {
       typeIndexerName(sym) + "$"
     } else {
-      symbolIndexerName(sym.owner) + "." + sym.nameString
+      symbolIndexerName(sym.owner) + "." + sym.encodedName
     }
   }
 


### PR DESCRIPTION
Fix #835

This seems to work in most cases :-)   The exception is operators on strings etc. which try to look up things like `java.lang.String.$plus`. But that looks like a separate issue.
