### PR TITLE
exclude the :scala-compiler-jars from assembly.jar

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -16,7 +16,7 @@ build:
         exit 1 ;
       fi
     - sbt ++$SCALA_VERSION test it:test
-    - if [ "${SCALA_VERSION}" = "2.11.6" ] ; then
+    - if [ "${SCALA_VERSION}" = "2.11.7" ] ; then
         git clone --depth 1 https://github.com/ensime/ensime-emacs.git ensime-emacs ;
         cd ensime-emacs ;
         cask pkg-file ;
@@ -34,7 +34,7 @@ build:
       fi
 
 # TODO https://github.com/ensime/ensime-server/issues/1091
-#    - if [ "${SCALA_VERSION}" = "2.11.6" ] ; then
+#    - if [ "${SCALA_VERSION}" = "2.11.7" ] ; then
 #        sbt ++$SCALA_VERSION clean ;
 #        sbt ++$SCALA_VERSION coverage test ;
 #        sbt ++$SCALA_VERSION coverage it:test ;
@@ -43,10 +43,8 @@ build:
 
 matrix:
   SCALA_VERSION:
-    - 2.11.6
-    - 2.10.4
-# 2.10.4 / 2.11.6 because that's what fommil uses at work :-D
-# EnsimeBuild tends to track latest stables
+    - 2.11.7
+    - 2.10.6
 
 deploy:
   dockerhub:
@@ -54,4 +52,4 @@ deploy:
     repo: ensime/ensime
     when:
       matrix:
-        SCALA_VERSION: 2.11.6
+        SCALA_VERSION: 2.11.7

--- a/project/EnsimeBuild.scala
+++ b/project/EnsimeBuild.scala
@@ -360,8 +360,14 @@ object EnsimeBuild extends Build with JdkResolver {
         case "META-INF/generated-layer.xml" => MergeStrategy.rename
         case other => MergeStrategy.defaultMergeStrategy(other)
       },
-      assemblyExcludedJars in assembly := List(Attributed.blank(JavaTools)),
-      assemblyJarName in assembly := s"ensime_${scalaVersion.value}-${version.value}-assembly.jar"
+      assemblyExcludedJars in assembly <<= (fullClasspath in assembly).map { everything =>
+        everything.filter { attr =>
+          val n = attr.data.getName
+          n.startsWith("scala-library") | n.startsWith("scala-compiler") |
+          n.startsWith("scala-reflect") | n.startsWith("scalap")
+        } :+ Attributed.blank(JavaTools)
+      },
+      assemblyJarName in assembly := s"ensime_${scalaBinaryVersion.value}-${version.value}-assembly.jar"
     )
 }
 


### PR DESCRIPTION
This will temporarily break ensime-emacs assembly launching, so we'll
leave both jars on ensime.typesafe.org for a little while.

goes some ways towards #1134