### PR TITLE
Don't insert fqn when completing index matches.

### DIFF
--- a/core/src/main/scala/org/ensime/core/Completion.scala
+++ b/core/src/main/scala/org/ensime/core/Completion.scala
@@ -167,7 +167,7 @@ trait CompletionControl {
         s.syms.map { s =>
           CompletionInfo(
             s.localName, CompletionSignature(List.empty, s.name),
-            -1, isCallable = false, 40, Some(s.name)
+            -1, isCallable = false, 40, None
           )
         }
       case unknown =>


### PR DESCRIPTION
A small usability fix. When selecting a completion candidate provided by the indexer, (always a class fqn atm), insert the unqualified name into the buffer, instead of the fully qualified name. User can follow up with ensime-import-type-at-point if they're missing the import.

TODO: send more detailed indexer completion results. For example: constructors with all param info if the user types 'new Foo...'