### PR TITLE
Add index on file column to the FqnSymbols table

### DIFF
--- a/core/src/main/scala/org/ensime/indexer/DatabaseService.scala
+++ b/core/src/main/scala/org/ensime/indexer/DatabaseService.scala
@@ -167,6 +167,7 @@ object DatabaseService {
     def * = (id.?, file, path, fqn, descriptor, internal, source, line, offset) <> (FqnSymbol.tupled, FqnSymbol.unapply)
     def fqnIdx = index("idx_fqn", fqn, unique = false) // fqns are unique by type and sig
     def uniq = index("idx_uniq", (fqn, descriptor, internal), unique = true)
+    def fileIdx = index("idx_file", file, unique = false)
   }
   private val fqnSymbols = TableQuery[FqnSymbols]
   private val fqnSymbolsCompiled = Compiled { TableQuery[FqnSymbols] }

--- a/core/src/main/scala/org/ensime/indexer/SearchService.scala
+++ b/core/src/main/scala/org/ensime/indexer/SearchService.scala
@@ -36,7 +36,7 @@ class SearchService(
     with SLF4JLogging {
 
   private val QUERY_TIMEOUT = 30 seconds
-  private val version = "1.0"
+  private val version = "1.1"
 
   private val index = new IndexService(config.cacheDir / ("index-" + version))
   private val db = new DatabaseService(config.cacheDir / ("sql-" + version))


### PR DESCRIPTION
This will make the batches of deletes quicker. (looking at the code, I see it already batches deletes 1000 at a time).
But this is always going to be a relatively slow operation for large scale deletes. Over a certain threshold, it may well be quicker to wipe and rebuild.