### PR TITLE
Improved support for case class navigation

### DIFF
--- a/testing/simple/src/main/scala/org/example/Bar.scala
+++ b/testing/simple/src/main/scala/org/example/Bar.scala
@@ -1,0 +1,13 @@
+package org.example
+
+object Bar extends App {
+  case class Foo(bar: String, baz: Int)
+  object Bla {
+    val foo: Foo = Foo(
+      bar = "Bar",
+      baz = 123
+    )
+
+    val fooUpd = foo.copy(bar = foo.bar.reverse)
+  }
+}


### PR DESCRIPTION
When symbol under cursor is member field of the case
class then function symbol under cursor (M-. or Control+Left-Click)
jumps to case class definition