### PR TITLE
Revert index

### DIFF
--- a/core/src/main/scala/org/ensime/indexer/DatabaseService.scala
+++ b/core/src/main/scala/org/ensime/indexer/DatabaseService.scala
@@ -168,7 +168,6 @@ object DatabaseService {
     def * = (id.?, file, path, fqn, descriptor, internal, source, line, offset) <> (FqnSymbol.tupled, FqnSymbol.unapply)
     def fqnIdx = index("idx_fqn", fqn, unique = false) // fqns are unique by type and sig
     def uniq = index("idx_uniq", (fqn, descriptor, internal), unique = true)
-    def fileIdx = index("idx_file", file, unique = false)
   }
   private val fqnSymbols = TableQuery[FqnSymbols]
   private val fqnSymbolsCompiled = Compiled { TableQuery[FqnSymbols] }

--- a/core/src/main/scala/org/ensime/indexer/SearchService.scala
+++ b/core/src/main/scala/org/ensime/indexer/SearchService.scala
@@ -36,6 +36,18 @@ class SearchService(
     with SLF4JLogging {
 
   private val QUERY_TIMEOUT = 30 seconds
+
+  /**
+   * Changelog:
+   *
+   * 1.0 - reverted index due to negative impact to startup time. The
+   *       workaround to large scale deletions is to just nuke the
+   *       .ensime_cache.
+   *
+   * 1.1 - added index to FileCheck.file to speed up delete.
+   *
+   * 1.0 - initial schema
+   */
   private val version = "1.0"
 
   private val index = new IndexService(config.cacheDir / ("index-" + version))

--- a/core/src/main/scala/org/ensime/indexer/SearchService.scala
+++ b/core/src/main/scala/org/ensime/indexer/SearchService.scala
@@ -36,7 +36,7 @@ class SearchService(
     with SLF4JLogging {
 
   private val QUERY_TIMEOUT = 30 seconds
-  private val version = "1.1"
+  private val version = "1.0"
 
   private val index = new IndexService(config.cacheDir / ("index-" + version))
   private val db = new DatabaseService(config.cacheDir / ("sql-" + version))


### PR DESCRIPTION
@smootoo @cvogt 

Apologies, I'm going to revert this as it slows down startup significantly (10 mins to 45 mins for my project).

Sue's right that if there are lots of changes, just drop the table... the user can do that by nuking the `.ensime_cache` directory.