### PR TITLE
Fix #1056: locate source of imported Java classes

### DIFF
--- a/core/src/it/scala/org/ensime/intg/BasicWorkflow.scala
+++ b/core/src/it/scala/org/ensime/intg/BasicWorkflow.scala
@@ -186,7 +186,7 @@ class BasicWorkflow extends WordSpec with Matchers
                 BasicTypeInfo("Bloo$", _: Int, DeclaredAs.Object, "org.example.Bloo$", List(), List(), Some(_), None),
                 BasicTypeInfo("CaseClassWithCamelCaseName", _: Int, DeclaredAs.Class, "org.example.CaseClassWithCamelCaseName", List(), List(), Some(_), None),
                 BasicTypeInfo("CaseClassWithCamelCaseName$", _: Int, DeclaredAs.Object, "org.example.CaseClassWithCamelCaseName$", List(), List(), Some(_), None),
-                BasicTypeInfo("Foo", _: Int, DeclaredAs.Class, "org.example.Foo", List(), List(), None, None),
+                BasicTypeInfo("Foo", _: Int, DeclaredAs.Class, "org.example.Foo", List(), List(), Some(_), None),
                 BasicTypeInfo("Foo$", _: Int, DeclaredAs.Object, "org.example.Foo$", List(), List(), Some(_), None),
                 BasicTypeInfo("package$", _: Int, DeclaredAs.Object, "org.example.package$", List(), List(), None, None),
                 BasicTypeInfo("package$", _: Int, DeclaredAs.Object, "org.example.package$", List(), List(), None, None)))) =>

--- a/core/src/main/scala/org/ensime/model/ModelBuilders.scala
+++ b/core/src/main/scala/org/ensime/model/ModelBuilders.scala
@@ -42,6 +42,16 @@ trait ModelBuilders { self: RichPresentationCompiler =>
   }
 
   def locateSymbolPos(sym: Symbol, needPos: PosNeeded): Option[SourcePosition] = {
+    _locateSymbolPos(sym, needPos).orElse({
+      logger.debug(s"search $sym: Try Companion")
+      sym.companionSymbol match {
+        case NoSymbol => None
+        case s: Symbol => _locateSymbolPos(s, needPos)
+      }
+    })
+  }
+
+  def _locateSymbolPos(sym: Symbol, needPos: PosNeeded): Option[SourcePosition] = {
     if (sym == NoSymbol || needPos == PosNeededNo)
       None
     else if (sym.pos != NoPosition) {


### PR DESCRIPTION
The problem was that there is  both a "java.io.File" class and "java.io.File" object. But there is obviously no "/java/io/File$.class" in the JRE jars.

Another way to fix this could be to have the indexer associate java "objects" to the appropriate .class files.
