### PR TITLE
Fix a bug breaking purely in-memory files.

### DIFF
--- a/core/src/main/scala/org/ensime/core/Analyzer.scala
+++ b/core/src/main/scala/org/ensime/core/Analyzer.scala
@@ -256,16 +256,12 @@ class Analyzer(
   }
 
   def handleReloadFiles(files: List[SourceFileInfo]): RpcResponse = {
-    val missingFiles = files.filterNot(FileUtils.exists)
+    val (existing, missingFiles) = files.partition(FileUtils.exists)
     if (missingFiles.nonEmpty) {
       val missingFilePaths = missingFiles.map { f => "\"" + f.file + "\"" }.mkString(",")
       EnsimeServerError(s"file(s): $missingFilePaths do not exist")
     } else {
-
-      val (javas, scalas) = files.filter(_.file.exists).partition(
-        _.file.getName.endsWith(".java")
-      )
-
+      val (javas, scalas) = existing.partition(_.file.getName.endsWith(".java"))
       if (scalas.nonEmpty) {
         val sourceFiles = scalas.map(createSourceFile)
         scalaCompiler.askReloadFiles(sourceFiles)

--- a/core/src/main/scala/org/ensime/core/Completion.scala
+++ b/core/src/main/scala/org/ensime/core/Completion.scala
@@ -41,6 +41,7 @@ import akka.pattern.Patterns
 import akka.util.Timeout
 import org.ensime.api._
 import org.ensime.util.Arrays
+import org.ensime.util.InMemorySourceFile
 
 import scala.collection.mutable
 import scala.concurrent.duration._
@@ -150,8 +151,8 @@ trait CompletionControl {
 
   private def spliceSource(s: SourceFile, start: Int, end: Int,
     replacement: String): SourceFile = {
-    new BatchSourceFile(
-      s.file,
+    new InMemorySourceFile(
+      s.file.path,
       Arrays.splice(s.content, start, end, replacement.toArray)
     )
   }

--- a/core/src/main/scala/org/ensime/util/FileUtil.scala
+++ b/core/src/main/scala/org/ensime/util/FileUtil.scala
@@ -7,9 +7,17 @@ import java.nio.charset.Charset
 import org.apache.commons.vfs2.FileObject
 
 import scala.collection.mutable
+import scala.reflect.internal.util.{ BatchSourceFile, SourceFile }
 
 import org.ensime.api._
 import org.ensime.util.file._
+
+/**
+ *  Wrap BatchSourceFile to allow access to only the (String, Array[Char])
+ *  constructor, which creates an in-memory source file.
+ */
+class InMemorySourceFile(path: String, content: Seq[Char])
+  extends BatchSourceFile(path, content.toArray) {}
 
 object RichFileObject {
   implicit class RichFileObject(val fo: FileObject) extends AnyVal {


### PR DESCRIPTION
It turns out that passing a string to BatchSourceFile constructor is the magic password to force it to use a VirtualFile internally. After this PR, completion should work for in-memory files with no backing disk file. 