### PR TITLE
Restore unsaved file support.

### DIFF
--- a/core/src/it/scala/org/ensime/intg/UnsavedFileTest.scala
+++ b/core/src/it/scala/org/ensime/intg/UnsavedFileTest.scala
@@ -1,0 +1,56 @@
+package org.ensime.intg
+
+import akka.event.slf4j.SLF4JLogging
+import org.apache.commons.io.FileUtils
+import org.ensime.api._
+import org.ensime.fixture._
+import org.scalatest.{ Matchers, WordSpec }
+import org.ensime.util.file._
+
+/**
+ * Verifies common operations work correctly for unsaved files.
+ */
+class UnsavedFileTest extends WordSpec with Matchers
+    with IsolatedEnsimeConfigFixture
+    with IsolatedTestKitFixture
+    with IsolatedProjectFixture
+    with SLF4JLogging {
+
+  val original = EnsimeConfigFixture.TimingTestProject
+
+  "ensime-server" should {
+    "handle unsaved files" in {
+      withEnsimeConfig { implicit config =>
+        withTestKit { implicit testkit =>
+          withProject { (project, asyncHelper) =>
+            import testkit._
+
+            val sourceRoot = scalaMain(config)
+            val missing = sourceRoot / "p1/Missing.scala"
+
+            assert(!missing.exists)
+
+            val inMemory = SourceFileInfo(
+              missing, Some("class Foo { def main = { System.out.println(1) } }"), None
+            )
+
+            project ! TypecheckFileReq(inMemory)
+            expectMsg(VoidResponse)
+            asyncHelper.expectMsg(FullTypeCheckCompleteEvent)
+
+            project ! SymbolDesignationsReq(Right(inMemory), 0, 50, SourceSymbol.allSymbols)
+            expectMsgPF() {
+              case SymbolDesignations(inMemory.file, syms: List[SymbolDesignation]) if syms.nonEmpty =>
+            }
+
+            project ! CompletionsReq(inMemory, 27, 0, false, false)
+            expectMsgPF() {
+              case CompletionInfoList("Sy", candidates) if candidates.exists(_.name == "System") =>
+            }
+          }
+        }
+      }
+    }
+  }
+
+}

--- a/core/src/main/scala/org/ensime/core/Analyzer.scala
+++ b/core/src/main/scala/org/ensime/core/Analyzer.scala
@@ -181,7 +181,7 @@ class Analyzer(
       sender ! handleRefactorExec(req)
     case req: CancelRefactorReq =>
       sender ! handleRefactorCancel(req)
-    case CompletionsReq(fileInfo, point, maxResults, caseSens, reload) =>
+    case CompletionsReq(fileInfo, point, maxResults, caseSens, _reload) =>
       reporter.disable()
       sender ! scalaCompiler.askCompletionsAt(pos(fileInfo, point), maxResults, caseSens)
     case UsesOfSymbolAtPointReq(file, point) =>

--- a/core/src/main/scala/org/ensime/core/RichPresentationCompiler.scala
+++ b/core/src/main/scala/org/ensime/core/RichPresentationCompiler.scala
@@ -50,6 +50,9 @@ import org.slf4j.LoggerFactory
 
 import scala.collection.mutable
 import scala.reflect.internal.util.{ BatchSourceFile, RangePosition, SourceFile }
+import scala.reflect.io.PlainFile
+import scala.reflect.io.VirtualFile
+
 import scala.tools.nsc.Settings
 import scala.tools.nsc.interactive.{ CompilerControl, Global }
 import scala.tools.nsc.io.AbstractFile
@@ -227,19 +230,19 @@ trait RichCompilerControl extends CompilerControl with RefactoringControl with C
   def createSourceFile(file: SourceFileInfo): BatchSourceFile = file match {
     case SourceFileInfo(f, None, None) =>
       new BatchSourceFile(
-        AbstractFile.getFile(f.getPath),
+        new PlainFile(f.getPath),
         f.readString()(charset).toCharArray
       )
 
     case SourceFileInfo(f, Some(contents), None) =>
       new BatchSourceFile(
-        AbstractFile.getFile(f.getPath),
+        new PlainFile(f.getPath),
         contents.toCharArray
       )
 
     case SourceFileInfo(f, None, Some(contentsIn)) =>
       new BatchSourceFile(
-        AbstractFile.getFile(f.getPath),
+        new PlainFile(f.getPath),
         contentsIn.readString()(charset).toCharArray
       )
   }


### PR DESCRIPTION
Turns out explicitly passing plain-old PlainFiles does the trick. Virtual file not necessary, and we avoid the PlainFile vs VirtualFile nonsense of #1160. Plus a test.