### PR TITLE
ENJINE: Implement show error at point

### DIFF
--- a/core/src/main/scala/org/ensime/core/JavaAnalyzer.scala
+++ b/core/src/main/scala/org/ensime/core/JavaAnalyzer.scala
@@ -74,6 +74,10 @@ class JavaAnalyzer(
     case SymbolAtPointReq(file, point) =>
       sender() ! javaCompiler.askSymbolAtPoint(file, point)
 
+    case ImplicitInfoReq(file, range: OffsetRange) =>
+      // Implicit type conversion information is not applicable for Java, so we
+      // return an empty list.
+      sender() ! ImplicitInfos(Nil)
   }
 
 }


### PR DESCRIPTION
Related to https://github.com/ensime/ensime-server/issues/345.

The function `ensime-print-errors-at-point` wasn't working on ensime-emacs for Java-files. I made a stab at implementing that support. Unfortunately I was unable to get the it-tests working locally with `sbt it:test`, so we'll have to see what the CI server says about my code.