### PR TITLE
add file modification time to a diff header

### DIFF
--- a/core/src/it/scala/org/ensime/core/RefactoringHandlerSpec.scala
+++ b/core/src/it/scala/org/ensime/core/RefactoringHandlerSpec.scala
@@ -1,6 +1,8 @@
 package org.ensime.core
 
 import java.io.File
+import java.text.SimpleDateFormat
+import java.util.Date
 import org.scalatest._
 
 import org.ensime.api._
@@ -273,9 +275,11 @@ class RefactoringHandlerSpec extends WordSpec with Matchers
           case _ => fail()
         }
 
+        val sdf = new SimpleDateFormat("yyyy-MM-dd hh:mm:ss Z")
+        val t = sdf.format(new Date((new File(file.path)).lastModified()))
         val diffContents = diffFile.readString()
-        val expectedContents = s"""|--- ${file.path}
-                                   |+++ ${file.path}
+        val expectedContents = s"""|--- ${file.path}	${t}
+                                   |+++ ${file.path}	${t}
                                    |@@ -1,3 +1,2 @@
                                    |-import java.lang.Integer.{valueOf => vo}
                                    |-import java.lang.Integer.toBinaryString

--- a/core/src/it/scala/org/ensime/util/DiffUtilSpec.scala
+++ b/core/src/it/scala/org/ensime/util/DiffUtilSpec.scala
@@ -20,8 +20,8 @@ class DiffUtilSpec extends WordSpec with Matchers {
       val a = new File("a").getAbsolutePath()
       val b = new File("b").getAbsolutePath()
       val expectedDiff =
-        s"""|--- $a
-            |+++ $b
+        s"""|--- $a	1970-01-01 12:00:00 +0000
+            |+++ $b	1970-01-01 12:00:00 +0000
             |@@ -1,3 +1,3 @@
             | line1
             |-line2

--- a/core/src/main/scala/org/ensime/util/DiffUtil.scala
+++ b/core/src/main/scala/org/ensime/util/DiffUtil.scala
@@ -1,15 +1,28 @@
 package org.ensime.util
 
 import java.io.File
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.TimeZone
 
 object DiffUtil {
 
   def compareContents(original: Seq[String], revised: Seq[String], originalFile: File = new File("a"), revisedFile: File = new File("b")): String = {
     import collection.JavaConverters._
     val diff = difflib.DiffUtils.diff(original.asJava, revised.asJava)
-    val originalName = originalFile.getAbsolutePath()
-    val revisedName = revisedFile.getAbsolutePath()
+    val originalInfo = originalFile.getAbsolutePath() + "\t" + fileModificationTimeOrEpoch(originalFile)
+    val revisedInfo = revisedFile.getAbsolutePath() + "\t" + fileModificationTimeOrEpoch(revisedFile)
     if (diff.getDeltas.isEmpty) ""
-    else difflib.DiffUtils.generateUnifiedDiff(originalName, revisedName, original.asJava, diff, 1).asScala.mkString("\n")
+    else difflib.DiffUtils.generateUnifiedDiff(originalInfo, revisedInfo, original.asJava, diff, 1).asScala.mkString("\n")
+  }
+
+  def fileModificationTimeOrEpoch(file: File): String = {
+    val format = new SimpleDateFormat("yyyy-MM-dd hh:mm:ss Z")
+    if (file.exists)
+      format.format(new Date(file.lastModified()))
+    else {
+      format.setTimeZone(TimeZone.getTimeZone("UTC"))
+      format.format(new Date(0L))
+    }
   }
 }


### PR DESCRIPTION
fix a bug in DiffUtil. 
`patch -p0 <diff ` is quite happy with a currently generated diff. However emacs `diff-mode` expects `tab` and  a timestamp after the file name in the diff header as per http://www.gnu.org/software/diffutils/manual/html_node/Detailed-Unified.html