### PR TITLE
Banish type-ids to the land of wind and ghosts

### DIFF
--- a/api/src/main/scala/org/ensime/api/incoming.scala
+++ b/api/src/main/scala/org/ensime/api/incoming.scala
@@ -143,16 +143,6 @@ case class PackageMemberCompletionReq(
 ) extends RpcAnalyserRequest
 
 /**
- * Responds with `CallCompletionInfo` if valid, or `FalseResponse`.
- */
-case class CallCompletionReq(id: Int) extends RpcAnalyserRequest
-
-/**
- * Responds with `TypeInfo` if valid, or `FalseResponse`.
- */
-case class TypeByIdReq(id: Int) extends RpcAnalyserRequest
-
-/**
  * Responds with `TypeInfo` if valid, or `FalseResponse`.
  */
 case class TypeByNameReq(name: String) extends RpcAnalyserRequest
@@ -182,15 +172,6 @@ case class TypeAtPointReq(
  * @param range in the file to inspect.
  */
 case class InspectTypeAtPointReq(file: Either[File, SourceFileInfo], range: OffsetRange) extends RpcAnalyserRequest
-
-/**
- * Request detailed type description by `typeId`.
- *
- * Responds with a `TypeInspectInfo` if the id is valid, or `FalseResponse`.
- *
- * @param id of the type to inspect (returned by other calls).
- */
-case class InspectTypeByIdReq(id: Int) extends RpcAnalyserRequest
 
 /**
  * Request detailed type description by fully qualified class name.

--- a/api/src/main/scala/org/ensime/api/outgoing.scala
+++ b/api/src/main/scala/org/ensime/api/outgoing.scala
@@ -311,8 +311,7 @@ case class SymbolInfo(
     localName: String,
     declPos: Option[SourcePosition],
     `type`: TypeInfo,
-    isCallable: Boolean,
-    ownerTypeId: Option[Int]
+    isCallable: Boolean
 ) extends RpcResponse {
   def tpe = `type`
 }
@@ -333,13 +332,13 @@ case class MethodBytecode(
 
 case class CompletionSignature(
   sections: List[List[(String, String)]],
-  result: String
+  result: String,
+  hasImplicit: Boolean
 )
 
 case class CompletionInfo(
   name: String,
   typeSig: CompletionSignature,
-  typeId: Int,
   isCallable: Boolean,
   relevance: Int,
   toInsert: Option[String]
@@ -479,13 +478,11 @@ case class NamedTypeMemberInfo(
 
 sealed trait TypeInfo extends EntityInfo {
   def name: String
-  def typeId: Int
   def declAs: DeclaredAs
   def fullName: String
   def typeArgs: Iterable[TypeInfo]
   def members: Iterable[EntityInfo]
   def pos: Option[SourcePosition]
-  def outerTypeId: Option[Int]
 
   final def declaredAs = declAs
   final def args = typeArgs
@@ -493,18 +490,15 @@ sealed trait TypeInfo extends EntityInfo {
 
 case class BasicTypeInfo(
   name: String,
-  typeId: Int,
   declAs: DeclaredAs,
   fullName: String,
   typeArgs: Iterable[TypeInfo],
   members: Iterable[EntityInfo],
-  pos: Option[SourcePosition],
-  outerTypeId: Option[Int]
+  pos: Option[SourcePosition]
 ) extends TypeInfo
 
 case class ArrowTypeInfo(
     name: String,
-    typeId: Int,
     resultType: TypeInfo,
     paramSections: Iterable[ParamSectionInfo]
 ) extends TypeInfo {
@@ -513,13 +507,7 @@ case class ArrowTypeInfo(
   def typeArgs = List.empty
   def members = List.empty
   def pos = None
-  def outerTypeId = None
 }
-
-case class CallCompletionInfo(
-  resultType: TypeInfo,
-  paramSections: Iterable[ParamSectionInfo]
-) extends RpcResponse
 
 case class ParamSectionInfo(
   params: Iterable[(String, TypeInfo)],
@@ -535,7 +523,6 @@ case class InterfaceInfo(
 
 case class TypeInspectInfo(
     `type`: TypeInfo,
-    companionId: Option[Int],
     interfaces: Iterable[InterfaceInfo],
     infoType: scala.Symbol = 'typeInspect // redundant field in protocol
 ) extends RpcResponse {
@@ -554,7 +541,7 @@ case class EnsimeImplementation(
 case class ConnectionInfo(
   pid: Option[Int] = None,
   implementation: EnsimeImplementation = EnsimeImplementation("ENSIME"),
-  version: String = "0.8.19"
+  version: String = "0.8.20"
 ) extends RpcResponse
 
 sealed trait ImplicitInfo

--- a/api/src/test/scala/org/ensime/api/EnsimeTestData.scala
+++ b/api/src/test/scala/org/ensime/api/EnsimeTestData.scala
@@ -14,13 +14,12 @@ trait EnsimeTestData {
     }
   }
 
-  val typeInfo = new BasicTypeInfo("type1", 7, DeclaredAs.Method, "FOO.type1", List(), List(), None, Some(8))
+  val typeInfo = new BasicTypeInfo("type1", DeclaredAs.Method, "FOO.type1", List(), List(), None)
 
   val interfaceInfo = new InterfaceInfo(typeInfo, Some("DEF"))
-  val typeInspectInfo = new TypeInspectInfo(typeInfo, Some(1), List(interfaceInfo))
+  val typeInspectInfo = new TypeInspectInfo(typeInfo, List(interfaceInfo))
 
   val paramSectionInfo = new ParamSectionInfo(List(("ABC", typeInfo)), false)
-  val callCompletionInfo = new CallCompletionInfo(typeInfo, List(paramSectionInfo))
 
   val symFile = canon("/abc")
   val symbolDesignations = SymbolDesignations(
@@ -31,7 +30,7 @@ trait EnsimeTestData {
     )
   )
 
-  val symbolInfo = new SymbolInfo("name", "localName", None, typeInfo, false, Some(2))
+  val symbolInfo = new SymbolInfo("name", "localName", None, typeInfo, false)
 
   val implicitInfos = List(
     ImplicitConversionInfo(5, 6, symbolInfo),
@@ -46,9 +45,9 @@ trait EnsimeTestData {
 
   val packageInfo = new PackageInfo("name", "fullName", List())
 
-  val completionInfo = new CompletionInfo("name", new CompletionSignature(List(List(("abc", "def"), ("hij", "lmn"))), "ABC"), 88, false, 90, Some("BAZ"))
+  val completionInfo = new CompletionInfo("name", new CompletionSignature(List(List(("abc", "def"), ("hij", "lmn"))), "ABC", false), false, 90, Some("BAZ"))
 
-  val completionInfo2 = new CompletionInfo("name2", new CompletionSignature(List(List(("abc", "def"))), "ABC"), 90, true, 91, None)
+  val completionInfo2 = new CompletionInfo("name2", new CompletionSignature(List(List(("abc", "def"))), "ABC", false), true, 91, None)
 
   val completionInfoList = List(completionInfo, completionInfo2)
 
@@ -116,7 +115,7 @@ trait EnsimeTestData {
 
   val noteList = NewScalaNotesEvent(isFull = true, List(note1, note2))
 
-  val entityInfo: TypeInfo = new ArrowTypeInfo("Arrow1", 8, typeInfo, List(paramSectionInfo))
+  val entityInfo: TypeInfo = new ArrowTypeInfo("Arrow1", typeInfo, List(paramSectionInfo))
 
   val sourceFileInfo = SourceFileInfo(file1, Some("{/* code here */}"), Some(file2))
   val dtid = DebugThreadId(13)

--- a/core/src/it/scala/org/ensime/intg/BasicWorkflow.scala
+++ b/core/src/it/scala/org/ensime/intg/BasicWorkflow.scala
@@ -56,30 +56,11 @@ class BasicWorkflow extends WordSpec with Matchers
             project ! SymbolAtPointReq(Left(fooFile), 128)
             val symbolAtPointOpt: Option[SymbolInfo] = expectMsgType[Option[SymbolInfo]]
 
-            val intTypeId = symbolAtPointOpt match {
-              case Some(SymbolInfo("scala.Int", "Int", Some(_), BasicTypeInfo("Int", typeId, DeclaredAs.Class, "scala.Int", List(), List(), _, None), false, Some(ownerTypeId))) =>
-                typeId
-              case _ =>
-                fail("Symbol at point does not match expectations, expected Int symbol got: " + symbolAtPointOpt)
-            }
-
             project ! TypeByNameReq("org.example.Foo")
             val fooClassByNameOpt = expectMsgType[Option[TypeInfo]]
-            val fooClassId = fooClassByNameOpt match {
-              case Some(BasicTypeInfo("Foo", fooTypeIdVal, DeclaredAs.Class, "org.example.Foo", List(), List(), _, None)) =>
-                fooTypeIdVal
-              case _ =>
-                fail("type by name for Foo class does not match expectations, got: " + fooClassByNameOpt)
-            }
 
             project ! TypeByNameReq("org.example.Foo$")
             val fooObjectByNameOpt = expectMsgType[Option[TypeInfo]]
-            val fooObjectId = fooObjectByNameOpt match {
-              case Some(BasicTypeInfo("Foo$", fooObjectIdVal, DeclaredAs.Object, "org.example.Foo$", List(), List(), Some(OffsetSourcePosition(`fooFile`, 28)), None)) =>
-                fooObjectIdVal
-              case _ =>
-                fail("type by name for Foo object does not match expectations, got: " + fooObjectByNameOpt)
-            }
 
             //-----------------------------------------------------------------------------------------------
             // public symbol search - java.io.File
@@ -102,29 +83,6 @@ class BasicWorkflow extends WordSpec with Matchers
                 TypeSearchResult("java.util.Random", "Random", DeclaredAs.Class, Some(_)),
                 TypeSearchResult("scala.util.Random", "Random", DeclaredAs.Class, Some(_)))) =>
               // this is a pretty ropey test at the best of times
-            }
-
-            //-----------------------------------------------------------------------------------------------
-            // type by id
-
-            project ! TypeByIdReq(intTypeId)
-            val typeByIdOpt = expectMsgType[Option[TypeInfo]]
-            val intTypeInspectInfo = typeByIdOpt match {
-              case Some(ti @ BasicTypeInfo("Int", `intTypeId`, DeclaredAs.Class, "scala.Int", List(), List(), Some(_), None)) =>
-                ti
-              case _ =>
-                fail("type by id does not match expectations, got " + typeByIdOpt)
-            }
-
-            //-----------------------------------------------------------------------------------------------
-            // inspect type by id
-            project ! InspectTypeByIdReq(intTypeId)
-            val inspectByIdOpt = expectMsgType[Option[TypeInspectInfo]]
-
-            inspectByIdOpt match {
-              case Some(TypeInspectInfo(`intTypeInspectInfo`, Some(intCompanionId), supers, _)) =>
-              case _ =>
-                fail("inspect by id does not match expectations, got: " + inspectByIdOpt)
             }
 
             //-----------------------------------------------------------------------------------------------
@@ -164,72 +122,72 @@ class BasicWorkflow extends WordSpec with Matchers
             // loaded by the pres compiler
             project ! SymbolAtPointReq(Left(fooFile), 276)
             expectMsgPF() {
-              case Some(SymbolInfo("testMethod", "testMethod", Some(OffsetSourcePosition(`fooFile`, 114)), ArrowTypeInfo("(i: Int, s: String)Int", 126, BasicTypeInfo("Int", 1, DeclaredAs.Class, "scala.Int", List(), List(), None, None), List(ParamSectionInfo(List((i, BasicTypeInfo("Int", 1, DeclaredAs.Class, "scala.Int", List(), List(), None, None)), (s, BasicTypeInfo("String", 39, DeclaredAs.Class, "java.lang.String", List(), List(), None, None))), false))), true, Some(_))) =>
+              case Some(SymbolInfo("testMethod", "testMethod", Some(OffsetSourcePosition(`fooFile`, 114)), ArrowTypeInfo("(i: Int, s: String)Int", BasicTypeInfo("Int", DeclaredAs.Class, "scala.Int", List(), List(), None), List(ParamSectionInfo(List((i, BasicTypeInfo("Int", DeclaredAs.Class, "scala.Int", List(), List(), None)), (s, BasicTypeInfo("String", DeclaredAs.Class, "java.lang.String", List(), List(), None))), false))), true)) =>
             }
 
             // M-.  external symbol
             project ! SymbolAtPointReq(Left(fooFile), 190)
             expectMsgPF() {
               case Some(SymbolInfo("Map", "Map", Some(OffsetSourcePosition(_, _)),
-                BasicTypeInfo("Map$", _, DeclaredAs.Object, "scala.collection.immutable.Map$", List(), List(), None, None),
-                false, Some(_))) =>
+                BasicTypeInfo("Map$", DeclaredAs.Object, "scala.collection.immutable.Map$", List(), List(), None),
+                false)) =>
             }
 
             project ! SymbolAtPointReq(Left(fooFile), 343)
             expectMsgPF() {
               case Some(SymbolInfo("fn", "fn", Some(OffsetSourcePosition(`fooFile`, 304)),
-                BasicTypeInfo("Function1", _, DeclaredAs.Trait, "scala.Function1",
+                BasicTypeInfo("Function1", DeclaredAs.Trait, "scala.Function1",
                   List(
-                    BasicTypeInfo("String", _, DeclaredAs.Class, "java.lang.String", List(), List(), None, None),
-                    BasicTypeInfo("Int", _, DeclaredAs.Class, "scala.Int", List(), List(), None, None)),
-                  List(), None, None),
-                false, Some(_))) =>
+                    BasicTypeInfo("String", DeclaredAs.Class, "java.lang.String", List(), List(), None),
+                    BasicTypeInfo("Int", DeclaredAs.Class, "scala.Int", List(), List(), None)),
+                  List(), None),
+                false)) =>
             }
 
             project ! SymbolAtPointReq(Left(barFile), 150)
             expectMsgPF() {
               case Some(SymbolInfo("apply", "apply", Some(OffsetSourcePosition(`barFile`, 59)),
-                ArrowTypeInfo("(bar: String, baz: Int)org.example.Bar.Foo", _,
-                  BasicTypeInfo("Foo", _, DeclaredAs.Class, "org.example.Bar$$Foo", List(), List(), None, Some(_)),
+                ArrowTypeInfo("(bar: String, baz: Int)org.example.Bar.Foo",
+                  BasicTypeInfo("Foo", DeclaredAs.Class, "org.example.Bar$$Foo", List(), List(), None),
                   List(ParamSectionInfo(
                     List(
-                      ("bar", BasicTypeInfo("String", _, DeclaredAs.Class, "java.lang.String", List(), List(), None, None)),
-                      ("baz", BasicTypeInfo("Int", _, DeclaredAs.Class, "scala.Int", List(), List(), None, None))), false))),
-                true, Some(_))) =>
+                      ("bar", BasicTypeInfo("String", DeclaredAs.Class, "java.lang.String", List(), List(), None)),
+                      ("baz", BasicTypeInfo("Int", DeclaredAs.Class, "scala.Int", List(), List(), None))), false))),
+                true)) =>
             }
 
             project ! SymbolAtPointReq(Left(barFile), 193)
             expectMsgPF() {
               case Some(SymbolInfo("copy", "copy", Some(OffsetSourcePosition(`barFile`, 59)),
-                ArrowTypeInfo("(bar: String, baz: Int)org.example.Bar.Foo", _,
-                  BasicTypeInfo("Foo", _, DeclaredAs.Class, "org.example.Bar$$Foo", List(), List(), None, Some(_)),
+                ArrowTypeInfo("(bar: String, baz: Int)org.example.Bar.Foo",
+                  BasicTypeInfo("Foo", DeclaredAs.Class, "org.example.Bar$$Foo", List(), List(), None),
                   List(ParamSectionInfo(
                     List(
-                      ("bar", BasicTypeInfo("String", _, DeclaredAs.Class, "java.lang.String", List(), List(), None, None)),
-                      ("baz", BasicTypeInfo("Int", _, DeclaredAs.Class, "scala.Int", List(), List(), None, None))), false))),
-                true, Some(_))) =>
+                      ("bar", BasicTypeInfo("String", DeclaredAs.Class, "java.lang.String", List(), List(), None)),
+                      ("baz", BasicTypeInfo("Int", DeclaredAs.Class, "scala.Int", List(), List(), None))), false))),
+                true)) =>
             }
 
             // C-c C-v p Inspect source of current package
             project ! InspectPackageByPathReq("org.example")
             expectMsgPF() {
               case Some(PackageInfo("example", "org.example", List(
-                BasicTypeInfo("Bar", _: Int, DeclaredAs.Class, "org.example.Bar", List(), List(), Some(_), None),
-                BasicTypeInfo("Bar$", _: Int, DeclaredAs.Object, "org.example.Bar$", List(), List(), Some(_), None),
-                BasicTypeInfo("Bloo", _: Int, DeclaredAs.Class, "org.example.Bloo", List(), List(), Some(_), None),
-                BasicTypeInfo("Bloo$", _: Int, DeclaredAs.Object, "org.example.Bloo$", List(), List(), Some(_), None),
-                BasicTypeInfo("Blue", _: Int, DeclaredAs.Class, "org.example.Blue", List(), List(), Some(_), None),
-                BasicTypeInfo("Blue$", _: Int, DeclaredAs.Object, "org.example.Blue$", List(), List(), Some(_), None),
-                BasicTypeInfo("CaseClassWithCamelCaseName", _: Int, DeclaredAs.Class, "org.example.CaseClassWithCamelCaseName", List(), List(), Some(_), None),
-                BasicTypeInfo("CaseClassWithCamelCaseName$", _: Int, DeclaredAs.Object, "org.example.CaseClassWithCamelCaseName$", List(), List(), Some(_), None),
-                BasicTypeInfo("Foo", _: Int, DeclaredAs.Class, "org.example.Foo", List(), List(), Some(_), None),
-                BasicTypeInfo("Foo$", _: Int, DeclaredAs.Object, "org.example.Foo$", List(), List(), Some(_), None),
-                BasicTypeInfo("Test1", _: Int, DeclaredAs.Class, "org.example.Test1", List(), List(), None, None),
-                BasicTypeInfo("Test1$", _: Int, DeclaredAs.Object, "org.example.Test1$", List(), List(), None, None),
-                BasicTypeInfo("Test2", _: Int, DeclaredAs.Class, "org.example.Test2", List(), List(), None, None),
-                BasicTypeInfo("Test2$", _: Int, DeclaredAs.Object, "org.example.Test2$", List(), List(), None, None),
-                BasicTypeInfo("package$", _: Int, DeclaredAs.Object, "org.example.package$", List(), List(), None, None),
-                BasicTypeInfo("package$", _: Int, DeclaredAs.Object, "org.example.package$", List(), List(), None, None)))) =>
+                BasicTypeInfo("Bar", DeclaredAs.Class, "org.example.Bar", List(), List(), Some(_)),
+                BasicTypeInfo("Bar$", DeclaredAs.Object, "org.example.Bar$", List(), List(), Some(_)),
+                BasicTypeInfo("Bloo", DeclaredAs.Class, "org.example.Bloo", List(), List(), Some(_)),
+                BasicTypeInfo("Bloo$", DeclaredAs.Object, "org.example.Bloo$", List(), List(), Some(_)),
+                BasicTypeInfo("Blue", DeclaredAs.Class, "org.example.Blue", List(), List(), Some(_)),
+                BasicTypeInfo("Blue$", DeclaredAs.Object, "org.example.Blue$", List(), List(), Some(_)),
+                BasicTypeInfo("CaseClassWithCamelCaseName", DeclaredAs.Class, "org.example.CaseClassWithCamelCaseName", List(), List(), Some(_)),
+                BasicTypeInfo("CaseClassWithCamelCaseName$", DeclaredAs.Object, "org.example.CaseClassWithCamelCaseName$", List(), List(), Some(_)),
+                BasicTypeInfo("Foo", DeclaredAs.Class, "org.example.Foo", List(), List(), Some(_)),
+                BasicTypeInfo("Foo$", DeclaredAs.Object, "org.example.Foo$", List(), List(), Some(_)),
+                BasicTypeInfo("Test1", DeclaredAs.Class, "org.example.Test1", List(), List(), None),
+                BasicTypeInfo("Test1$", DeclaredAs.Object, "org.example.Test1$", List(), List(), None),
+                BasicTypeInfo("Test2", DeclaredAs.Class, "org.example.Test2", List(), List(), None),
+                BasicTypeInfo("Test2$", DeclaredAs.Object, "org.example.Test2$", List(), List(), None),
+                BasicTypeInfo("package$", DeclaredAs.Object, "org.example.package$", List(), List(), None),
+                BasicTypeInfo("package$", DeclaredAs.Object, "org.example.package$", List(), List(), None)))) =>
             }
 
             // expand selection around 'val foo'

--- a/core/src/it/scala/org/ensime/intg/JavaWorkflow.scala
+++ b/core/src/it/scala/org/ensime/intg/JavaWorkflow.scala
@@ -32,7 +32,7 @@ class JavaWorkflow extends WordSpec with Matchers
             expectMsg(VoidResponse)
 
             project ! TypeAtPointReq(Left(fooFile), OffsetRange(30))
-            expectMsg(Some(BasicTypeInfo("pure.NoScalaHere", -1, DeclaredAs.Class, "pure.NoScalaHere", Nil, Nil, Some(EmptySourcePosition()), None)))
+            expectMsg(Some(BasicTypeInfo("pure.NoScalaHere", DeclaredAs.Class, "pure.NoScalaHere", Nil, Nil, Some(EmptySourcePosition()))))
           }
         }
       }

--- a/core/src/main/scala/org/ensime/core/Analyzer.scala
+++ b/core/src/main/scala/org/ensime/core/Analyzer.scala
@@ -112,7 +112,6 @@ class Analyzer(
   }
 
   override def postStop(): Unit = {
-    Try(scalaCompiler.askClearTypeCache())
     Try(scalaCompiler.askShutdown())
   }
 
@@ -201,8 +200,6 @@ class Analyzer(
       val p = pos(file, range)
       scalaCompiler.askLoadedTyped(p.source)
       sender ! scalaCompiler.askInspectTypeAt(p)
-    case InspectTypeByIdReq(id: Int) =>
-      sender ! scalaCompiler.askInspectTypeById(id)
     case InspectTypeByNameReq(name: String) =>
       sender ! scalaCompiler.askInspectTypeByName(name)
     case SymbolAtPointReq(file, point: Int) =>
@@ -223,17 +220,12 @@ class Analyzer(
       val p = pos(file, range)
       scalaCompiler.askLoadedTyped(p.source)
       sender ! scalaCompiler.askTypeInfoAt(p)
-    case TypeByIdReq(id: Int) =>
-      sender ! scalaCompiler.askTypeInfoById(id)
     case TypeByNameReq(name: String) =>
       sender ! scalaCompiler.askTypeInfoByName(name)
     case TypeByNameAtPointReq(name: String, file, range: OffsetRange) =>
       val p = pos(file, range)
       scalaCompiler.askLoadedTyped(p.source)
       sender ! scalaCompiler.askTypeInfoByNameAt(name, p)
-    case CallCompletionReq(id: Int) =>
-      sender ! scalaCompiler.askCallCompletionInfoById(id)
-
     case SymbolDesignationsReq(f, start, end, Nil) =>
       sender ! SymbolDesignations(f.file, List.empty)
     case SymbolDesignationsReq(f, start, end, tpes) =>

--- a/core/src/main/scala/org/ensime/core/Completion.scala
+++ b/core/src/main/scala/org/ensime/core/Completion.scala
@@ -312,7 +312,7 @@ object Keywords {
     "yield"
   )
 
-  val keywordCompletions = keywords map { CompletionInfo(_, CompletionSignature(List(), ""), -1, false, 100, None) }
+  val keywordCompletions = keywords map { CompletionInfo(_, CompletionSignature(List(), "", false), false, 100, None) }
 
 }
 
@@ -327,7 +327,7 @@ trait Completion { self: RichPresentationCompiler =>
         memberSyms.flatMap { s =>
           val name = if (s.hasPackageFlag) { s.nameString } else { typeShortName(s) }
           if (name.startsWith(prefix)) {
-            Some(CompletionInfo(name, CompletionSignature(List.empty, ""), -1, isCallable = false, 50, None))
+            Some(CompletionInfo(name, CompletionSignature(List.empty, "", false), isCallable = false, 50, None))
           } else None
         }.toList.sortBy(ci => (ci.relevance, ci.name))
       case _ => List.empty
@@ -362,8 +362,8 @@ object CompletionUtil {
       case s: SymbolSearchResults =>
         s.syms.map { s =>
           CompletionInfo(
-            s.localName, CompletionSignature(List.empty, s.name),
-            -1, isCallable = false, 40, None
+            s.localName, CompletionSignature(List.empty, s.name, false),
+            isCallable = false, 40, None
           )
         }
       case unknown =>

--- a/core/src/main/scala/org/ensime/core/RichPresentationCompiler.scala
+++ b/core/src/main/scala/org/ensime/core/RichPresentationCompiler.scala
@@ -110,9 +110,6 @@ trait RichCompilerControl extends CompilerControl with RefactoringControl with C
   def askTypeInfoAt(p: Position): Option[TypeInfo] =
     askOption(typeAt(p).map(TypeInfo(_, PosNeededYes))).flatten
 
-  def askTypeInfoById(id: Int): Option[TypeInfo] =
-    askOption(typeById(id).map(TypeInfo(_, PosNeededYes))).flatten
-
   def askTypeInfoByName(name: String): Option[TypeInfo] =
     askOption(typeByName(name).map(TypeInfo(_, PosNeededYes))).flatten
 
@@ -133,9 +130,6 @@ trait RichCompilerControl extends CompilerControl with RefactoringControl with C
       }
     ) yield infos).flatten
   }
-
-  def askCallCompletionInfoById(id: Int): Option[CallCompletionInfo] =
-    askOption(typeById(id).map(CallCompletionInfo(_))).flatten
 
   def askPackageByPath(path: String): Option[PackageInfo] =
     askOption(PackageInfo.fromPath(path))
@@ -177,9 +171,6 @@ trait RichCompilerControl extends CompilerControl with RefactoringControl with C
   def askReloadExistingFiles() =
     askReloadFiles(loadedFiles)
 
-  def askInspectTypeById(id: Int): Option[TypeInspectInfo] =
-    askOption(typeById(id).map(inspectType)).flatten
-
   def askInspectTypeAt(p: Position): Option[TypeInspectInfo] =
     askOption(inspectTypeAt(p)).flatten
 
@@ -210,8 +201,6 @@ trait RichCompilerControl extends CompilerControl with RefactoringControl with C
         new ImplicitAnalyzer(this).implicitDetails(p)
       ).getOrElse(List.empty)
     )
-
-  def askClearTypeCache(): Unit = clearTypeCache()
 
   def askNotifyWhenReady(): Unit = ask(setNotifyWhenReady)
 
@@ -376,7 +365,6 @@ class RichPresentationCompiler(
     val parents = tpe.parents
     new TypeInspectInfo(
       TypeInfo(tpe, PosNeededAvail),
-      companionTypeOf(tpe).map(cacheType),
       prepareSortedInterfaceInfo(typePublicMembers(tpe.asInstanceOf[Type]), parents)
     )
   }
@@ -388,7 +376,6 @@ class RichPresentationCompiler(
       val preparedMembers = prepareSortedInterfaceInfo(members, parents)
       new TypeInspectInfo(
         TypeInfo(tpe, PosNeededAvail),
-        companionTypeOf(tpe).map(cacheType),
         preparedMembers
       )
     }).orElse {

--- a/core/src/main/scala/org/ensime/core/javac/JavaCompiler.scala
+++ b/core/src/main/scala/org/ensime/core/javac/JavaCompiler.scala
@@ -109,14 +109,13 @@ class JavaCompiler(
       case (info: CompilationInfo, path: TreePath) =>
         def withName(name: String): Option[SymbolInfo] = {
           val tpeMirror = Option(info.getTrees().getTypeMirror(path))
-          val nullTpe = new BasicTypeInfo("NA", -1, DeclaredAs.Nil, "NA", List.empty, List.empty, None, None)
+          val nullTpe = new BasicTypeInfo("NA", DeclaredAs.Nil, "NA", List.empty, List.empty, None)
           Some(SymbolInfo(
             fqn(info, path).map(_.toFqnString).getOrElse(name),
             name,
             findDeclPos(info, path),
             tpeMirror.map(typeMirrorToTypeInfo).getOrElse(nullTpe),
-            tpeMirror.map(_.getKind == TypeKind.EXECUTABLE).getOrElse(false),
-            None
+            tpeMirror.map(_.getKind == TypeKind.EXECUTABLE).getOrElse(false)
           ))
         }
         path.getLeaf match {
@@ -157,7 +156,7 @@ class JavaCompiler(
   }
 
   private def typeMirrorToTypeInfo(tm: TypeMirror): TypeInfo = {
-    BasicTypeInfo(tm.toString, -1, DeclaredAs.Class, tm.toString, List(), List(), Some(EmptySourcePosition()), None)
+    BasicTypeInfo(tm.toString, DeclaredAs.Class, tm.toString, List(), List(), Some(EmptySourcePosition()))
   }
 
   private def getTypeMirror(info: CompilationInfo, offset: Int): Option[TypeMirror] = {

--- a/core/src/main/scala/org/ensime/core/javac/JavaCompletion.scala
+++ b/core/src/main/scala/org/ensime/core/javac/JavaCompletion.scala
@@ -232,24 +232,25 @@ trait JavaCompletion extends Helpers with SLF4JLogging {
     CompletionInfo(
       s,
       CompletionSignature(
-        List(e.getParameters().map { p => (p.getSimpleName.toString, localTypeName(p.asType)) }.toList),
-        localTypeName(e.getReturnType())
+        List(e.getParameters().map { p => (p.getSimpleName.toString, p.asType.toString) }.toList),
+        e.getReturnType.toString,
+        false
       ),
-      -1, true, relavence, None
+      true, relavence, None
     )
   }
 
   private def fieldInfo(e: VariableElement, relavence: Int): CompletionInfo = {
     val s = e.getSimpleName.toString
     CompletionInfo(
-      s, CompletionSignature(List(), localTypeName(e.asType())), -1, false, relavence, None
+      s, CompletionSignature(List(), e.asType.toString, false), false, relavence, None
     )
   }
 
   private def typeInfo(e: TypeElement, relavence: Int): CompletionInfo = {
     val s = e.getSimpleName.toString
     CompletionInfo(
-      s, CompletionSignature(List(), localTypeName(e.asType())), -1, false, relavence, None
+      s, CompletionSignature(List(), e.asType.toString, false), false, relavence, None
     )
   }
 

--- a/protocol-jerky/src/test/scala/org/ensime/jerk/JerkFormatsSpec.scala
+++ b/protocol-jerky/src/test/scala/org/ensime/jerk/JerkFormatsSpec.scala
@@ -111,18 +111,8 @@ class JerkFormatsSpec extends FlatSpec with Matchers
     )
 
     roundtrip(
-      CallCompletionReq(13): RpcRequest,
-      """{"typehint":"CallCompletionReq","id":13}"""
-    )
-
-    roundtrip(
       UsesOfSymbolAtPointReq(Left(file1), 100): RpcRequest,
       s"""{"typehint":"UsesOfSymbolAtPointReq","file":"$file1","point":100}"""
-    )
-
-    roundtrip(
-      TypeByIdReq(13): RpcRequest,
-      """{"typehint":"TypeByIdReq","id":13}"""
     )
 
     roundtrip(
@@ -143,11 +133,6 @@ class JerkFormatsSpec extends FlatSpec with Matchers
     roundtrip(
       InspectTypeAtPointReq(Left(file1), OffsetRange(1, 100)): RpcRequest,
       s"""{"typehint":"InspectTypeAtPointReq","file":"$file1","range":{"from":1,"to":100}}"""
-    )
-
-    roundtrip(
-      InspectTypeByIdReq(13): RpcRequest,
-      """{"typehint":"InspectTypeByIdReq","id":13}"""
     )
 
     roundtrip(
@@ -509,37 +494,37 @@ class JerkFormatsSpec extends FlatSpec with Matchers
 
     roundtrip(
       completionInfo: EnsimeServerMessage,
-      """{"typehint":"CompletionInfo","name":"name","typeId":88,"typeSig":{"sections":[[["abc","def"],["hij","lmn"]]],"result":"ABC"},"relevance":90,"isCallable":false,"toInsert":"BAZ"}"""
+      """{"typehint":"CompletionInfo","name":"name","typeSig":{"sections":[[["abc","def"],["hij","lmn"]]],"result":"ABC", "hasImplicit": false},"relevance":90,"isCallable":false,"toInsert":"BAZ"}"""
     )
 
     roundtrip(
       completionInfo2: EnsimeServerMessage,
-      """{"typehint":"CompletionInfo","name":"name2","typeId":90,"typeSig":{"sections":[[["abc","def"]]],"result":"ABC"},"relevance":91,"isCallable":true}"""
+      """{"typehint":"CompletionInfo","name":"name2","typeSig":{"sections":[[["abc","def"]]],"result":"ABC", "hasImplicit": false},"relevance":91,"isCallable":true}"""
     )
 
     roundtrip(
       CompletionInfoList("fooBar", List(completionInfo)): EnsimeServerMessage,
-      """{"typehint":"CompletionInfoList","prefix":"fooBar","completions":[{"name":"name","typeId":88,"typeSig":{"sections":[[["abc","def"],["hij","lmn"]]],"result":"ABC"},"relevance":90,"isCallable":false,"toInsert":"BAZ"}]}"""
+      """{"typehint":"CompletionInfoList","prefix":"fooBar","completions":[{"name":"name","typeSig":{"sections":[[["abc","def"],["hij","lmn"]]],"result":"ABC", "hasImplicit": false},"relevance":90,"isCallable":false,"toInsert":"BAZ"}]}"""
     )
 
     roundtrip(
-      new SymbolInfo("name", "localName", None, typeInfo, false, Some(2)): EnsimeServerMessage,
-      """{"typehint":"SymbolInfo","name":"name","localName":"localName","type":{"name":"type1","fullName":"FOO.type1","typehint":"BasicTypeInfo","typeId":7,"outerTypeId":8,"typeArgs":[],"members":[],"declAs":{"typehint":"Method"}},"isCallable":false,"ownerTypeId":2}"""
+      new SymbolInfo("name", "localName", None, typeInfo, false): EnsimeServerMessage,
+      """{"typehint":"SymbolInfo","name":"name","localName":"localName","type":{"name":"type1","fullName":"FOO.type1","typehint":"BasicTypeInfo","typeArgs":[],"members":[],"declAs":{"typehint":"Method"}},"isCallable":false}"""
     )
 
     roundtrip(
       new NamedTypeMemberInfo("typeX", typeInfo, None, None, DeclaredAs.Method): EnsimeServerMessage,
-      """{"typehint":"NamedTypeMemberInfo","name":"typeX","type":{"name":"type1","fullName":"FOO.type1","typehint":"BasicTypeInfo","typeId":7,"outerTypeId":8,"typeArgs":[],"members":[],"declAs":{"typehint":"Method"}},"declAs":{"typehint":"Method"}}"""
+      """{"typehint":"NamedTypeMemberInfo","name":"typeX","type":{"name":"type1","fullName":"FOO.type1","typehint":"BasicTypeInfo","typeArgs":[],"members":[],"declAs":{"typehint":"Method"}},"declAs":{"typehint":"Method"}}"""
     )
 
     roundtrip(
       entityInfo: EnsimeServerMessage,
-      """{"resultType":{"name":"type1","fullName":"FOO.type1","typehint":"BasicTypeInfo","typeId":7,"outerTypeId":8,"typeArgs":[],"members":[],"declAs":{"typehint":"Method"}},"name":"Arrow1","paramSections":[{"params":[["ABC",{"name":"type1","fullName":"FOO.type1","typehint":"BasicTypeInfo","typeId":7,"outerTypeId":8,"typeArgs":[],"members":[],"declAs":{"typehint":"Method"}}]],"isImplicit":false}],"typehint":"ArrowTypeInfo","typeId":8}"""
+      """{"resultType":{"name":"type1","fullName":"FOO.type1","typehint":"BasicTypeInfo","typeArgs":[],"members":[],"declAs":{"typehint":"Method"}},"name":"Arrow1","paramSections":[{"params":[["ABC",{"name":"type1","fullName":"FOO.type1","typehint":"BasicTypeInfo","typeArgs":[],"members":[],"declAs":{"typehint":"Method"}}]],"isImplicit":false}],"typehint":"ArrowTypeInfo"}"""
     )
 
     roundtrip(
       typeInfo: EnsimeServerMessage,
-      """{"name":"type1","fullName":"FOO.type1","typehint":"BasicTypeInfo","typeId":7,"outerTypeId":8,"typeArgs":[],"members":[],"declAs":{"typehint":"Method"}}"""
+      """{"name":"type1","fullName":"FOO.type1","typehint":"BasicTypeInfo","typeArgs":[],"members":[],"declAs":{"typehint":"Method"}}"""
     )
 
     roundtrip(
@@ -548,18 +533,13 @@ class JerkFormatsSpec extends FlatSpec with Matchers
     )
 
     roundtrip(
-      new CallCompletionInfo(typeInfo, List(paramSectionInfo)): EnsimeServerMessage,
-      """{"typehint":"CallCompletionInfo","resultType":{"name":"type1","fullName":"FOO.type1","typehint":"BasicTypeInfo","typeId":7,"outerTypeId":8,"typeArgs":[],"members":[],"declAs":{"typehint":"Method"}},"paramSections":[{"params":[["ABC",{"name":"type1","fullName":"FOO.type1","typehint":"BasicTypeInfo","typeId":7,"outerTypeId":8,"typeArgs":[],"members":[],"declAs":{"typehint":"Method"}}]],"isImplicit":false}]}"""
-    )
-
-    roundtrip(
       interfaceInfo: EnsimeServerMessage,
-      """{"typehint":"InterfaceInfo","type":{"name":"type1","fullName":"FOO.type1","typehint":"BasicTypeInfo","typeId":7,"outerTypeId":8,"typeArgs":[],"members":[],"declAs":{"typehint":"Method"}},"viaView":"DEF"}"""
+      """{"typehint":"InterfaceInfo","type":{"name":"type1","fullName":"FOO.type1","typehint":"BasicTypeInfo","typeArgs":[],"members":[],"declAs":{"typehint":"Method"}},"viaView":"DEF"}"""
     )
 
     roundtrip(
-      new TypeInspectInfo(typeInfo, Some(1), List(interfaceInfo)): EnsimeServerMessage,
-      """{"typehint":"TypeInspectInfo","type":{"name":"type1","fullName":"FOO.type1","typehint":"BasicTypeInfo","typeId":7,"outerTypeId":8,"typeArgs":[],"members":[],"declAs":{"typehint":"Method"}},"companionId":1,"interfaces":[{"type":{"name":"type1","fullName":"FOO.type1","typehint":"BasicTypeInfo","typeId":7,"outerTypeId":8,"typeArgs":[],"members":[],"declAs":{"typehint":"Method"}},"viaView":"DEF"}],"infoType":"typeInspect"}"""
+      new TypeInspectInfo(typeInfo, List(interfaceInfo)): EnsimeServerMessage,
+      """{"typehint":"TypeInspectInfo","type":{"name":"type1","fullName":"FOO.type1","typehint":"BasicTypeInfo","typeArgs":[],"members":[],"declAs":{"typehint":"Method"}},"interfaces":[{"type":{"name":"type1","fullName":"FOO.type1","typehint":"BasicTypeInfo","typeArgs":[],"members":[],"declAs":{"typehint":"Method"}},"viaView":"DEF"}],"infoType":"typeInspect"}"""
     )
   }
 
@@ -608,12 +588,12 @@ class JerkFormatsSpec extends FlatSpec with Matchers
 
     roundtrip(
       ImplicitInfos(List(ImplicitConversionInfo(5, 6, symbolInfo))): EnsimeServerMessage,
-      """{"typehint":"ImplicitInfos","infos":[{"typehint":"ImplicitConversionInfo","start":5,"end":6,"fun":{"name":"name","localName":"localName","type":{"name":"type1","fullName":"FOO.type1","typehint":"BasicTypeInfo","typeId":7,"outerTypeId":8,"typeArgs":[],"members":[],"declAs":{"typehint":"Method"}},"isCallable":false,"ownerTypeId":2}}]}"""
+      """{"typehint":"ImplicitInfos","infos":[{"typehint":"ImplicitConversionInfo","start":5,"end":6,"fun":{"name":"name","localName":"localName","type":{"name":"type1","fullName":"FOO.type1","typehint":"BasicTypeInfo","typeArgs":[],"members":[],"declAs":{"typehint":"Method"}},"isCallable":false}}]}"""
     )
 
     roundtrip(
       ImplicitInfos(List(ImplicitParamInfo(5, 6, symbolInfo, List(symbolInfo, symbolInfo), true))): EnsimeServerMessage,
-      """{"typehint":"ImplicitInfos","infos":[{"params":[{"name":"name","localName":"localName","type":{"name":"type1","fullName":"FOO.type1","typehint":"BasicTypeInfo","typeId":7,"outerTypeId":8,"typeArgs":[],"members":[],"declAs":{"typehint":"Method"}},"isCallable":false,"ownerTypeId":2},{"name":"name","localName":"localName","type":{"name":"type1","fullName":"FOO.type1","typehint":"BasicTypeInfo","typeId":7,"outerTypeId":8,"typeArgs":[],"members":[],"declAs":{"typehint":"Method"}},"isCallable":false,"ownerTypeId":2}],"typehint":"ImplicitParamInfo","fun":{"name":"name","localName":"localName","type":{"name":"type1","fullName":"FOO.type1","typehint":"BasicTypeInfo","typeId":7,"outerTypeId":8,"typeArgs":[],"members":[],"declAs":{"typehint":"Method"}},"isCallable":false,"ownerTypeId":2},"funIsImplicit":true,"end":6,"start":5}]}"""
+      """{"typehint":"ImplicitInfos","infos":[{"params":[{"name":"name","localName":"localName","type":{"name":"type1","fullName":"FOO.type1","typehint":"BasicTypeInfo","typeArgs":[],"members":[],"declAs":{"typehint":"Method"}},"isCallable":false},{"name":"name","localName":"localName","type":{"name":"type1","fullName":"FOO.type1","typehint":"BasicTypeInfo","typeArgs":[],"members":[],"declAs":{"typehint":"Method"}},"isCallable":false}],"typehint":"ImplicitParamInfo","fun":{"name":"name","localName":"localName","type":{"name":"type1","fullName":"FOO.type1","typehint":"BasicTypeInfo","typeArgs":[],"members":[],"declAs":{"typehint":"Method"}},"isCallable":false},"funIsImplicit":true,"end":6,"start":5}]}"""
     )
 
   }

--- a/protocol-swanky/CHANGELOG.md
+++ b/protocol-swanky/CHANGELOG.md
@@ -1,6 +1,14 @@
-Protocol Version: 0.8.19 (Must match version at ConnectionInfo.protocolVersion)
+Protocol Version: 0.8.20 (Must match version at ConnectionInfo.protocolVersion)
 
 Protocol Change Log:
+  0.8.20
+    Removed CallCompletionInfoReq
+    Removed TypeByIdReq
+    Removed InspectTypeByIdReq
+    Removed all type-id fields from result types, including
+      :type-id, :companion-id, :outer-type-id
+    Add :has-implicit field to CompletionSignature result type
+    CompletionSignature now returns fully qualified param types
   0.8.19
     Added swank:diff-refactor
   0.8.18

--- a/protocol-swanky/src/main/scala/org/ensime/server/protocol/swank/SwankFormats.scala
+++ b/protocol-swanky/src/main/scala/org/ensime/server/protocol/swank/SwankFormats.scala
@@ -378,11 +378,12 @@ object SwankProtocolResponse {
   implicit object CompletionSignatureFormat extends SexpFormat[CompletionSignature] {
     private implicit val Tuple2Format = SexpFormat[(String, String)]
     def write(cs: CompletionSignature): Sexp =
-      SexpList(cs.sections.toSexp, cs.result.toSexp)
+      SexpList(cs.sections.toSexp, cs.result.toSexp, cs.hasImplicit.toSexp)
     def read(sexp: Sexp): CompletionSignature = sexp match {
-      case SexpList(a :: b :: Nil) => CompletionSignature(
+      case SexpList(a :: b :: c :: Nil) => CompletionSignature(
         a.convertTo[List[List[(String, String)]]],
-        b.convertTo[String]
+        b.convertTo[String],
+        c.convertTo[Boolean]
       )
       case _ => deserializationError(sexp)
     }
@@ -424,7 +425,6 @@ object SwankProtocolResponse {
   implicit def ParamSectionInfoFormat = SexpFormat[ParamSectionInfo]
   implicit def ArrowTypeInfoFormat = SexpFormat[ArrowTypeInfo]
   implicit def BasicTypeInfoFormat = SexpFormat[BasicTypeInfo]
-  implicit def CallCompletionInfoFormat = SexpFormat[CallCompletionInfo]
   implicit def SymbolInfoFormat = SexpFormat[SymbolInfo]
   implicit def InterfaceInfoFormat = SexpFormat[InterfaceInfo]
   implicit def TypeInspectInfoFormat = SexpFormat[TypeInspectInfo]
@@ -542,7 +542,6 @@ object SwankProtocolResponse {
       case value: CompletionInfo => value.toSexp
       case value: CompletionInfoList => value.toSexp
       case value: SymbolInfo => value.toSexp
-      case value: CallCompletionInfo => value.toSexp
       case value: InterfaceInfo => value.toSexp
       case value: TypeInspectInfo => value.toSexp
       case value: SymbolSearchResults => value.toSexp
@@ -622,14 +621,11 @@ object SwankProtocolRequest {
   implicit val DocUriForSymbolReqHint = TypeHint[DocUriForSymbolReq](SexpSymbol("swank:doc-uri-for-symbol"))
   implicit val CompletionsReqHint = TypeHint[CompletionsReq](SexpSymbol("swank:completions"))
   implicit val PackageMemberCompletionReqHint = TypeHint[PackageMemberCompletionReq](SexpSymbol("swank:package-member-completion"))
-  implicit val CallCompletionReqHint = TypeHint[CallCompletionReq](SexpSymbol("swank:call-completion"))
   implicit val UsesOfSymbolAtPointReqHint = TypeHint[UsesOfSymbolAtPointReq](SexpSymbol("swank:uses-of-symbol-at-point"))
-  implicit val TypeByIdReqHint = TypeHint[TypeByIdReq](SexpSymbol("swank:type-by-id"))
   implicit val TypeByNameReqHint = TypeHint[TypeByNameReq](SexpSymbol("swank:type-by-name"))
   implicit val TypeByNameAtPointReqHint = TypeHint[TypeByNameAtPointReq](SexpSymbol("swank:type-by-name-at-point"))
   implicit val TypeAtPointReqHint = TypeHint[TypeAtPointReq](SexpSymbol("swank:type-at-point"))
   implicit val InspectTypeAtPointReqHint = TypeHint[InspectTypeAtPointReq](SexpSymbol("swank:inspect-type-at-point"))
-  implicit val InspectTypeByIdReqHint = TypeHint[InspectTypeByIdReq](SexpSymbol("swank:inspect-type-by-id"))
   implicit val InspectTypeByNameReqHint = TypeHint[InspectTypeByNameReq](SexpSymbol("swank:inspect-type-by-name"))
   implicit val SymbolAtPointReqHint = TypeHint[SymbolAtPointReq](SexpSymbol("swank:symbol-at-point"))
   implicit val SymbolByNameReqHint = TypeHint[SymbolByNameReq](SexpSymbol("swank:symbol-by-name"))
@@ -774,14 +770,11 @@ object SwankProtocolRequest {
   implicit def DocUriForSymbolReqFormat = SexpFormat[DocUriForSymbolReq]
   implicit def CompletionsReqFormat = SexpFormat[CompletionsReq]
   implicit def PackageMemberCompletionReqFormat = SexpFormat[PackageMemberCompletionReq]
-  implicit def CallCompletionReqFormat = SexpFormat[CallCompletionReq]
   implicit def UsesOfSymbolAtPointReqFormat = SexpFormat[UsesOfSymbolAtPointReq]
-  implicit def TypeByIdReqFormat = SexpFormat[TypeByIdReq]
   implicit def TypeByNameReqFormat = SexpFormat[TypeByNameReq]
   implicit def TypeByNameAtPointReqFormat = SexpFormat[TypeByNameAtPointReq]
   implicit def TypeAtPointReqFormat = SexpFormat[TypeAtPointReq]
   implicit def InspectTypeAtPointReqFormat = SexpFormat[InspectTypeAtPointReq]
-  implicit def InspectTypeByIdReqFormat = SexpFormat[InspectTypeByIdReq]
   implicit def InspectTypeByNameReqFormat = SexpFormat[InspectTypeByNameReq]
   implicit def SymbolAtPointReqFormat = SexpFormat[SymbolAtPointReq]
   implicit def SymbolByNameReqFormat = SexpFormat[SymbolByNameReq]
@@ -828,14 +821,11 @@ object SwankProtocolRequest {
           case s if s == DocUriForSymbolReqHint.hint => value.convertTo[DocUriForSymbolReq]
           case s if s == CompletionsReqHint.hint => value.convertTo[CompletionsReq]
           case s if s == PackageMemberCompletionReqHint.hint => value.convertTo[PackageMemberCompletionReq]
-          case s if s == CallCompletionReqHint.hint => value.convertTo[CallCompletionReq]
           case s if s == UsesOfSymbolAtPointReqHint.hint => value.convertTo[UsesOfSymbolAtPointReq]
-          case s if s == TypeByIdReqHint.hint => value.convertTo[TypeByIdReq]
           case s if s == TypeByNameReqHint.hint => value.convertTo[TypeByNameReq]
           case s if s == TypeByNameAtPointReqHint.hint => value.convertTo[TypeByNameAtPointReq]
           case s if s == TypeAtPointReqHint.hint => value.convertTo[TypeAtPointReq]
           case s if s == InspectTypeAtPointReqHint.hint => value.convertTo[InspectTypeAtPointReq]
-          case s if s == InspectTypeByIdReqHint.hint => value.convertTo[InspectTypeByIdReq]
           case s if s == InspectTypeByNameReqHint.hint => value.convertTo[InspectTypeByNameReq]
           case s if s == SymbolAtPointReqHint.hint => value.convertTo[SymbolAtPointReq]
           case s if s == SymbolByNameReqHint.hint => value.convertTo[SymbolByNameReq]

--- a/protocol-swanky/src/test/scala/org/ensime/server/protocol/swank/SwankFormatsSpec.scala
+++ b/protocol-swanky/src/test/scala/org/ensime/server/protocol/swank/SwankFormatsSpec.scala
@@ -128,18 +128,8 @@ class SwankFormatsSpec extends FlatSpec with Matchers with EnsimeTestData {
     )
 
     unmarshal(
-      """(swank:call-completion 13)""",
-      CallCompletionReq(13): RpcRequest
-    )
-
-    unmarshal(
       s"""(swank:uses-of-symbol-at-point "$file1" 100)""",
       UsesOfSymbolAtPointReq(Left(file1), 100): RpcRequest
-    )
-
-    unmarshal(
-      s"""(swank:type-by-id 13)""",
-      TypeByIdReq(13): RpcRequest
     )
 
     unmarshal(
@@ -160,11 +150,6 @@ class SwankFormatsSpec extends FlatSpec with Matchers with EnsimeTestData {
     unmarshal(
       s"""(swank:inspect-type-at-point "$file1" (1 100))""",
       InspectTypeAtPointReq(Left(file1), OffsetRange(1, 100)): RpcRequest
-    )
-
-    unmarshal(
-      s"""(swank:inspect-type-by-id 13)""",
-      InspectTypeByIdReq(13): RpcRequest
     )
 
     unmarshal(
@@ -525,27 +510,27 @@ class SwankFormatsSpec extends FlatSpec with Matchers with EnsimeTestData {
 
     marshal(
       completionInfo: CompletionInfo,
-      """(:name "name" :type-sig (((("abc" "def") ("hij" "lmn"))) "ABC") :type-id 88 :is-callable nil :relevance 90 :to-insert "BAZ")"""
+      """(:name "name" :type-sig (((("abc" "def") ("hij" "lmn"))) "ABC" nil) :is-callable nil :relevance 90 :to-insert "BAZ")"""
     )
 
     marshal(
       completionInfo2: CompletionInfo,
-      """(:name "name2" :type-sig (((("abc" "def"))) "ABC") :type-id 90 :is-callable t :relevance 91 :to-insert nil)"""
+      """(:name "name2" :type-sig (((("abc" "def"))) "ABC" nil) :is-callable t :relevance 91 :to-insert nil)"""
     )
 
     marshal(
       CompletionInfoList("fooBar", List(completionInfo)): CompletionInfoList,
-      """(:prefix "fooBar" :completions ((:name "name" :type-sig (((("abc" "def") ("hij" "lmn"))) "ABC") :type-id 88 :is-callable nil :relevance 90 :to-insert "BAZ")))"""
+      """(:prefix "fooBar" :completions ((:name "name" :type-sig (((("abc" "def") ("hij" "lmn"))) "ABC" nil) :is-callable nil :relevance 90 :to-insert "BAZ")))"""
     )
 
     marshal(
-      new SymbolInfo("name", "localName", None, typeInfo, false, Some(2)): SymbolInfo,
-      """(:name "name" :local-name "localName" :decl-pos nil :type (:arrow-type nil :name "type1" :type-id 7 :decl-as method :full-name "FOO.type1" :type-args nil :members nil :pos nil :outer-type-id 8) :is-callable nil :owner-type-id 2)"""
+      new SymbolInfo("name", "localName", None, typeInfo, false): SymbolInfo,
+      """(:name "name" :local-name "localName" :decl-pos nil :type (:arrow-type nil :name "type1" :decl-as method :full-name "FOO.type1" :type-args nil :members nil :pos nil) :is-callable nil)"""
     )
 
     marshal(
       new NamedTypeMemberInfo("typeX", typeInfo, None, None, DeclaredAs.Method): EntityInfo,
-      """(:name "typeX" :type (:arrow-type nil :name "type1" :type-id 7 :decl-as method :full-name "FOO.type1" :type-args nil :members nil :pos nil :outer-type-id 8) :pos nil :signature-string nil :decl-as method)"""
+      """(:name "typeX" :type (:arrow-type nil :name "type1" :decl-as method :full-name "FOO.type1" :type-args nil :members nil :pos nil) :pos nil :signature-string nil :decl-as method)"""
     )
 
     marshal(
@@ -564,18 +549,13 @@ class SwankFormatsSpec extends FlatSpec with Matchers with EnsimeTestData {
     )
 
     marshal(
-      new CallCompletionInfo(typeInfo, List(paramSectionInfo)): CallCompletionInfo,
-      """(:result-type (:arrow-type nil :name "type1" :type-id 7 :decl-as method :full-name "FOO.type1" :type-args nil :members nil :pos nil :outer-type-id 8) :param-sections ((:params (("ABC" (:arrow-type nil :name "type1" :type-id 7 :decl-as method :full-name "FOO.type1" :type-args nil :members nil :pos nil :outer-type-id 8))) :is-implicit nil)))"""
-    )
-
-    marshal(
       interfaceInfo: InterfaceInfo,
-      """(:type (:arrow-type nil :name "type1" :type-id 7 :decl-as method :full-name "FOO.type1" :type-args nil :members nil :pos nil :outer-type-id 8) :via-view "DEF")"""
+      """(:type (:arrow-type nil :name "type1" :decl-as method :full-name "FOO.type1" :type-args nil :members nil :pos nil) :via-view "DEF")"""
     )
 
     marshal(
-      new TypeInspectInfo(typeInfo, Some(1), List(interfaceInfo)): TypeInspectInfo,
-      """(:type (:arrow-type nil :name "type1" :type-id 7 :decl-as method :full-name "FOO.type1" :type-args nil :members nil :pos nil :outer-type-id 8) :companion-id 1 :interfaces ((:type (:arrow-type nil :name "type1" :type-id 7 :decl-as method :full-name "FOO.type1" :type-args nil :members nil :pos nil :outer-type-id 8) :via-view "DEF")) :info-type typeInspect)"""
+      new TypeInspectInfo(typeInfo, List(interfaceInfo)): TypeInspectInfo,
+      """(:type (:arrow-type nil :name "type1" :decl-as method :full-name "FOO.type1" :type-args nil :members nil :pos nil) :interfaces ((:type (:arrow-type nil :name "type1" :decl-as method :full-name "FOO.type1" :type-args nil :members nil :pos nil) :via-view "DEF")) :info-type typeInspect)"""
     )
 
     marshal(

--- a/protocol-swanky/src/test/scala/org/ensime/server/protocol/swank/SwankTestData.scala
+++ b/protocol-swanky/src/test/scala/org/ensime/server/protocol/swank/SwankTestData.scala
@@ -6,7 +6,7 @@ import org.ensime.api._
 
 object SwankTestData extends EnsimeTestData {
 
-  val typeInfoStr = """(:arrow-type nil :name "type1" :type-id 7 :decl-as method :full-name "FOO.type1" :type-args nil :members nil :pos nil :outer-type-id 8)"""
+  val typeInfoStr = """(:arrow-type nil :name "type1" :decl-as method :full-name "FOO.type1" :type-args nil :members nil :pos nil)"""
 
   val typeInspectInfoStr = s"""(:type $typeInfoStr :companion-id 1 :interfaces ((:type """ + typeInfoStr + """ :via-view "DEF")) :info-type typeInspect)"""
 
@@ -14,7 +14,7 @@ object SwankTestData extends EnsimeTestData {
 
   val symbolDesignationsStr = s"""(:file $symFile :syms ((object 7 9) (trait 11 22)))"""
 
-  val symbolInfoStr = """(:name "name" :local-name "localName" :decl-pos nil :type """ + typeInfoStr + """ :is-callable nil :owner-type-id 2)"""
+  val symbolInfoStr = """(:name "name" :local-name "localName" :decl-pos nil :type """ + typeInfoStr + """ :is-callable nil)"""
 
   val implicitInfosStr = s"""((:type conversion :start 5 :end 6 :fun $symbolInfoStr) (:type param :start 7 :end 8 :fun $symbolInfoStr :params ($symbolInfoStr $symbolInfoStr) :fun-is-implicit t))"""
 
@@ -24,9 +24,9 @@ object SwankTestData extends EnsimeTestData {
 
   val packageInfoStr = """(:info-type package :name "name" :full-name "fullName" :members nil)"""
 
-  val completionInfoStr = """(:name "name" :type-sig (((("abc" "def") ("hij" "lmn"))) "ABC") :type-id 88 :is-callable nil :relevance 90 :to-insert "BAZ")"""
+  val completionInfoStr = """(:name "name" :type-sig (((("abc" "def") ("hij" "lmn"))) "ABC") :is-callable nil :relevance 90 :to-insert "BAZ")"""
 
-  val completionInfo2Str = """(:name "name2" :type-sig (((("abc" "def"))) "ABC") :type-id 90 :is-callable t :relevance 91 :to-insert nil)"""
+  val completionInfo2Str = """(:name "name2" :type-sig (((("abc" "def"))) "ABC") :is-callable t :relevance 91 :to-insert nil)"""
 
   val completionInfoListStr = "(" + completionInfoStr + " " + completionInfo2Str + ")"
 
@@ -65,5 +65,5 @@ object SwankTestData extends EnsimeTestData {
 
   val noteListStr = "(:is-full t :notes (" + note1Str + " " + note2Str + "))"
 
-  val entityInfoStr = """(:arrow-type t :name "Arrow1" :type-id 8 :result-type (:arrow-type nil :name "type1" :type-id 7 :decl-as method :full-name "FOO.type1" :type-args nil :members nil :pos nil :outer-type-id 8) :param-sections ((:params (("ABC" (:arrow-type nil :name "type1" :type-id 7 :decl-as method :full-name "FOO.type1" :type-args nil :members nil :pos nil :outer-type-id 8))) :is-implicit nil)))"""
+  val entityInfoStr = """(:arrow-type t :name "Arrow1" :result-type (:arrow-type nil :name "type1" :decl-as method :full-name "FOO.type1" :type-args nil :members nil :pos nil) :param-sections ((:params (("ABC" (:arrow-type nil :name "type1" :decl-as method :full-name "FOO.type1" :type-args nil :members nil :pos nil))) :is-implicit nil)))"""
 }


### PR DESCRIPTION
The emacs client only uses CallCompletionInfo at this point, and I believe I can get rid of that by making small tweaks to CompletionSignature, which is returned with the CompletionInfo objects. In the mean time, let's get all the client teams on the same page (my guess is not many folks use this stuff..).
@rorygraves @fommil 