### PR TITLE
Temporarily disable java events.

### DIFF
--- a/core/src/main/scala/org/ensime/core/JavaAnalyzer.scala
+++ b/core/src/main/scala/org/ensime/core/JavaAnalyzer.scala
@@ -33,8 +33,10 @@ class JavaAnalyzer(
 
     // legacy clients expect to see AnalyzerReady and a
     // FullTypeCheckCompleteEvent on connection.
-    broadcaster ! Broadcaster.Persist(AnalyzerReadyEvent)
-    broadcaster ! Broadcaster.Persist(FullTypeCheckCompleteEvent)
+
+    // TODO re-enable when elisp tests go green
+    //broadcaster ! Broadcaster.Persist(AnalyzerReadyEvent)
+    //broadcaster ! Broadcaster.Persist(FullTypeCheckCompleteEvent)
   }
 
   override def postStop(): Unit = {


### PR DESCRIPTION
This may be contributing to the cluster-cuss of test breakage in ensime-emacs. Disable until we get clarity.