### PR TITLE
Improved navigation in source files

### DIFF
--- a/core/src/it/scala/org/ensime/core/RichPresentationCompilerSpec.scala
+++ b/core/src/it/scala/org/ensime/core/RichPresentationCompilerSpec.scala
@@ -155,8 +155,8 @@ class RichPresentationCompilerSpec extends WordSpec with Matchers
         "  )",
         "}") { (p, label, cc) =>
           val sym = cc.askSymbolInfoAt(p).get
-          assert(sym.name == "com.example.Foo$")
-          assert(sym.localName == "Foo")
+          assert(sym.name == "apply")
+          assert(sym.localName == "apply")
           assert(sym.declPos.isDefined)
           assert(sym.declPos.get match {
             case OffsetSourcePosition(f, i) => i > 0
@@ -178,8 +178,8 @@ class RichPresentationCompilerSpec extends WordSpec with Matchers
         " val fooUpd = foo.copy(b@@ar = foo.bar.reverse)",
         "}") { (p, label, cc) =>
           val sym = cc.askSymbolInfoAt(p).get
-          assert(sym.name == "com.example.Foo")
-          assert(sym.localName == "Foo")
+          assert(sym.name == "copy")
+          assert(sym.localName == "copy")
           assert(sym.declPos.isDefined)
           assert(sym.declPos.get match {
             case OffsetSourcePosition(f, i) => i > 0

--- a/core/src/main/scala/org/ensime/core/RichPresentationCompiler.scala
+++ b/core/src/main/scala/org/ensime/core/RichPresentationCompiler.scala
@@ -478,32 +478,14 @@ class RichPresentationCompiler(
           }
         case Annotated(atp, _) =>
           List(atp.symbol)
-        case st: SymTree =>
+        case ap @ Select(qualifier, nme.apply) =>
+          // If we would like to give user choice if to go to method apply or value
+          // like Eclipse is doing we would need to return:
+          // List(qualifier.symbol, ap.symbol)
+          List(qualifier.symbol)
+        case st if st.symbol ne null =>
           logger.debug("using symbol of " + tree.getClass + " tree")
-          val treeSymbol =
-            st match {
-              case Select(qualifier, name) if name.decoded == "apply" && qualifier.pos.includes(pos) =>
-                specificOwnerOfSymbolAt(pos) match {
-                  case Some(ownerSymbol) if ownerSymbol.fullName.startsWith("scala.Function") => qualifier.symbol
-                  case _ => tree.symbol
-                }
-              case _ => tree.symbol
-            }
-          List(treeSymbol)
-        case applyTree @ Apply(Select(qualifier, sym), args) =>
-          sym.decoded match {
-            case "apply" =>
-              List(qualifier.symbol)
-            case "copy" =>
-              typeOfTree(applyTree) match {
-                case Some(treeType) =>
-                  List(treeType.typeSymbol)
-                case None =>
-                  noDefinitionFound(tree)
-              }
-            case _ =>
-              noDefinitionFound(tree)
-          }
+          List(st.symbol)
         case _ =>
           noDefinitionFound(tree)
       }

--- a/testing/simple/src/main/scala/org/example/Foo.scala
+++ b/testing/simple/src/main/scala/org/example/Foo.scala
@@ -18,15 +18,10 @@ object Foo extends App {
 
   val fn: String => Int = str => str.size
 
-  println(fn.apply("foobar"))
-  println(Baz.fn("foobar"))
+  fn("foobar")
 }
 
 // for SearchServiceSpec
 case class CaseClassWithCamelCaseName()
 case class Bloo()
 case object Blue
-
-object Baz {
-  val fn: String => Int = str => str.size
-}


### PR DESCRIPTION
Improvements in RichPresentationCompiler. Method `symbolAt(pos:
Position)` now copy behaviour from Eclipse even more than before.

If point now allow jump to method apply, or some value, we will jump
to value, since it is more reasonable alternative.