### PR TITLE
Fix #997 : typeAt works on Import trees

### DIFF
--- a/core/src/main/scala/org/ensime/core/RichPresentationCompiler.scala
+++ b/core/src/main/scala/org/ensime/core/RichPresentationCompiler.scala
@@ -350,8 +350,10 @@ class RichPresentationCompiler(
   }
 
   protected def typeAt(p: Position): Option[Type] = {
-    val tree = wrapTypedTreeAt(p)
-    typeOfTree(tree)
+    wrapTypedTreeAt(p) match {
+      case Import(_, _) => symbolAt(p).map(_.tpe)
+      case tree => typeOfTree(tree)
+    }
   }
 
   protected def typeByName(name: String): Option[Type] =
@@ -407,7 +409,7 @@ class RichPresentationCompiler(
             }
             List(locate(pos, expr))
           } else {
-            selectors.filter(_.namePos < pos.point).sortBy(_.namePos).lastOption map { sel =>
+            selectors.filter(_.namePos <= pos.point).sortBy(_.namePos).lastOption map { sel =>
               val tpe = stabilizedType(expr)
               List(tpe.member(sel.name), tpe.member(sel.name.toTypeName))
             } getOrElse Nil

--- a/core/src/main/scala/org/ensime/model/Helpers.scala
+++ b/core/src/main/scala/org/ensime/model/Helpers.scala
@@ -123,10 +123,14 @@ trait Helpers { self: Global =>
       }
     }
     val typeSym = tpe.typeSymbol
+    val prefix =
+      if (typeSym.enclosingPackage == NoSymbol)
+        ""
+      else typeSym.enclosingPackage.fullName + "."
     if (typeSym.isNestedClass) {
-      typeSym.enclosingPackage.fullName + "." + nestedClassName(typeSym)
+      prefix + nestedClassName(typeSym)
     } else {
-      typeSym.enclosingPackage.fullName + "." + typeShortName(typeSym)
+      prefix + typeShortName(typeSym)
     }
   }
 


### PR DESCRIPTION
Fix #997   Hovering on package names or imported classes isn't super useful but at least we don't return `nil` now. Hovering over an imported class member is what's important.
