### PR TITLE
False positive Unused import warning crash

### DIFF
--- a/core/src/main/scala/org/ensime/util/Reporter.scala
+++ b/core/src/main/scala/org/ensime/util/Reporter.scala
@@ -40,6 +40,12 @@ class PresentationReporter(handler: ReportHandler) extends Reporter with Positio
           if (pos.isDefined) {
             val source = pos.source
             val f = source.file.absolute.path
+            val posColumn = if (pos.point == -1) {
+              0
+            } else {
+              pos.column
+            }
+
             val note = new Note(
               f,
               formatMessage(msg),
@@ -47,7 +53,7 @@ class PresentationReporter(handler: ReportHandler) extends Reporter with Positio
               pos.startOrCursor,
               pos.endOrCursor,
               pos.line,
-              pos.column
+              posColumn
             )
             handler.reportScalaNotes(List(note))
           }


### PR DESCRIPTION
In some cases when macro is in use, presentation compiler issues false positive of
Unused import warning. Parameter `pos` has in this case field `point` set to -1, what
cause `ArrayIndexOutOfBoundsException` when trying to get `pos.column`. This
fix detect this situation and return 0 instead of `pos.column`