### PR TITLE
#1068 scalariform dies if it doesn't like the input

### DIFF
--- a/core/src/it/scala/org/ensime/core/RefactoringHandlerSpec.scala
+++ b/core/src/it/scala/org/ensime/core/RefactoringHandlerSpec.scala
@@ -96,6 +96,24 @@ class RefactoringHandlerSpec extends WordSpec with Matchers
       assert(formatted === expectedContents)
     }
 
+    "not format invalid files" in withAnalyzer { (config, analyzerRef) =>
+      val file = srcFile(config, "abc.scala", contents(
+        "package blah",
+        "invalid scala syntax"
+      ), write = true, encoding = encoding)
+
+      val analyzer = analyzerRef.underlyingActor
+
+      analyzer.handleFormatFiles(List(new File(file.path)))
+      val fileContents = readSrcFile(file, encoding)
+
+      val expectedContents = contents(
+        "package blah",
+        "invalid scala syntax"
+      )
+      assert(fileContents === expectedContents)
+    }
+
     //
     // core/src/main/scala/org/ensime/core/Refactoring.scala#L.239
     //


### PR DESCRIPTION
ScalaFormatter.format throws ScalaParserException. When this happens formatting will not be applied and original file content will be returned. I've provided test for this issue.