### PR TITLE
fix for "localhost" being broken in java 7/8 u45

### DIFF
--- a/server/src/main/scala/org/ensime/server/tcp/TCPServer.scala
+++ b/server/src/main/scala/org/ensime/server/tcp/TCPServer.scala
@@ -25,7 +25,7 @@ class TCPServer(
 
   var activeConnections = 0
 
-  IO(Tcp) ! Bind(self, new InetSocketAddress("localhost", 0))
+  IO(Tcp) ! Bind(self, new InetSocketAddress("127.0.0.1", 0))
 
   def receive = {
     case b @ Bound(localAddress) =>


### PR DESCRIPTION
Using "localhost" is broken in java 7/8 u45. In certain situations, Java lists the local interfaces and takes one at a certain numeric index as a super naive approach to determine the "localhost" ip address. This can break down for users who have additional network interfaces changing the order. Here's the issue https://bugs.openjdk.java.net/browse/JDK-8080819

I have VPN network interfaces, which trigger the bug. In my case java resolves "localhost" to my local network ip address "192.168.1.x" instead of "127.0.0.1" and ensime-server binds to 192.168.1.x. ensime-sublime however tries to connect to 127.0.0.1 so the connect fails.