### PR TITLE
Ensure that repeated ConnectionInfoReq calls do not cause error

### DIFF
--- a/core/src/main/scala/org/ensime/core/Project.scala
+++ b/core/src/main/scala/org/ensime/core/Project.scala
@@ -135,6 +135,10 @@ class Project(
     case m: RpcDebuggerRequest => debugger forward m
     case m: RpcSearchRequest => indexer forward m
     case m: DocSigPair => docs forward m
+
+    // added here to prevent errors when client sends this repeatedly (e.g. as a keepalive
+    case ConnectionInfoReq =>
+      sender() ! ConnectionInfo()
   }
 
 }

--- a/jerk/src/test/scala/org/ensime/jerk/JerkFormatsSpec.scala
+++ b/jerk/src/test/scala/org/ensime/jerk/JerkFormatsSpec.scala
@@ -1,6 +1,5 @@
 package org.ensime.jerk
 
-import java.io.File
 import org.scalatest._
 import org.ensime.api._
 


### PR DESCRIPTION
A recent updated meant that if ConnectionInfo was requested more than once it resulted in a server side error.
When using WebSockets you need to send periodic messages to avoid the WebSocket timing out, and using a NoOp request such as ConnectionInfo makes sense.

