### PR TITLE
Remove ".package" when indexing symbol names, for good

### DIFF
--- a/core/src/it/scala/org/ensime/indexer/SearchServiceSpec.scala
+++ b/core/src/it/scala/org/ensime/indexer/SearchServiceSpec.scala
@@ -81,6 +81,11 @@ class SearchServiceSpec extends WordSpec with Matchers
       )
 
       searchesClasses(
+        "org.example.Blue$",
+        "o e blue"
+      )
+
+      searchesClasses(
         "org.example.CaseClassWithCamelCaseName",
         "CaseClassWith", "caseclasswith",
         "o e Case", "o.e.caseclasswith",
@@ -90,10 +95,14 @@ class SearchServiceSpec extends WordSpec with Matchers
 
     "return results from package objects" in withSearchService { implicit service =>
       searchClasses(
-        "org.example.Blip",
+        "org.example.Blip$",
         "Blip"
       )
 
+      searchClasses(
+        "org.example.Blop",
+        "Blop"
+      )
     }
   }
 

--- a/core/src/it/scala/org/ensime/intg/BasicWorkflow.scala
+++ b/core/src/it/scala/org/ensime/intg/BasicWorkflow.scala
@@ -188,6 +188,8 @@ class BasicWorkflow extends WordSpec with Matchers
               case Some(PackageInfo("example", "org.example", List(
                 BasicTypeInfo("Bloo", _: Int, DeclaredAs.Class, "org.example.Bloo", List(), List(), Some(_), None),
                 BasicTypeInfo("Bloo$", _: Int, DeclaredAs.Object, "org.example.Bloo$", List(), List(), Some(_), None),
+                BasicTypeInfo("Blue", _: Int, DeclaredAs.Class, "org.example.Blue", List(), List(), Some(_), None),
+                BasicTypeInfo("Blue$", _: Int, DeclaredAs.Object, "org.example.Blue$", List(), List(), Some(_), None),
                 BasicTypeInfo("CaseClassWithCamelCaseName", _: Int, DeclaredAs.Class, "org.example.CaseClassWithCamelCaseName", List(), List(), Some(_), None),
                 BasicTypeInfo("CaseClassWithCamelCaseName$", _: Int, DeclaredAs.Object, "org.example.CaseClassWithCamelCaseName$", List(), List(), Some(_), None),
                 BasicTypeInfo("Foo", _: Int, DeclaredAs.Class, "org.example.Foo", List(), List(), Some(_), None),

--- a/core/src/main/scala/org/ensime/indexer/SearchService.scala
+++ b/core/src/main/scala/org/ensime/indexer/SearchService.scala
@@ -171,7 +171,7 @@ class SearchService(
             val internal = field.clazz.internalString
             FqnSymbol(None, name, path, field.name.fqnString, None, Some(internal), sourceUri, clazz.source.line)
           } ::: depickler.getTypeAliases.toList.filter(_.access == Public).map { rawType =>
-            FqnSymbol(None, name, path, rawType.fqn, None, None, sourceUri, None)
+            FqnSymbol(None, name, path, rawType.fqnString, None, None, sourceUri, None)
           }
 
     }

--- a/core/src/main/scala/org/ensime/model/Helpers.scala
+++ b/core/src/main/scala/org/ensime/model/Helpers.scala
@@ -102,13 +102,18 @@ trait Helpers { self: Global =>
       }
     }
 
-    if (sym.isType) {
+    val name = if (sym.isType) {
       typeIndexerName(sym)
     } else if (sym.isModule) {
       typeIndexerName(sym) + "$"
     } else {
       symbolIndexerName(sym.owner) + "." + sym.encodedName
     }
+    name.replaceAll("\\.package\\$\\$", ".")
+      .replaceAll("\\.package\\$\\.", ".")
+      .replaceAll("\\.package\\$(?!$)", ".")
+      .replaceAll("\\.package\\.", ".")
+      .replaceAll("\\.package$", ".package\\$")
   }
 
   /**
@@ -122,6 +127,7 @@ trait Helpers { self: Global =>
         case None => typeShortName(sym)
       }
     }
+
     val typeSym = tpe.typeSymbol
     val prefix =
       if (typeSym.enclosingPackage == NoSymbol)

--- a/core/src/test/scala/org/ensime/indexer/ClassNameSpec.scala
+++ b/core/src/test/scala/org/ensime/indexer/ClassNameSpec.scala
@@ -1,0 +1,19 @@
+package org.ensime.indexer
+
+import org.scalatest._
+
+class ClassNameSpec extends WordSpec with Matchers {
+  "ClassName" should {
+    "remove \"package\" from FQNs" in {
+      ClassName(PackageName(List("org", "example")), s"package$$Class").fqnString shouldBe "org.example.Class"
+      ClassName(PackageName(List("org", "example")), "package$Class$Subclass").fqnString shouldBe "org.example.Class$Subclass"
+      ClassName(PackageName(List("org", "example", "package")), "Class").fqnString shouldBe "org.example.Class"
+      ClassName(PackageName(List("org", "example", "package$")), "Class").fqnString shouldBe "org.example.Class"
+    }
+
+    "preserve the FQN of package objects" in {
+      ClassName(PackageName(List("org.example")), "package").fqnString shouldBe "org.example.package$"
+      ClassName(PackageName(List("org.example")), "package$").fqnString shouldBe "org.example.package$"
+    }
+  }
+}

--- a/core/src/test/scala/org/ensime/indexer/MethodNameSpec.scala
+++ b/core/src/test/scala/org/ensime/indexer/MethodNameSpec.scala
@@ -1,0 +1,12 @@
+package org.ensime.indexer
+
+import org.scalatest._
+
+class MemberNameSpec extends WordSpec with Matchers {
+  "MemberName" should {
+    "remove \"package\" from FQNs" in {
+      MemberName(ClassName(PackageName(List("org", "example")), "package"), "member").fqnString shouldBe "org.example.member"
+      MemberName(ClassName(PackageName(List("org", "example")), "package$"), "member").fqnString shouldBe "org.example.member"
+    }
+  }
+}

--- a/testing/simple/src/main/scala/org/example/Foo.scala
+++ b/testing/simple/src/main/scala/org/example/Foo.scala
@@ -20,3 +20,4 @@ object Foo extends App {
 // for SearchServiceSpec
 case class CaseClassWithCamelCaseName()
 case class Bloo()
+case object Blue

--- a/testing/simple/src/main/scala/org/example/package.scala
+++ b/testing/simple/src/main/scala/org/example/package.scala
@@ -2,4 +2,5 @@ package org
 
 package object example {
   case object Blip
+  case class Blop()
 }


### PR DESCRIPTION
Fir #959
- Remove ".package" from type-alias symbols
- Fix symbol position lookup