### PR TITLE
Migrate tests to EnsimeSpec

### DIFF
--- a/core/src/it/scala/org/ensime/core/DocFindingSpec.scala
+++ b/core/src/it/scala/org/ensime/core/DocFindingSpec.scala
@@ -2,24 +2,16 @@
 // Licence: http://www.gnu.org/licenses/gpl-3.0.en.html
 package org.ensime.core
 
-import java.io.File
-
-import akka.event.slf4j.SLF4JLogging
 import org.ensime.fixture._
-import org.scalatest._
-
-import scala.collection.immutable.Queue
-import scala.concurrent.Await
+import org.ensime.util.EnsimeSpec
 import scala.reflect.internal.util.{ BatchSourceFile, OffsetPosition }
 import scala.tools.nsc.Settings
 import scala.tools.nsc.reporters.ConsoleReporter
-import scala.util.Properties
 
-class DocFindingSpec extends FlatSpec with Matchers
+class DocFindingSpec extends EnsimeSpec
     with IsolatedRichPresentationCompilerFixture
     with RichPresentationCompilerTestUtils
-    with ReallyRichPresentationCompilerFixture
-    with SLF4JLogging {
+    with ReallyRichPresentationCompilerFixture {
   import ReallyRichPresentationCompilerFixture._
 
   val original = EnsimeConfigFixture.DocsTestProject

--- a/core/src/it/scala/org/ensime/core/DocJarReadingSpec.scala
+++ b/core/src/it/scala/org/ensime/core/DocJarReadingSpec.scala
@@ -3,9 +3,9 @@
 package org.ensime.core
 
 import org.ensime.fixture._
-import org.scalatest._
+import org.ensime.util.EnsimeSpec
 
-class DocJarReadingSpec extends FlatSpec with Matchers with SharedEnsimeConfigFixture {
+class DocJarReadingSpec extends EnsimeSpec with SharedEnsimeConfigFixture {
 
   val original = EnsimeConfigFixture.DocsTestProject
 

--- a/core/src/it/scala/org/ensime/core/DocResolverSpec.scala
+++ b/core/src/it/scala/org/ensime/core/DocResolverSpec.scala
@@ -8,10 +8,11 @@ import akka.pattern.ask
 import akka.testkit.TestActorRef
 import org.ensime.api._
 import org.ensime.fixture._
-import org.scalatest._
+import org.ensime.util.EnsimeSpec
 
-class DocResolverSpec extends FlatSpec with Matchers with SLF4JLogging
-    with IsolatedEnsimeConfigFixture with IsolatedTestKitFixture {
+class DocResolverSpec extends EnsimeSpec
+    with IsolatedEnsimeConfigFixture
+    with IsolatedTestKitFixture {
 
   val original = EnsimeConfigFixture.DocsTestProject
 

--- a/core/src/it/scala/org/ensime/core/ImplicitAnalyzerSpec.scala
+++ b/core/src/it/scala/org/ensime/core/ImplicitAnalyzerSpec.scala
@@ -2,13 +2,12 @@
 // Licence: http://www.gnu.org/licenses/gpl-3.0.en.html
 package org.ensime.core
 
-import org.ensime.fixture._
 import org.ensime.api._
-import org.scalatest._
-
+import org.ensime.fixture._
+import org.ensime.util.EnsimeSpec
 import scala.reflect.internal.util.{ OffsetPosition, RangePosition }
 
-class ImplicitAnalyzerSpec extends WordSpec with Matchers
+class ImplicitAnalyzerSpec extends EnsimeSpec
     with IsolatedRichPresentationCompilerFixture
     with RichPresentationCompilerTestUtils
     with ReallyRichPresentationCompilerFixture {
@@ -36,8 +35,8 @@ class ImplicitAnalyzerSpec extends WordSpec with Matchers
     }
   }
 
-  "ImplicitAnalyzer" should {
-    "render implicit conversions" in withPresCompiler { (config, cc) =>
+  "ImplicitAnalyzer" should "render implicit conversions" in {
+    withPresCompiler { (config, cc) =>
       val dets = getImplicitDetails(
         cc,
         """
@@ -49,12 +48,14 @@ class ImplicitAnalyzerSpec extends WordSpec with Matchers
             }
         """
       )
-      assert(dets === List(
+      dets should ===(List(
         ("conversion", "\"sample\"", "StringToTest")
       ))
     }
+  }
 
-    "render implicit parameters passed to implicit conversion functions" in withPresCompiler { (config, cc) =>
+  it should "render implicit parameters passed to implicit conversion functions" in {
+    withPresCompiler { (config, cc) =>
       val dets = getImplicitDetails(
         cc,
         """
@@ -68,13 +69,15 @@ class ImplicitAnalyzerSpec extends WordSpec with Matchers
             }
         """
       )
-      assert(dets === List(
+      dets should ===(List(
         ("param", "\"sample\"", "StringToTest", List("myThing"), true),
         ("conversion", "\"sample\"", "StringToTest")
       ))
     }
+  }
 
-    "render implicit parameters" in withPresCompiler { (config, cc) =>
+  it should "render implicit parameters" in {
+    withPresCompiler { (config, cc) =>
       val dets = getImplicitDetails(
         cc,
         """
@@ -91,13 +94,15 @@ class ImplicitAnalyzerSpec extends WordSpec with Matchers
             }
         """
       )
-      assert(dets === List(
+      dets should ===(List(
         ("param", "zz(1)(\"abc\")", "zz", List("myThing", "myThong"), false),
         ("param", "yy", "yy", List("myThing"), false)
       ))
     }
+  }
 
-    "work with offset positions" in withPresCompiler { (config, cc) =>
+  it should "work with offset positions" in {
+    withPresCompiler { (config, cc) =>
 
       val content = """
             package com.example
@@ -114,11 +119,11 @@ class ImplicitAnalyzerSpec extends WordSpec with Matchers
 
       val pos = new OffsetPosition(file, implicitPos)
       val dets = new ImplicitAnalyzer(cc).implicitDetails(pos)
-      assert(dets.length === 1)
+      dets should have length 1
 
       val pos1 = new OffsetPosition(file, implicitPos + 1)
       val dets1 = new ImplicitAnalyzer(cc).implicitDetails(pos1)
-      assert(dets1.length === 0)
+      dets1 shouldBe empty
     }
   }
 }

--- a/core/src/it/scala/org/ensime/core/RefactoringHandlerSpec.scala
+++ b/core/src/it/scala/org/ensime/core/RefactoringHandlerSpec.scala
@@ -5,14 +5,13 @@ package org.ensime.core
 import java.io.File
 import java.text.SimpleDateFormat
 import java.util.Date
-import org.scalatest._
-
 import org.ensime.api._
 import org.ensime.fixture._
+import org.ensime.util.EnsimeSpec
 
-class RefactoringHandlerSpec extends WordSpec with Matchers
-    with IsolatedAnalyzerFixture with RichPresentationCompilerTestUtils
-    with GivenWhenThen {
+class RefactoringHandlerSpec extends EnsimeSpec
+    with IsolatedAnalyzerFixture
+    with RichPresentationCompilerTestUtils {
 
   val encoding = "UTF-16"
   def original = EnsimeConfigFixture.EmptyTestProject.copy(
@@ -25,8 +24,8 @@ class RefactoringHandlerSpec extends WordSpec with Matchers
   def ContentsInSourceFileInfo(file: File, contentsIn: File) =
     SourceFileInfo(file, contentsIn = Some(contentsIn))
 
-  "RefactoringHandler" should {
-    "format files and preserve encoding" in withAnalyzer { (config, analyzerRef) =>
+  "RefactoringHandler" should "format files and preserve encoding" in {
+    withAnalyzer { (config, analyzerRef) =>
       val file = srcFile(config, "abc.scala", contents(
         "package blah",
         "   class Something {",
@@ -47,10 +46,12 @@ class RefactoringHandlerSpec extends WordSpec with Matchers
         "  val x = (1 \u2192 2)",
         "}"
       )
-      assert(fileContents === expectedContents)
+      fileContents should ===(expectedContents)
     }
+  }
 
-    "format files from ContentsSourceFileInfo with handleFormatFile" in withAnalyzer { (dir, analyzerRef) =>
+  it should "format files from ContentsSourceFileInfo with handleFormatFile" in {
+    withAnalyzer { (dir, analyzerRef) =>
       val content = contents(
         "package blah",
         "   class  Something   {}"
@@ -63,10 +64,12 @@ class RefactoringHandlerSpec extends WordSpec with Matchers
         "class Something {}",
         ""
       )
-      assert(formatted === expectedContents)
+      formatted should ===(expectedContents)
     }
+  }
 
-    "format files from ContentsInSourceFileInfo with handleFormatFile and handle encoding" in withAnalyzer { (dir, analyzerRef) =>
+  it should "format files from ContentsInSourceFileInfo with handleFormatFile and handle encoding" in {
+    withAnalyzer { (dir, analyzerRef) =>
       val file = srcFile(dir, "tmp-contents", contents(
         "package blah",
         "   class  Something   {}"
@@ -80,10 +83,12 @@ class RefactoringHandlerSpec extends WordSpec with Matchers
         "class Something {}",
         ""
       )
-      assert(formatted === expectedContents)
+      formatted should ===(expectedContents)
     }
+  }
 
-    "format files from FileSourceFileInfo with handleFormatFile and handle encoding" in withAnalyzer { (dir, analyzerRef) =>
+  it should "format files from FileSourceFileInfo with handleFormatFile and handle encoding" in {
+    withAnalyzer { (dir, analyzerRef) =>
       val file = srcFile(dir, "abc.scala", contents(
         "package blah",
         "   class  Something   {}"
@@ -97,117 +102,119 @@ class RefactoringHandlerSpec extends WordSpec with Matchers
         "class Something {}",
         ""
       )
-      assert(formatted === expectedContents)
+      formatted === (expectedContents)
     }
+  }
 
-    "not format invalid files" in withAnalyzer { (config, analyzerRef) =>
-      val file = srcFile(config, "abc.scala", contents(
-        "package blah",
-        "invalid scala syntax"
-      ), write = true, encoding = encoding)
+  it should "not format invalid files" in withAnalyzer { (config, analyzerRef) =>
+    val file = srcFile(config, "abc.scala", contents(
+      "package blah",
+      "invalid scala syntax"
+    ), write = true, encoding = encoding)
 
-      val analyzer = analyzerRef.underlyingActor
+    val analyzer = analyzerRef.underlyingActor
 
-      analyzer.handleFormatFiles(List(new File(file.path)))
-      val fileContents = readSrcFile(file, encoding)
+    analyzer.handleFormatFiles(List(new File(file.path)))
+    val fileContents = readSrcFile(file, encoding)
 
-      val expectedContents = contents(
-        "package blah",
-        "invalid scala syntax"
+    val expectedContents = contents(
+      "package blah",
+      "invalid scala syntax"
+    )
+    fileContents should ===(expectedContents)
+  }
+
+  //
+  // core/src/main/scala/org/ensime/core/Refactoring.scala#L.239
+  //
+  it should "organize imports when 3 imports exist" in withAnalyzer { (dir, analyzerRef) =>
+
+    // Please refer Scala IDE
+    // scala-refactoring/src/test/scala/scala/tools/refactoring/tests/implementations/imports/
+    // --> OrganizeImportsWildcardsTest.scala
+
+    // OrganizeImports need some paren --> "{...}"
+    val file = srcFile(dir, "tmp-contents", contents(
+      "import java.lang.Integer.{valueOf => vo}",
+      "import java.lang.Integer.toBinaryString",
+      "import java.lang.String.valueOf",
+      " ",
+      "trait Temp {",
+      "  valueOf(5)",
+      "  vo(\"5\")",
+      "  toBinaryString(27)",
+      "}"
+    ), write = true, encoding = encoding)
+
+    val analyzer = analyzerRef.underlyingActor
+
+    val procId = 1
+    analyzer.handleRefactorPrepareRequest(
+      new PrepareRefactorReq(
+        procId, 'Ignored, OrganiseImportsRefactorDesc(new File(file.path)), false
       )
-      assert(fileContents === expectedContents)
-    }
+    )
+    analyzer.handleRefactorExec(
+      new ExecRefactorReq(procId, RefactorType.OrganizeImports)
+    )
 
-    //
-    // core/src/main/scala/org/ensime/core/Refactoring.scala#L.239
-    //
-    "organize imports when 3 imports exist" in withAnalyzer { (dir, analyzerRef) =>
+    val formatted = readSrcFile(file, encoding)
+    val expectedContents = contents(
+      "import java.lang.Integer.{toBinaryString, valueOf => vo}",
+      "import java.lang.String.valueOf",
+      " ",
+      "trait Temp {",
+      "  valueOf(5)",
+      "  vo(\"5\")",
+      "  toBinaryString(27)",
+      "}"
+    )
+    formatted should ===(expectedContents)
+  }
 
-      // Please refer Scala IDE
-      // scala-refactoring/src/test/scala/scala/tools/refactoring/tests/implementations/imports/
-      // --> OrganizeImportsWildcardsTest.scala
+  it should "add imports on the first line" in withAnalyzer { (dir, analyzerRef) =>
+    val file = srcFile(dir, "tmp-contents", contents(
+      "import java.lang.Integer.toBinaryString",
+      "import java.lang.String.valueOf",
+      "",
+      "trait Temp {",
+      "  valueOf(5)",
+      "  vo(\"5\")",
+      "  toBinaryString(27)",
+      "}"
+    ), write = true, encoding = encoding)
 
-      // OrganizeImports need some paren --> "{...}"
-      val file = srcFile(dir, "tmp-contents", contents(
-        "import java.lang.Integer.{valueOf => vo}",
-        "import java.lang.Integer.toBinaryString",
-        "import java.lang.String.valueOf",
-        " ",
-        "trait Temp {",
-        "  valueOf(5)",
-        "  vo(\"5\")",
-        "  toBinaryString(27)",
-        "}"
-      ), write = true, encoding = encoding)
+    val analyzer = analyzerRef.underlyingActor
 
-      val analyzer = analyzerRef.underlyingActor
-
-      val procId = 1
-      analyzer.handleRefactorPrepareRequest(
-        new PrepareRefactorReq(
-          procId, 'Ignored, OrganiseImportsRefactorDesc(new File(file.path)), false
-        )
+    val procId = 1
+    analyzer.handleRefactorPrepareRequest(
+      new PrepareRefactorReq(
+        procId, 'Ignored, AddImportRefactorDesc("java.lang.Integer.{valueOf => vo}", new File(file.path)), false
       )
-      analyzer.handleRefactorExec(
-        new ExecRefactorReq(procId, RefactorType.OrganizeImports)
-      )
+    )
+    analyzer.handleRefactorExec(
+      new ExecRefactorReq(procId, RefactorType.AddImport)
+    )
 
-      val formatted = readSrcFile(file, encoding)
-      val expectedContents = contents(
-        "import java.lang.Integer.{toBinaryString, valueOf => vo}",
-        "import java.lang.String.valueOf",
-        " ",
-        "trait Temp {",
-        "  valueOf(5)",
-        "  vo(\"5\")",
-        "  toBinaryString(27)",
-        "}"
-      )
-      assert(formatted === expectedContents)
-    }
+    val formatted = readSrcFile(file, encoding)
 
-    "add imports on the first line" in withAnalyzer { (dir, analyzerRef) =>
-      val file = srcFile(dir, "tmp-contents", contents(
-        "import java.lang.Integer.toBinaryString",
-        "import java.lang.String.valueOf",
-        "",
-        "trait Temp {",
-        "  valueOf(5)",
-        "  vo(\"5\")",
-        "  toBinaryString(27)",
-        "}"
-      ), write = true, encoding = encoding)
+    val expectedContents = contents(
+      "import java.lang.Integer.toBinaryString",
+      "import java.lang.String.valueOf",
+      "import java.lang.Integer.{valueOf => vo}",
+      "",
+      "trait Temp {",
+      "  valueOf(5)",
+      "  vo(\"5\")",
+      "  toBinaryString(27)",
+      "}"
+    )
 
-      val analyzer = analyzerRef.underlyingActor
+    formatted should ===(expectedContents)
+  }
 
-      val procId = 1
-      analyzer.handleRefactorPrepareRequest(
-        new PrepareRefactorReq(
-          procId, 'Ignored, AddImportRefactorDesc("java.lang.Integer.{valueOf => vo}", new File(file.path)), false
-        )
-      )
-      analyzer.handleRefactorExec(
-        new ExecRefactorReq(procId, RefactorType.AddImport)
-      )
-
-      val formatted = readSrcFile(file, encoding)
-
-      val expectedContents = contents(
-        "import java.lang.Integer.toBinaryString",
-        "import java.lang.String.valueOf",
-        "import java.lang.Integer.{valueOf => vo}",
-        "",
-        "trait Temp {",
-        "  valueOf(5)",
-        "  vo(\"5\")",
-        "  toBinaryString(27)",
-        "}"
-      )
-
-      assert(formatted === expectedContents)
-    }
-
-    "add imports on the first line when other examples come" in withAnalyzer { (dir, analyzerRef) =>
+  it should "add imports on the first line when other examples come" in {
+    withAnalyzer { (dir, analyzerRef) =>
       val file = srcFile(dir, "tmp-contents", contents(
         "package org.ensime.testing",
         "",
@@ -244,88 +251,90 @@ class RefactoringHandlerSpec extends WordSpec with Matchers
         "}"
       )
 
-      assert(formatted === expectedContents)
+      formatted should ===(expectedContents)
     }
+  }
 
-    "rename a function id with params' opening/closing parenthesis on different lines" ignore withAnalyzer { (dir, analyzerRef) =>
+  it should "rename a function id with params' opening/closing parenthesis on different lines" ignore withAnalyzer { (dir, analyzerRef) =>
+
+    val file = srcFile(dir, "tmp-contents", contents(
+      "package org.ensime.testing",
+      "trait Foo {",
+      "def doIt(",
+      ") = \"\"",
+      "}",
+      ""
+    ), write = true, encoding = encoding)
+
+    val analyzer = analyzerRef.underlyingActor
+
+    val procId = 1
+    analyzer.handleRefactorPrepareRequest(
+      new PrepareRefactorReq(
+        procId, 'rename, RenameRefactorDesc("doItNow", new File(file.path), 43, 47), false
+      )
+    )
+    analyzer.handleRefactorExec(
+      new ExecRefactorReq(procId, RefactorType.Rename)
+    )
+    val formatted = readSrcFile(file, encoding)
+    val expectedContents = contents(
+      "package org.ensime.testing",
+      "trait Foo {",
+      "def doItNow(",
+      ") = \"\"",
+      "}",
+      ""
+    )
+    formatted should ===(expectedContents)
+  }
+
+  it should "organize imports" in {
+    withAnalyzer { (dir, analyzerRef) =>
+      import org.ensime.util.file._
+
+      //when 3 imports exist
+      // "produce a diff file in the unified output format"
 
       val file = srcFile(dir, "tmp-contents", contents(
-        "package org.ensime.testing",
-        "trait Foo {",
-        "def doIt(",
-        ") = \"\"",
-        "}",
-        ""
+        "import java.lang.Integer.{valueOf => vo}",
+        "import java.lang.Integer.toBinaryString",
+        "import java.lang.String.valueOf",
+        " ",
+        "trait Temp {",
+        "  valueOf(5)",
+        "  vo(\"5\")",
+        "  toBinaryString(27)",
+        "}"
       ), write = true, encoding = encoding)
 
       val analyzer = analyzerRef.underlyingActor
 
       val procId = 1
-      analyzer.handleRefactorPrepareRequest(
-        new PrepareRefactorReq(
-          procId, 'rename, RenameRefactorDesc("doItNow", new File(file.path), 43, 47), false
+      val result = analyzer.handleRefactorRequest(
+        new RefactorReq(
+          procId, OrganiseImportsRefactorDesc(new File(file.path)), false
         )
       )
-      analyzer.handleRefactorExec(
-        new ExecRefactorReq(procId, RefactorType.Rename)
-      )
-      val formatted = readSrcFile(file, encoding)
-      val expectedContents = contents(
-        "package org.ensime.testing",
-        "trait Foo {",
-        "def doItNow(",
-        ") = \"\"",
-        "}",
-        ""
-      )
-      assert(formatted === expectedContents)
-    }
-  }
-
-  "RefactoringHandler" should {
-    "produce a diff file in the unified output format" when {
-      "organize imports when 3 imports exist" in withAnalyzer { (dir, analyzerRef) =>
-        import org.ensime.util.file._
-        val file = srcFile(dir, "tmp-contents", contents(
-          "import java.lang.Integer.{valueOf => vo}",
-          "import java.lang.Integer.toBinaryString",
-          "import java.lang.String.valueOf",
-          " ",
-          "trait Temp {",
-          "  valueOf(5)",
-          "  vo(\"5\")",
-          "  toBinaryString(27)",
-          "}"
-        ), write = true, encoding = encoding)
-
-        val analyzer = analyzerRef.underlyingActor
-
-        val procId = 1
-        val result = analyzer.handleRefactorRequest(
-          new RefactorReq(
-            procId, OrganiseImportsRefactorDesc(new File(file.path)), false
-          )
-        )
-        val diffFile = result match {
-          case RefactorDiffEffect(_, _, f) => f.canon
-          case _ => fail()
-        }
-
-        val sdf = new SimpleDateFormat("yyyy-MM-dd hh:mm:ss Z")
-        val t = sdf.format(new Date((new File(file.path)).lastModified()))
-        val diffContents = diffFile.readString()
-        val expectedContents = s"""|--- ${file.path}	${t}
-                                   |+++ ${file.path}	${t}
-                                   |@@ -1,3 +1,2 @@
-                                   |-import java.lang.Integer.{valueOf => vo}
-                                   |-import java.lang.Integer.toBinaryString
-                                   |+import java.lang.Integer.{toBinaryString, valueOf => vo}
-                                   | import java.lang.String.valueOf
-                                   |""".stripMargin
-
-        assert(diffContents === expectedContents)
-        diffFile.delete()
+      val diffFile = result match {
+        case RefactorDiffEffect(_, _, f) => f.canon
+        case _ => fail()
       }
+
+      val sdf = new SimpleDateFormat("yyyy-MM-dd hh:mm:ss Z")
+      val t = sdf.format(new Date((new File(file.path)).lastModified()))
+      val diffContents = diffFile.readString()
+      val expectedContents = s"""|--- ${file.path}	${t}
+                                 |+++ ${file.path}	${t}
+                                 |@@ -1,3 +1,2 @@
+                                 |-import java.lang.Integer.{valueOf => vo}
+                                 |-import java.lang.Integer.toBinaryString
+                                 |+import java.lang.Integer.{toBinaryString, valueOf => vo}
+                                 | import java.lang.String.valueOf
+                                 |""".stripMargin
+
+      diffContents should ===(expectedContents)
+      diffFile.delete()
     }
   }
 

--- a/core/src/it/scala/org/ensime/core/RichPresentationCompilerSpec.scala
+++ b/core/src/it/scala/org/ensime/core/RichPresentationCompilerSpec.scala
@@ -3,14 +3,11 @@
 package org.ensime.core
 
 import java.io.File
-
-import akka.event.slf4j.SLF4JLogging
 import org.ensime.api._
 import org.ensime.fixture._
 import org.ensime.vfs._
-import org.scalatest._
+import org.ensime.util.EnsimeSpec
 import org.ensime.util.file._
-
 import scala.collection.immutable.Queue
 import scala.concurrent.Await
 import scala.concurrent.duration._
@@ -19,16 +16,15 @@ import scala.tools.nsc.Settings
 import scala.tools.nsc.reporters.ConsoleReporter
 import scala.util.Properties
 
-class RichPresentationCompilerThatNeedsJavaLibsSpec extends WordSpec with Matchers
+class RichPresentationCompilerThatNeedsJavaLibsSpec extends EnsimeSpec
     with IsolatedRichPresentationCompilerFixture
     with RichPresentationCompilerTestUtils
-    with ReallyRichPresentationCompilerFixture
-    with SLF4JLogging {
+    with ReallyRichPresentationCompilerFixture {
 
   val original = EnsimeConfigFixture.SimpleTestProject
 
-  "RichPresentationCompiler" should {
-    "locate source position of Java classes in import statements" in withPresCompiler { (config, cc) =>
+  "RichPresentationCompiler" should "locate source position of Java classes in import statements" in {
+    withPresCompiler { (config, cc) =>
       import ReallyRichPresentationCompilerFixture._
 
       cc.search.refreshResolver()
@@ -38,27 +34,25 @@ class RichPresentationCompilerThatNeedsJavaLibsSpec extends WordSpec with Matche
         "package com.example",
         "import java.io.File@0@") { (p, label, cc) =>
           val sym = cc.askSymbolInfoAt(p).get
-          assert(sym.declPos.isDefined)
-          assert(sym.declPos.get match {
-            case LineSourcePosition(f, i) =>
-              f.parts.contains("File.java") && i > 0
-            case _ => false
-          })
+          inside(sym.declPos) {
+            case Some(LineSourcePosition(f, i)) =>
+              f.parts should contain("File.java")
+              i should be > 0
+          }
         }
     }
   }
 }
 
-class RichPresentationCompilerSpec extends WordSpec with Matchers
+class RichPresentationCompilerSpec extends EnsimeSpec
     with IsolatedRichPresentationCompilerFixture
     with RichPresentationCompilerTestUtils
-    with ReallyRichPresentationCompilerFixture
-    with SLF4JLogging {
+    with ReallyRichPresentationCompilerFixture {
 
   val original = EnsimeConfigFixture.EmptyTestProject
 
-  "RichPresentationCompiler" should {
-    "round-trip between typeFullName and askTypeInfoByName" in withPresCompiler { (config, cc) =>
+  "RichPresentationCompiler" should "round-trip between typeFullName and askTypeInfoByName" in {
+    withPresCompiler { (config, cc) =>
       val file = srcFile(config, "abc.scala", contents(
         "package com.example",
         "object /*1*/A { ",
@@ -79,10 +73,10 @@ class RichPresentationCompilerSpec extends WordSpec with Matchers
         val index = file.content.mkString.indexOf(comment)
         val tpe = cc.askTypeInfoAt(new OffsetPosition(file, index + comment.length)).get
         val fullName = tpe.fullName
-        assert(fullName === expectedFullName)
+        fullName should ===(expectedFullName)
 
         val tpe2 = cc.askTypeInfoByName(fullName).get
-        assert(tpe2.fullName === expectedFullName)
+        tpe2.fullName should ===(expectedFullName)
       }
 
       roundtrip("1", "com.example.A$")
@@ -93,23 +87,26 @@ class RichPresentationCompilerSpec extends WordSpec with Matchers
       roundtrip("2.1", "com.example.A$X")
       roundtrip("2.2", "com.example.A$X$")
     }
+  }
 
-    "get symbol info with cursor immediately after and before symbol" in withPresCompiler { (config, cc) =>
+  it should "get symbol info with cursor immediately after and before symbol" in {
+    withPresCompiler { (config, cc) =>
       import ReallyRichPresentationCompilerFixture._
       runForPositionInCompiledSource(config, cc,
         "package com.example",
         "object @0@Bla@1@ { def !(x:Int) = x }",
         "object Abc { def main { Bla @2@!@3@ 0 } }") { (p, label, cc) =>
           val sym = cc.askSymbolInfoAt(p).get
-          assert(sym.declPos.isDefined)
-          assert(sym.declPos.get match {
-            case OffsetSourcePosition(f, i) => i > 0
-            case _ => false
-          })
+          inside(sym.declPos) {
+            case Some(OffsetSourcePosition(f, i)) =>
+              i should be > 0
+          }
         }
     }
+  }
 
-    "find source declaration of standard operator" in withPresCompiler { (config, cc) =>
+  it should "find source declaration of standard operator" in {
+    withPresCompiler { (config, cc) =>
       import ReallyRichPresentationCompilerFixture._
 
       cc.search.refreshResolver()
@@ -119,33 +116,34 @@ class RichPresentationCompilerSpec extends WordSpec with Matchers
         "package com.example",
         "object Bla { val x = 1 @0@+ 1 }") { (p, label, cc) =>
           val sym = cc.askSymbolInfoAt(p).get
-          assert(sym.declPos.isDefined)
-          assert(sym.declPos.get match {
-            case OffsetSourcePosition(f, i) =>
-              f.parts.contains("Int.scala") && i > 0
-            case _ => false
-          })
+          inside(sym.declPos) {
+            case Some(OffsetSourcePosition(f, i)) =>
+              f.parts should contain("Int.scala")
+              i should be > 0
+          }
         }
     }
+  }
 
-    "jump to function definition instead of Function1.apply" in withPresCompiler { (config, cc) =>
+  it should "jump to function definition instead of Function1.apply" in {
+    withPresCompiler { (config, cc) =>
       import ReallyRichPresentationCompilerFixture._
       runForPositionInCompiledSource(config, cc,
         "package com.example",
         "object Bla { val fn: String => Int = str => str.lenght }",
         "object Abc { def main { Bla.f@@n(\"bal\" } }") { (p, label, cc) =>
           val sym = cc.askSymbolInfoAt(p).get
-          assert(sym.name == "fn")
-          assert(sym.localName == "fn")
-          assert(sym.declPos.isDefined)
-          assert(sym.declPos.get match {
-            case OffsetSourcePosition(f, i) => i > 0
-            case _ => false
-          })
+          sym.name shouldBe "fn"
+          sym.localName shouldBe "fn"
+          inside(sym.declPos) {
+            case Some(OffsetSourcePosition(f, i)) => i should be > 0
+          }
         }
     }
+  }
 
-    "jump to case class definition when symbol under cursor is name of case class field" in withPresCompiler { (config, cc) =>
+  it should "jump to case class definition when symbol under cursor is name of case class field" in {
+    withPresCompiler { (config, cc) =>
       import ReallyRichPresentationCompilerFixture._
       runForPositionInCompiledSource(config, cc,
         "package com.example",
@@ -157,17 +155,17 @@ class RichPresentationCompilerSpec extends WordSpec with Matchers
         "  )",
         "}") { (p, label, cc) =>
           val sym = cc.askSymbolInfoAt(p).get
-          assert(sym.name == "apply")
-          assert(sym.localName == "apply")
-          assert(sym.declPos.isDefined)
-          assert(sym.declPos.get match {
-            case OffsetSourcePosition(f, i) => i > 0
-            case _ => false
-          })
+          sym.name shouldBe "apply"
+          sym.localName shouldBe "apply"
+          inside(sym.declPos) {
+            case Some(OffsetSourcePosition(f, i)) => i should be > 0
+          }
         }
     }
+  }
 
-    "jump to case class definition when symbol under cursor is name of case class field in copy method" in withPresCompiler { (config, cc) =>
+  it should "jump to case class definition when symbol under cursor is name of case class field in copy method" in {
+    withPresCompiler { (config, cc) =>
       import ReallyRichPresentationCompilerFixture._
       runForPositionInCompiledSource(config, cc,
         "package com.example",
@@ -180,382 +178,384 @@ class RichPresentationCompilerSpec extends WordSpec with Matchers
         " val fooUpd = foo.copy(b@@ar = foo.bar.reverse)",
         "}") { (p, label, cc) =>
           val sym = cc.askSymbolInfoAt(p).get
-          assert(sym.name == "copy")
-          assert(sym.localName == "copy")
-          assert(sym.declPos.isDefined)
-          assert(sym.declPos.get match {
-            case OffsetSourcePosition(f, i) => i > 0
-            case _ => false
-          })
+          sym.name shouldBe "copy"
+          sym.localName shouldBe "copy"
+          inside(sym.declPos) {
+            case Some(OffsetSourcePosition(f, i)) => i should be > 0
+          }
         }
     }
+  }
 
-    "get symbol info by name" in withPresCompiler { (config, cc) =>
-      def verify(
-        fqn: String, member: Option[String], sig: Option[String], expectedLocalName: String,
-        expectedName: String, expectedDeclAs: DeclaredAs
-      ) = {
-        val symOpt = cc.askSymbolByName(fqn, member, sig)
-        assert(symOpt.isDefined)
-        val sym = symOpt.get
-        assert(sym.localName === expectedLocalName)
-        assert(sym.name === expectedName)
-        assert(sym.tpe.declaredAs === expectedDeclAs)
-      }
-      verify("java.lang.String", Some("startsWith"), None, "startsWith", "startsWith", DeclaredAs.Nil)
-      verify("java.lang.String", None, None, "String", "java.lang.String", DeclaredAs.Class)
-      // TODO: should not be getting 'nil for declaredAs.
-      verify("scala.Option", Some("wait"), Some("(x$1: Long,x$2: Int): Unit"),
-        "wait", "wait", DeclaredAs.Nil)
-      verify("scala.Option", Some("wait"), Some("(x$1: Long): Unit"),
-        "wait", "wait", DeclaredAs.Nil)
-      verify("scala.Option", Some("wait"), Some("(): Unit"), "wait", "wait", DeclaredAs.Nil)
-      verify("java$", Some("lang"), None, "lang", "java.lang$", DeclaredAs.Object)
-      verify("scala$", Some("Option$"), None, "Option", "scala.Option$", DeclaredAs.Object)
-      verify("scala$", Some("Option"), None, "Option", "scala.Option", DeclaredAs.Class)
-      verify("scala.Option", Some("WithFilter"), None, "WithFilter", "scala.Option$WithFilter", DeclaredAs.Class)
-      verify("scala.Option$WithFilter", Some("flatMap"), None, "flatMap", "flatMap", DeclaredAs.Nil)
-      verify("scala.Boolean", None, None, "Boolean", "scala.Boolean", DeclaredAs.Class)
-      verify("scala.Predef$", Some("DummyImplicit$"), None, "DummyImplicit", "scala.Predef$$DummyImplicit$", DeclaredAs.Object)
+  it should "get symbol info by name" in withPresCompiler { (config, cc) =>
+    def verify(
+      fqn: String, member: Option[String], sig: Option[String], expectedLocalName: String,
+      expectedName: String, expectedDeclAs: DeclaredAs
+    ) = {
+      val symOpt = cc.askSymbolByName(fqn, member, sig)
+      symOpt shouldBe defined
+      val sym = symOpt.get
+      sym.localName should ===(expectedLocalName)
+      sym.name should ===(expectedName)
+      sym.tpe.declaredAs should ===(expectedDeclAs)
     }
+    verify("java.lang.String", Some("startsWith"), None, "startsWith", "startsWith", DeclaredAs.Nil)
+    verify("java.lang.String", None, None, "String", "java.lang.String", DeclaredAs.Class)
+    // TODO: should not be getting 'nil for declaredAs.
+    verify("scala.Option", Some("wait"), Some("(x$1: Long,x$2: Int): Unit"),
+      "wait", "wait", DeclaredAs.Nil)
+    verify("scala.Option", Some("wait"), Some("(x$1: Long): Unit"),
+      "wait", "wait", DeclaredAs.Nil)
+    verify("scala.Option", Some("wait"), Some("(): Unit"), "wait", "wait", DeclaredAs.Nil)
+    verify("java$", Some("lang"), None, "lang", "java.lang$", DeclaredAs.Object)
+    verify("scala$", Some("Option$"), None, "Option", "scala.Option$", DeclaredAs.Object)
+    verify("scala$", Some("Option"), None, "Option", "scala.Option", DeclaredAs.Class)
+    verify("scala.Option", Some("WithFilter"), None, "WithFilter", "scala.Option$WithFilter", DeclaredAs.Class)
+    verify("scala.Option$WithFilter", Some("flatMap"), None, "flatMap", "flatMap", DeclaredAs.Nil)
+    verify("scala.Boolean", None, None, "Boolean", "scala.Boolean", DeclaredAs.Class)
+    verify("scala.Predef$", Some("DummyImplicit$"), None, "DummyImplicit", "scala.Predef$$DummyImplicit$", DeclaredAs.Object)
+  }
 
-    "handle askSymbolByName" in withPresCompiler { (config, cc) =>
-      val file = srcFile(config, "abc.scala", contents(
-        "package com.example",
-        "object A { ",
-        "   val x: Int = 1",
-        "   class  X {}",
-        "   object X {}",
-        "}",
-        "class A { ",
-        "   class  X {}",
-        "   object X {}",
-        "}"
-      ))
-      cc.askReloadFile(file)
-      cc.askLoadedTyped(file)
-
-      def test(typeName: String, memberName: String, localName: String,
-        symFullName: String, isType: Boolean, expectedTypeName: String, expectedDeclAs: DeclaredAs) = {
-        val sym = cc.askSymbolByName(typeName, Some(memberName), None).get
-        assert(sym.localName === localName)
-        assert(sym.name === symFullName)
-        assert(sym.tpe.fullName === expectedTypeName)
-        assert(sym.tpe.declaredAs === expectedDeclAs)
-        sym.tpe.declaredAs
-      }
-
-      test("com.example$", "A$", "A", "com.example.A$", isType = false, "com.example.A$", DeclaredAs.Object)
-      test("com.example.A$", "x", "x", "x", isType = false, "scala.Int", DeclaredAs.Class)
-      test("com.example.A$", "X$", "X", "com.example.A$$X$", isType = false, "com.example.A$$X$", DeclaredAs.Object)
-      test("com.example.A$", "X", "X", "com.example.A$$X", isType = true, "com.example.A$$X", DeclaredAs.Class)
-
-      test("com.example$", "A", "A", "com.example.A", isType = true, "com.example.A", DeclaredAs.Class)
-      test("com.example.A", "X$", "X", "com.example.A$X$", isType = false, "com.example.A$X$", DeclaredAs.Object)
-      test("com.example.A", "X", "X", "com.example.A$X", isType = true, "com.example.A$X", DeclaredAs.Class)
-    }
-
-    "get completions on member with no prefix" in withPosInCompiledSource(
+  it should "handle askSymbolByName" in withPresCompiler { (config, cc) =>
+    val file = srcFile(config, "abc.scala", contents(
       "package com.example",
-      "object A { def aMethod(a: Int) = a }",
-      "object B { val x = A.@@ "
-    ) { (p, cc) =>
-        val result = cc.completionsAt(p, 10, caseSens = false)
-        result.completions should not be empty
-        result.completions.head.name shouldBe "aMethod"
-      }
-
-    "won't try to complete the declaration containing point" in withPosInCompiledSource(
-      "package com.example",
-      "object Ab@@c {}"
-    ) { (p, cc) =>
-        val result = cc.completionsAt(p, 10, caseSens = false)
-        assert(!result.completions.exists(_.name == "Abc"))
-      }
-
-    "get completions on a member with a prefix" in withPosInCompiledSource(
-      "package com.example",
-      "object A { def aMethod(a: Int) = a }",
-      "object B { val x = A.aMeth@@ }"
-    ) { (p, cc) =>
-        val result = cc.completionsAt(p, 10, caseSens = false)
-        assert(result.completions.length == 1)
-        assert(result.completions.head.name == "aMethod")
-      }
-
-    "get completions on an object name" in withPosInCompiledSource(
-      "package com.example",
-      "object Abc { def aMethod(a: Int) = a }",
-      "object B { val x = Ab@@ }"
-    ) { (p, cc) =>
-        val result = cc.completionsAt(p, 10, caseSens = false)
-        assert(result.completions.length > 1)
-        assert(result.completions.head.name == "Abc")
-      }
-
-    "get members for infix method call" in withPosInCompiledSource(
-      "package com.example",
-      "object Abc { def aMethod(a: Int) = a }",
-      "object B { val x = Abc aM@@ }"
-    ) { (p, cc) =>
-        val result = cc.completionsAt(p, 10, caseSens = false)
-        assert(result.completions.head.name == "aMethod")
-      }
-
-    "get members for infix method call without prefix" in withPosInCompiledSource(
-      "package com.example",
-      "object Abc { def aMethod(a: Int) = a }",
-      "object B { val x = Abc @@ }"
-    ) { (p, cc) =>
-        val result = cc.completionsAt(p, 10, caseSens = false)
-        assert(result.completions.head.name == "aMethod")
-      }
-
-    "complete multi-character infix operator" in withPosInCompiledSource(
-      "package com.example",
-      "object B { val l = Nil; val ll = l +@@ }"
-    ) { (p, cc) =>
-        val result = cc.completionsAt(p, 10, caseSens = false)
-        assert(result.completions.exists(_.name == "++"))
-      }
-
-    "complete top level import" in withPosInCompiledSource(
-      "package com.example",
-      "import ja@@"
-    ) { (p, cc) =>
-        val result = cc.completionsAt(p, 10, caseSens = false)
-        assert(result.completions.exists(_.name == "java"))
-      }
-
-    "complete sub-import" in withPosInCompiledSource(
-      "package com.example",
-      "import java.ut@@"
-    ) { (p, cc) =>
-        val result = cc.completionsAt(p, 10, caseSens = false)
-        assert(result.completions.exists(_.name == "util"))
-      }
-
-    "complete multi-import" in withPosInCompiledSource(
-      "package com.example",
-      "import java.util.{ V@@ }"
-    ) { (p, cc) =>
-        val result = cc.completionsAt(p, 10, caseSens = false)
-        assert(result.completions.exists(_.name == "Vector"))
-      }
-
-    "complete new construction" in withPosInCompiledSource(
-      "package com.example",
-      "import java.util.Vector",
-      "object A { def main { new V@@ } }"
-    ) { (p, cc) =>
-        val result = cc.completionsAt(p, 10, caseSens = false)
-        assert(result.completions.exists(m => m.name == "Vector" && m.isCallable))
-      }
-
-    "complete symbol in logical op" in withPosInCompiledSource(
-      "package com.example",
-      "object A { val apple = true; true || app@@ }"
-    ) { (p, cc) =>
-        val result = cc.completionsAt(p, 10, caseSens = false)
-        assert(result.completions.exists(_.name == "apple"))
-      }
-
-    "complete infix method of Set." in withPosInCompiledSource(
-      "package com.example",
-      "object A { val t = Set[String](\"a\", \"b\"); t @@ }"
-    ) { (p, cc) =>
-        val result = cc.completionsAt(p, 10, caseSens = false)
-        assert(result.completions.exists(_.name == "seq"))
-        assert(result.completions.exists(_.name == "|"))
-        assert(result.completions.exists(_.name == "&"))
-      }
-
-    "complete interpolated variables in strings" in withPosInCompiledSource(
-      "package com.example",
-      "object Abc { def aMethod(a: Int) = a }",
-      s"""object B { val x = s"hello there, $${Abc.aMe@@}"}"""
-    ) { (p, cc) =>
-        val result = cc.completionsAt(p, 10, caseSens = false)
-        assert(result.completions.head.name == "aMethod")
-      }
-
-    "not attempt to complete symbols in strings" in withPosInCompiledSource(
-      "package com.example",
-      "object Abc { def aMethod(a: Int) = a }",
-      "object B { val x = \"hello there Ab@@\"}"
-    ) { (p, cc) =>
-        val result = cc.completionsAt(p, 10, caseSens = false)
-        assert(result.completions.isEmpty)
-      }
-
-    "show all type arguments in the inspector." in withPosInCompiledSource(
-      "package com.example",
-      "class A { ",
-      "def banana(p: List[String]): List[String] = p",
-      "def pineapple: List[String] = List(\"spiky\")",
+      "object A { ",
+      "   val x: Int = 1",
+      "   class  X {}",
+      "   object X {}",
       "}",
-      "object Main { def main { val my@@A = new A() }}"
-    ) { (p, cc) =>
-        val info = cc.askInspectTypeAt(p).get
-        val sup = info.supers.find(sup => sup.tpe.name == "A").get;
-        {
-          val mem = sup.tpe.members.find(_.name == "banana").get.asInstanceOf[NamedTypeMemberInfo]
-          val tpe = mem.tpe.asInstanceOf[ArrowTypeInfo]
-          assert(tpe.resultType.name == "List")
-          assert(tpe.resultType.args.head.name == "String")
-          val (paramName, paramTpe) = tpe.paramSections.head.params.head
-          assert(paramName == "p")
-          assert(paramTpe.name == "List")
-          assert(paramTpe.args.head.name == "String")
-        }
-        {
-          val mem = sup.tpe.members.find(_.name == "pineapple").get.asInstanceOf[NamedTypeMemberInfo]
-          val tpe = mem.tpe.asInstanceOf[BasicTypeInfo]
-          assert(tpe.name == "List")
-          assert(tpe.args.head.name == "String")
-        }
-      }
+      "class A { ",
+      "   class  X {}",
+      "   object X {}",
+      "}"
+    ))
+    cc.askReloadFile(file)
+    cc.askLoadedTyped(file)
 
-    "show classes without visible members in the inspector" in withPosInCompiledSource(
+    def test(typeName: String, memberName: String, localName: String,
+      symFullName: String, isType: Boolean, expectedTypeName: String, expectedDeclAs: DeclaredAs) = {
+      val res = cc.askSymbolByName(typeName, Some(memberName), None)
+      res shouldBe defined
+      val sym = res.get
+      withClue(sym) {
+        sym.localName should ===(localName)
+        sym.name should ===(symFullName)
+        sym.tpe.fullName should ===(expectedTypeName)
+        sym.tpe.declaredAs should ===(expectedDeclAs)
+      }
+    }
+
+    test("com.example$", "A$", "A", "com.example.A$", isType = false, "com.example.A$", DeclaredAs.Object)
+    test("com.example.A$", "x", "x", "x", isType = false, "scala.Int", DeclaredAs.Class)
+    test("com.example.A$", "X$", "X", "com.example.A$$X$", isType = false, "com.example.A$$X$", DeclaredAs.Object)
+    test("com.example.A$", "X", "X", "com.example.A$$X", isType = true, "com.example.A$$X", DeclaredAs.Class)
+
+    test("com.example$", "A", "A", "com.example.A", isType = true, "com.example.A", DeclaredAs.Class)
+    test("com.example.A", "X$", "X", "com.example.A$X$", isType = false, "com.example.A$X$", DeclaredAs.Object)
+    test("com.example.A", "X", "X", "com.example.A$X", isType = true, "com.example.A$X", DeclaredAs.Class)
+  }
+
+  it should "get completions on member with no prefix" in withPosInCompiledSource(
+    "package com.example",
+    "object A { def aMethod(a: Int) = a }",
+    "object B { val x = A.@@ "
+  ) { (p, cc) =>
+      val result = cc.completionsAt(p, 10, caseSens = false)
+      forAtLeast(1, result.completions) { _.name shouldBe "aMethod" }
+    }
+
+  it should "not try to complete the declaration containing point" in withPosInCompiledSource(
+    "package com.example",
+    "object Ab@@c {}"
+  ) { (p, cc) =>
+      val result = cc.completionsAt(p, 10, caseSens = false)
+      forAll(result.completions) { _.name should not be "Abc" }
+    }
+
+  it should "get completions on a member with a prefix" in withPosInCompiledSource(
+    "package com.example",
+    "object A { def aMethod(a: Int) = a }",
+    "object B { val x = A.aMeth@@ }"
+  ) { (p, cc) =>
+      val result = cc.completionsAt(p, 10, caseSens = false)
+      forAtLeast(1, result.completions) { _.name shouldBe "aMethod" }
+    }
+
+  it should "get completions on an object name" in withPosInCompiledSource(
+    "package com.example",
+    "object Abc { def aMethod(a: Int) = a }",
+    "object B { val x = Ab@@ }"
+  ) { (p, cc) =>
+      val result = cc.completionsAt(p, 10, caseSens = false)
+      forAtLeast(1, result.completions) { _.name shouldBe "Abc" }
+    }
+
+  it should "get members for infix method call" in withPosInCompiledSource(
+    "package com.example",
+    "object Abc { def aMethod(a: Int) = a }",
+    "object B { val x = Abc aM@@ }"
+  ) { (p, cc) =>
+      val result = cc.completionsAt(p, 10, caseSens = false)
+      forAtLeast(1, result.completions) { _.name shouldBe "aMethod" }
+    }
+
+  it should "get members for infix method call without prefix" in withPosInCompiledSource(
+    "package com.example",
+    "object Abc { def aMethod(a: Int) = a }",
+    "object B { val x = Abc @@ }"
+  ) { (p, cc) =>
+      val result = cc.completionsAt(p, 10, caseSens = false)
+      forAtLeast(1, result.completions) { _.name shouldBe "aMethod" }
+    }
+
+  it should "complete multi-character infix operator" in withPosInCompiledSource(
+    "package com.example",
+    "object B { val l = Nil; val ll = l +@@ }"
+  ) { (p, cc) =>
+      val result = cc.completionsAt(p, 10, caseSens = false)
+      forAtLeast(1, result.completions) { _.name shouldBe "++" }
+    }
+
+  it should "complete top level import" in withPosInCompiledSource(
+    "package com.example",
+    "import ja@@"
+  ) { (p, cc) =>
+      val result = cc.completionsAt(p, 10, caseSens = false)
+      forAtLeast(1, result.completions) { _.name shouldBe "java" }
+    }
+
+  it should "complete sub-import" in withPosInCompiledSource(
+    "package com.example",
+    "import java.ut@@"
+  ) { (p, cc) =>
+      val result = cc.completionsAt(p, 10, caseSens = false)
+      forAtLeast(1, result.completions) { _.name shouldBe "util" }
+    }
+
+  it should "complete multi-import" in withPosInCompiledSource(
+    "package com.example",
+    "import java.util.{ V@@ }"
+  ) { (p, cc) =>
+      val result = cc.completionsAt(p, 10, caseSens = false)
+      forAtLeast(1, result.completions) { _.name shouldBe "Vector" }
+    }
+
+  it should "complete new construction" in withPosInCompiledSource(
+    "package com.example",
+    "import java.util.Vector",
+    "object A { def main { new V@@ } }"
+  ) { (p, cc) =>
+      val result = cc.completionsAt(p, 10, caseSens = false)
+      forAtLeast(1, result.completions) { x =>
+        x.name shouldBe "Vector"
+        x.isCallable shouldBe true
+      }
+    }
+
+  it should "complete symbol in logical op" in withPosInCompiledSource(
+    "package com.example",
+    "object A { val apple = true; true || app@@ }"
+  ) { (p, cc) =>
+      val result = cc.completionsAt(p, 10, caseSens = false)
+      assert(result.completions.exists(_.name == "apple"))
+    }
+
+  it should "complete infix method of Set." in withPosInCompiledSource(
+    "package com.example",
+    "object A { val t = Set[String](\"a\", \"b\"); t @@ }"
+  ) { (p, cc) =>
+      val result = cc.completionsAt(p, 10, caseSens = false)
+      forAtLeast(1, result.completions) { _.name shouldBe "seq" }
+      forAtLeast(1, result.completions) { _.name shouldBe "|" }
+      forAtLeast(1, result.completions) { _.name shouldBe "&" }
+    }
+
+  it should "complete interpolated variables in strings" in withPosInCompiledSource(
+    "package com.example",
+    "object Abc { def aMethod(a: Int) = a }",
+    s"""object B { val x = s"hello there, $${Abc.aMe@@}"}"""
+  ) { (p, cc) =>
+      val result = cc.completionsAt(p, 10, caseSens = false)
+      forAtLeast(1, result.completions) { _.name shouldBe "aMethod" }
+    }
+
+  it should "not attempt to complete symbols in strings" in withPosInCompiledSource(
+    "package com.example",
+    "object Abc { def aMethod(a: Int) = a }",
+    "object B { val x = \"hello there Ab@@\"}"
+  ) { (p, cc) =>
+      val result = cc.completionsAt(p, 10, caseSens = false)
+      result.completions shouldBe empty
+    }
+
+  it should "show all type arguments in the inspector" in withPosInCompiledSource(
+    "package com.example",
+    "class A { ",
+    "def banana(p: List[String]): List[String] = p",
+    "def pineapple: List[String] = List(\"spiky\")",
+    "}",
+    "object Main { def main { val my@@A = new A() }}"
+  ) { (p, cc) =>
+      val info = cc.askInspectTypeAt(p).get
+      val sup = info.supers.find(sup => sup.tpe.name == "A").get;
+      {
+        val mem = sup.tpe.members.find(_.name == "banana").get.asInstanceOf[NamedTypeMemberInfo]
+        val tpe = mem.tpe.asInstanceOf[ArrowTypeInfo]
+
+        tpe.resultType.name shouldBe "List"
+        tpe.resultType.args.head.name shouldBe "String"
+        val (paramName, paramTpe) = tpe.paramSections.head.params.head
+        paramName shouldBe "p"
+        paramTpe.name shouldBe "List"
+        paramTpe.args.head.name shouldBe "String"
+      }
+      {
+        val mem = sup.tpe.members.find(_.name == "pineapple").get.asInstanceOf[NamedTypeMemberInfo]
+        val tpe = mem.tpe.asInstanceOf[BasicTypeInfo]
+        tpe.name shouldBe "List"
+        tpe.args.head.name shouldBe "String"
+      }
+    }
+
+  it should "show classes without visible members in the inspector" in withPosInCompiledSource(
+    "package com.example",
+    "trait bidon { }",
+    "case class pi@@po extends bidon { }"
+  ) { (p, cc) =>
+      val info = cc.askInspectTypeAt(p)
+      val supers = info.map(_.supers).getOrElse(List())
+      val supersNames = supers.map(_.tpe.name).toList
+      supersNames.toSet should ===(Set("pipo", "bidon", "Object", "Product", "Serializable", "Any"))
+    }
+
+  it should "get type info for imports" in withPresCompiler { (config, cc) =>
+    val expected = Map(
+      "1.0" -> Some("java$"),
+      "1.1" -> Some("java$"),
+      "1.2" -> Some("java.io$"),
+      "1.3" -> Some("java.io$"),
+      "1.4" -> Some("java.io.File$"),
+      "1.5" -> Some("java.io.File$"),
+      "1.6" -> Some("java.lang.String"),
+      "1.7" -> Some("java.lang.String"),
+      "2.0" -> Some("java.io.Bits$"),
+      "2.1" -> Some("java.io.Bits$"),
+      "2.2" -> Some("java.io.File$"),
+      "2.3" -> Some("java.io.File$"),
+      "3.0" -> None
+    )
+
+    import ReallyRichPresentationCompilerFixture._
+    runForPositionInCompiledSource(config, cc,
       "package com.example",
-      "trait bidon { }",
-      "case class pi@@po extends bidon { }"
-    ) { (p, cc) =>
-        val info = cc.askInspectTypeAt(p)
-        val supers = info.map(_.supers).getOrElse(List())
-        val supersNames = supers.map(_.tpe.name).toList
-        assert(supersNames.toSet === Set("pipo", "bidon", "Object", "Product", "Serializable", "Any"))
+      "import @1.0@java@1.1@.@1.2@io@1.3@.@1.4@File@1.5@.@1.6@separator@1.7@",
+      "import java.io.{ @2.0@Bits => one@2.1@, @2.2@File => two@2.3@ }",
+      "import java.io._@3.0@") { (p, label, cc) =>
+        val info = cc.askTypeInfoAt(p)
+        info.map(_.fullName) should ===(expected(label))
       }
+  }
 
-    "get type info for imports" in withPresCompiler { (config, cc) =>
-      val expected = Map(
-        "1.0" -> Some("java$"),
-        "1.1" -> Some("java$"),
-        "1.2" -> Some("java.io$"),
-        "1.3" -> Some("java.io$"),
-        "1.4" -> Some("java.io.File$"),
-        "1.5" -> Some("java.io.File$"),
-        "1.6" -> Some("java.lang.String"),
-        "1.7" -> Some("java.lang.String"),
-        "2.0" -> Some("java.io.Bits$"),
-        "2.1" -> Some("java.io.Bits$"),
-        "2.2" -> Some("java.io.File$"),
-        "2.3" -> Some("java.io.File$"),
-        "3.0" -> None
-      )
+  it should "get symbol positions for compiled files" in withPresCompiler { (config, cc) =>
+    val defsFile = srcFile(config, "com/example/defs.scala", contents(
+      "package com.example",
+      "object /*1*/A { ",
+      "   val /*1.1*/x: Int = 1",
+      "   class /*1.2*/X {} ",
+      "}",
+      "class  /*2*/B { ",
+      "   val /*2.1*/y: Int = 1",
+      "   def /*2.2*/meth(a: String): Int = 1",
+      "   def /*2.3*/meth(a: Int): Int = 1",
+      "}",
+      "trait  /*3*/C { ",
+      "   val /*3.1*/z: Int = 1",
+      "   class /*3.2*/Z {}",
+      "}",
+      "class /*4*/D extends C { }",
+      "package object /*5.0*/pkg {",
+      "   type /*5.1*/A  = java.lang.Error",
+      "   def /*5.2*/B = 1",
+      "   val /*5.3*/C = 2",
+      "   class /*5.4*/D {}",
+      "   object /*5.5*/E {}",
+      "}"
+    ), write = true)
+    val usesFile = srcFile(config, "com/example/uses.scala", contents(
+      "package com.example",
+      "object Test { ",
+      "   val x_1 = A/*1*/",
+      "   val x_1_1 = A.x/*1.1*/",
+      "   val x_1_2 = new A.X/*1.2*/",
+      "   val x_2 = new B/*2*/",
+      "   val x_2_1 = new B().y/*2.1*/",
+      "   val x_2_2 = new B().meth/*2.2*/(\"x\")",
+      "   val x_2_3 = new B().meth/*2.3*/(1)",
+      "   val x_3: C/*3*/ = new D/*4*/",
+      "   val x_3_1 = x_3.z/*3.1*/",
+      "   val x_3_2 = new x_3.Z/*3.2*/",
+      "   val x_5_0 = pkg.`package`/*5.0*/",
+      "   var x_5_1: pkg.A/*5.1*/ = null",
+      "   val x_5_2 = pkg.B/*5.2*/",
+      "   val x_5_3 = pkg.C/*5.3*/",
+      "   val x_5_4 = new pkg.D/*5.4*/",
+      "   val x_5_5 = pkg.E/*5.5*/",
+      "}"
+    ))
 
-      import ReallyRichPresentationCompilerFixture._
-      runForPositionInCompiledSource(config, cc,
-        "package com.example",
-        "import @1.0@java@1.1@.@1.2@io@1.3@.@1.4@File@1.5@.@1.6@separator@1.7@",
-        "import java.io.{ @2.0@Bits => one@2.1@, @2.2@File => two@2.3@ }",
-        "import java.io._@3.0@") { (p, label, cc) =>
-          val info = cc.askTypeInfoAt(p)
-          assert(info.map { _.fullName } === expected(label))
+    def test(label: String, cc: RichPresentationCompiler) = {
+      val comment = "/*" + label + "*/"
+      val defPos = defsFile.content.mkString.indexOf(comment) + comment.length
+      val usePos = usesFile.content.mkString.indexOf(comment) - 1
+
+      // Create a fresh pres. compiler unaffected by previous tests:
+      // finding a symbol's position loads the source into the compiler
+      // which changes its state.
+
+      implicit val ensimeVFS = EnsimeVFS()
+      val cc1 = new RichPresentationCompiler(cc.config, cc.settings, cc.reporter, cc.parent, cc.indexer, cc.search)
+
+      try {
+        cc1.askReloadFile(usesFile)
+        cc1.askLoadedTyped(usesFile)
+
+        val info = cc1.askSymbolInfoAt(new OffsetPosition(usesFile, usePos)) match {
+          case Some(x) => x
+          case None => fail(s"For $comment, askSymbolInfoAt returned None")
         }
+        val declPos = info.declPos
+        declPos match {
+          case Some(op: OffsetSourcePosition) => assert(op.offset === defPos)
+          case _ => fail(s"For $comment, unexpected declPos value: $declPos")
+        }
+      } finally {
+        cc1.askShutdown()
+        ensimeVFS.close()
+      }
     }
 
-    "get symbol positions for compiled files" in withPresCompiler { (config, cc) =>
-      val defsFile = srcFile(config, "com/example/defs.scala", contents(
-        "package com.example",
-        "object /*1*/A { ",
-        "   val /*1.1*/x: Int = 1",
-        "   class /*1.2*/X {} ",
-        "}",
-        "class  /*2*/B { ",
-        "   val /*2.1*/y: Int = 1",
-        "   def /*2.2*/meth(a: String): Int = 1",
-        "   def /*2.3*/meth(a: Int): Int = 1",
-        "}",
-        "trait  /*3*/C { ",
-        "   val /*3.1*/z: Int = 1",
-        "   class /*3.2*/Z {}",
-        "}",
-        "class /*4*/D extends C { }",
-        "package object /*5.0*/pkg {",
-        "   type /*5.1*/A  = java.lang.Error",
-        "   def /*5.2*/B = 1",
-        "   val /*5.3*/C = 2",
-        "   class /*5.4*/D {}",
-        "   object /*5.5*/E {}",
-        "}"
-      ), write = true)
-      val usesFile = srcFile(config, "com/example/uses.scala", contents(
-        "package com.example",
-        "object Test { ",
-        "   val x_1 = A/*1*/",
-        "   val x_1_1 = A.x/*1.1*/",
-        "   val x_1_2 = new A.X/*1.2*/",
-        "   val x_2 = new B/*2*/",
-        "   val x_2_1 = new B().y/*2.1*/",
-        "   val x_2_2 = new B().meth/*2.2*/(\"x\")",
-        "   val x_2_3 = new B().meth/*2.3*/(1)",
-        "   val x_3: C/*3*/ = new D/*4*/",
-        "   val x_3_1 = x_3.z/*3.1*/",
-        "   val x_3_2 = new x_3.Z/*3.2*/",
-        "   val x_5_0 = pkg.`package`/*5.0*/",
-        "   var x_5_1: pkg.A/*5.1*/ = null",
-        "   val x_5_2 = pkg.B/*5.2*/",
-        "   val x_5_3 = pkg.C/*5.3*/",
-        "   val x_5_4 = new pkg.D/*5.4*/",
-        "   val x_5_5 = pkg.E/*5.5*/",
-        "}"
-      ))
+    compileScala(
+      List(defsFile.path),
+      config.subprojects.head.targetDirs.head,
+      cc.settings.classpath.value
+    )
 
-      def test(label: String, cc: RichPresentationCompiler) = {
-        val comment = "/*" + label + "*/"
-        val defPos = defsFile.content.mkString.indexOf(comment) + comment.length
-        val usePos = usesFile.content.mkString.indexOf(comment) - 1
+    cc.search.refreshResolver()
+    Await.result(cc.search.refresh(), Duration.Inf)
 
-        // Create a fresh pres. compiler unaffected by previous tests:
-        // finding a symbol's position loads the source into the compiler
-        // which changes its state.
-
-        implicit val ensimeVFS = EnsimeVFS()
-        val cc1 = new RichPresentationCompiler(cc.config, cc.settings, cc.reporter, cc.parent, cc.indexer, cc.search)
-
-        try {
-          cc1.askReloadFile(usesFile)
-          cc1.askLoadedTyped(usesFile)
-
-          val info = cc1.askSymbolInfoAt(new OffsetPosition(usesFile, usePos)) match {
-            case Some(x) => x
-            case None => fail(s"For $comment, askSymbolInfoAt returned None")
-          }
-          val declPos = info.declPos
-          declPos match {
-            case Some(op: OffsetSourcePosition) => assert(op.offset === defPos)
-            case _ => fail(s"For $comment, unexpected declPos value: $declPos")
-          }
-        } finally {
-          cc1.askShutdown()
-          ensimeVFS.close()
-        }
-      }
-
-      compileScala(
-        List(defsFile.path),
-        config.subprojects.head.targetDirs.head,
-        cc.settings.classpath.value
-      )
-
-      cc.search.refreshResolver()
-      Await.result(cc.search.refresh(), Duration.Inf)
-
-      val scalaVersion = scala.util.Properties.versionNumberString
-      val parts = scalaVersion.split("\\.").map { _.toInt }
-      if (parts(0) > 2 || (parts(0) == 2 && parts(1) > 10)) {
-        /* in Scala 2.10, the declaration position of "pacakge object" is
-           different so we just skip this test */
-        test("5.0", cc)
-      }
-
-      List(
-        "1", "1.1", "1.2", "2", "2.1", "2.2", "2.3", "3", "3.1", "3.2", "4",
-        "5.1", "5.2", "5.3", "5.4", "5.5"
-      ).
-        foreach(test(_, cc))
+    val scalaVersion = scala.util.Properties.versionNumberString
+    val parts = scalaVersion.split("\\.").map { _.toInt }
+    if (parts(0) > 2 || (parts(0) == 2 && parts(1) > 10)) {
+      /* in Scala 2.10, the declaration position of "pacakge object" is
+       different so we just skip this test */
+      test("5.0", cc)
     }
+
+    List(
+      "1", "1.1", "1.2", "2", "2.1", "2.2", "2.3", "3", "3.1", "3.2", "4",
+      "5.1", "5.2", "5.3", "5.4", "5.5"
+    ).
+      foreach(test(_, cc))
   }
 }
 

--- a/core/src/it/scala/org/ensime/core/SemanticHighlightingSpec.scala
+++ b/core/src/it/scala/org/ensime/core/SemanticHighlightingSpec.scala
@@ -4,11 +4,11 @@ package org.ensime.core
 
 import org.ensime.fixture._
 import org.ensime.api._
-import org.scalatest._
+import org.ensime.util.EnsimeSpec
 
 import scala.reflect.internal.util.RangePosition
 
-class SemanticHighlightingSpec extends WordSpec with Matchers
+class SemanticHighlightingSpec extends EnsimeSpec
     with IsolatedRichPresentationCompilerFixture
     with RichPresentationCompilerTestUtils
     with ReallyRichPresentationCompilerFixture {
@@ -32,10 +32,9 @@ class SemanticHighlightingSpec extends WordSpec with Matchers
       }
   }
 
-  "SemanticHighlighting" should {
-    "highlight classes" in withPresCompiler { (config, cc) =>
-      val sds = getSymbolDesignations(
-        config, cc, """
+  "SemanticHighlighting" should "highlight classes" in withPresCompiler { (config, cc) =>
+    val sds = getSymbolDesignations(
+      config, cc, """
             package com.example
             class X1[+A] { }
             class X2 { class Y { } }
@@ -47,23 +46,23 @@ class SemanticHighlightingSpec extends WordSpec with Matchers
               def fun(a: Any) = a match { case x: Test => Unit }
             }
           """,
-        List(ClassSymbol)
-      )
-      assert(sds === List(
-        (ClassSymbol, "Int"),
-        (ClassSymbol, "X1[Any]"),
-        (ClassSymbol, "X1[String]"),
-        (ClassSymbol, "X2"),
-        (ClassSymbol, "X2"),
-        (ClassSymbol, "Y"),
-        (ClassSymbol, "Any"),
-        (ClassSymbol, "Test")
-      ))
-    }
+      List(ClassSymbol)
+    )
+    sds should ===(List(
+      (ClassSymbol, "Int"),
+      (ClassSymbol, "X1[Any]"),
+      (ClassSymbol, "X1[String]"),
+      (ClassSymbol, "X2"),
+      (ClassSymbol, "X2"),
+      (ClassSymbol, "Y"),
+      (ClassSymbol, "Any"),
+      (ClassSymbol, "Test")
+    ))
+  }
 
-    "highlight constructors" in withPresCompiler { (config, cc) =>
-      val sds = getSymbolDesignations(
-        config, cc, """
+  it should "highlight constructors" in withPresCompiler { (config, cc) =>
+    val sds = getSymbolDesignations(
+      config, cc, """
             package com.example
             class X1(a: Int = 0) { }
             class X2(a: String) { }
@@ -75,20 +74,20 @@ class SemanticHighlightingSpec extends WordSpec with Matchers
               val e1 = new   X3
             }
           """,
-        List(ConstructorSymbol)
-      )
-      // TODO It would be better if the "new" was consistent.
-      assert(sds === List(
-        (ConstructorSymbol, "X1"),
-        (ConstructorSymbol, "new X1(  )"),
-        (ConstructorSymbol, "X2"),
-        (ConstructorSymbol, "new   X3")
-      ))
-    }
+      List(ConstructorSymbol)
+    )
+    // TODO It would be better if the "new" was consistent.
+    sds should ===(List(
+      (ConstructorSymbol, "X1"),
+      (ConstructorSymbol, "new X1(  )"),
+      (ConstructorSymbol, "X2"),
+      (ConstructorSymbol, "new   X3")
+    ))
+  }
 
-    "highlight function calls" in withPresCompiler { (config, cc) =>
-      val sds = getSymbolDesignations(
-        config, cc, """
+  it should "highlight function calls" in withPresCompiler { (config, cc) =>
+    val sds = getSymbolDesignations(
+      config, cc, """
             package com.example
             class Test {
               def fun(u: Int, v: Int) { u + v }
@@ -98,19 +97,19 @@ class SemanticHighlightingSpec extends WordSpec with Matchers
               def baz { def quux(): Int = { 1 } ; quux() }
             }
           """,
-        List(FunctionCallSymbol)
-      )
-      assert(sds === List(
-        (FunctionCallSymbol, "fun"),
-        (FunctionCallSymbol, "foo"),
-        (FunctionCallSymbol, "substring"),
-        (FunctionCallSymbol, "quux")
-      ))
-    }
+      List(FunctionCallSymbol)
+    )
+    sds should ===(List(
+      (FunctionCallSymbol, "fun"),
+      (FunctionCallSymbol, "foo"),
+      (FunctionCallSymbol, "substring"),
+      (FunctionCallSymbol, "quux")
+    ))
+  }
 
-    "highlight deprecated symbols" in withPresCompiler { (config, cc) =>
-      val sds = getSymbolDesignations(
-        config, cc, """
+  it should "highlight deprecated symbols" in withPresCompiler { (config, cc) =>
+    val sds = getSymbolDesignations(
+      config, cc, """
             package com.example
             class Test {
               @deprecated("bad trait", "1.0")
@@ -147,43 +146,43 @@ class SemanticHighlightingSpec extends WordSpec with Matchers
               X.Y.goo()
             }            
           """,
-        List(DeprecatedSymbol)
-      )
-      assert(sds == List(
-        (DeprecatedSymbol, "BadTrait"),
-        (DeprecatedSymbol, "BadClass"),
-        (DeprecatedSymbol, "BadObject"),
-        (DeprecatedSymbol, "foo"),
-        (DeprecatedSymbol, "badVal"),
-        (DeprecatedSymbol, "badVar"),
-        (DeprecatedSymbol, "Baz"),
-        (DeprecatedSymbol, "boo"),
-        (DeprecatedSymbol, "X"),
-        (DeprecatedSymbol, "Y"),
-        (DeprecatedSymbol, "goo")
-      ))
-    }
+      List(DeprecatedSymbol)
+    )
+    sds should ===(List(
+      (DeprecatedSymbol, "BadTrait"),
+      (DeprecatedSymbol, "BadClass"),
+      (DeprecatedSymbol, "BadObject"),
+      (DeprecatedSymbol, "foo"),
+      (DeprecatedSymbol, "badVal"),
+      (DeprecatedSymbol, "badVar"),
+      (DeprecatedSymbol, "Baz"),
+      (DeprecatedSymbol, "boo"),
+      (DeprecatedSymbol, "X"),
+      (DeprecatedSymbol, "Y"),
+      (DeprecatedSymbol, "goo")
+    ))
+  }
 
-    "highlight imported names" in withPresCompiler { (config, cc) =>
-      val sds = getSymbolDesignations(
-        config, cc, """
+  it should "highlight imported names" in withPresCompiler { (config, cc) =>
+    val sds = getSymbolDesignations(
+      config, cc, """
             package com.example
             import scala.reflect.internal.util.RangePosition
             import org.scalatest. { Matchers,
                  FunSpec }
             """,
-        List(ImportedNameSymbol)
-      )
-      assert(sds === List(
-        (ImportedNameSymbol, "RangePosition"),
-        (ImportedNameSymbol, "Matchers"),
-        (ImportedNameSymbol, "FunSpec")
-      ))
-    }
+      List(ImportedNameSymbol)
+    )
+    sds should ===(List(
+      (ImportedNameSymbol, "RangePosition"),
+      (ImportedNameSymbol, "Matchers"),
+      (ImportedNameSymbol, "FunSpec")
+    ))
+  }
 
-    "highlight objects" in withPresCompiler { (config, cc) =>
-      val sds = getSymbolDesignations(
-        config, cc, """
+  it should "highlight objects" in withPresCompiler { (config, cc) =>
+    val sds = getSymbolDesignations(
+      config, cc, """
             package com.example
             object A { object B { } }
             case class C() { }
@@ -195,72 +194,72 @@ class SemanticHighlightingSpec extends WordSpec with Matchers
               val d = c.E(1)
             }
           """,
-        List(ObjectSymbol)
-      )
-      assert(sds === List(
-        (ObjectSymbol, "C"),
-        (ObjectSymbol, "A"),
-        (ObjectSymbol, "B"),
-        (ObjectSymbol, "D"),
-        // TODO two problems there: "c" should be a varField ; E should be highlighted.
-        (ObjectSymbol, "c")
-      ))
-    }
+      List(ObjectSymbol)
+    )
+    sds should ===(List(
+      (ObjectSymbol, "C"),
+      (ObjectSymbol, "A"),
+      (ObjectSymbol, "B"),
+      (ObjectSymbol, "D"),
+      // TODO two problems there: "c" should be a varField ; E should be highlighted.
+      (ObjectSymbol, "c")
+    ))
+  }
 
-    "highlight operators" in withPresCompiler { (config, cc) =>
-      val sds = getSymbolDesignations(
-        config, cc, """
+  it should "highlight operators" in withPresCompiler { (config, cc) =>
+    val sds = getSymbolDesignations(
+      config, cc, """
             package com.example
             object Test {
               var a = 1 + 2 * 3
               a += 8
             }
           """,
-        List(OperatorFieldSymbol)
-      )
-      // TODO We should highlight the "+="
-      assert(sds === List(
-        (OperatorFieldSymbol, "+"),
-        (OperatorFieldSymbol, "*")
-      ))
-    }
+      List(OperatorFieldSymbol)
+    )
+    // TODO We should highlight the "+="
+    sds should ===(List(
+      (OperatorFieldSymbol, "+"),
+      (OperatorFieldSymbol, "*")
+    ))
+  }
 
-    "highlight packages" in withPresCompiler { (config, cc) =>
-      val sds = getSymbolDesignations(
-        config, cc, """
+  it should "highlight packages" in withPresCompiler { (config, cc) =>
+    val sds = getSymbolDesignations(
+      config, cc, """
              package com.example
              package other
           """,
-        List(PackageSymbol)
-      )
-      assert(sds === List(
-        (PackageSymbol, "com"),
-        (PackageSymbol, "example"),
-        (PackageSymbol, "other")
-      ))
-    }
+      List(PackageSymbol)
+    )
+    sds should ===(List(
+      (PackageSymbol, "com"),
+      (PackageSymbol, "example"),
+      (PackageSymbol, "other")
+    ))
+  }
 
-    "highlight params" in withPresCompiler { (config, cc) =>
-      val sds = getSymbolDesignations(
-        config, cc, """
+  it should "highlight params" in withPresCompiler { (config, cc) =>
+    val sds = getSymbolDesignations(
+      config, cc, """
             package com.example
             class Test {
               def f(u:  Int, v   :String) = v + u
             }
           """,
-        List(ParamSymbol)
-      )
-      assert(sds === List(
-        (ParamSymbol, "u"),
-        (ParamSymbol, "v"),
-        (ParamSymbol, "v"),
-        (ParamSymbol, "u")
-      ))
-    }
+      List(ParamSymbol)
+    )
+    sds should ===(List(
+      (ParamSymbol, "u"),
+      (ParamSymbol, "v"),
+      (ParamSymbol, "v"),
+      (ParamSymbol, "u")
+    ))
+  }
 
-    "highlight traits" in withPresCompiler { (config, cc) =>
-      val sds = getSymbolDesignations(
-        config, cc, """
+  it should "highlight traits" in withPresCompiler { (config, cc) =>
+    val sds = getSymbolDesignations(
+      config, cc, """
             package com.example
             trait X1 { }
             trait X2 { }
@@ -278,20 +277,20 @@ class SemanticHighlightingSpec extends WordSpec with Matchers
               }
             }
           """,
-        List(TraitSymbol)
-      )
-      assert(sds === List(
-        (TraitSymbol, "X2"),
-        (TraitSymbol, "X3"),
-        (TraitSymbol, "X4"),
-        (TraitSymbol, "X5[ String]"),
-        (TraitSymbol, "v2 .X6")
-      ))
-    }
+      List(TraitSymbol)
+    )
+    sds should ===(List(
+      (TraitSymbol, "X2"),
+      (TraitSymbol, "X3"),
+      (TraitSymbol, "X4"),
+      (TraitSymbol, "X5[ String]"),
+      (TraitSymbol, "v2 .X6")
+    ))
+  }
 
-    "highlight typeParams" in withPresCompiler { (config, cc) =>
-      val sds = getSymbolDesignations(
-        config, cc, """
+  it should "highlight typeParams" in withPresCompiler { (config, cc) =>
+    val sds = getSymbolDesignations(
+      config, cc, """
             package com.example
             class Test {
               def f[XX,YY](y: YY, x: XX) = {
@@ -300,20 +299,20 @@ class SemanticHighlightingSpec extends WordSpec with Matchers
               f[Int, String](1, "a")
             }
           """,
-        List(TypeParamSymbol)
-      )
-      assert(sds === List(
-        (TypeParamSymbol, "XX"),
-        (TypeParamSymbol, "YY"),
-        (TypeParamSymbol, "YY"),
-        (TypeParamSymbol, "XX"),
-        (TypeParamSymbol, "YY")
-      ))
-    }
+      List(TypeParamSymbol)
+    )
+    sds should ===(List(
+      (TypeParamSymbol, "XX"),
+      (TypeParamSymbol, "YY"),
+      (TypeParamSymbol, "YY"),
+      (TypeParamSymbol, "XX"),
+      (TypeParamSymbol, "YY")
+    ))
+  }
 
-    "highlight vals" in withPresCompiler { (config, cc) =>
-      val sds = getSymbolDesignations(
-        config, cc, """
+  it should "highlight vals" in withPresCompiler { (config, cc) =>
+    val sds = getSymbolDesignations(
+      config, cc, """
             package com.example
             class Test {
               def fun() = {
@@ -323,18 +322,18 @@ class SemanticHighlightingSpec extends WordSpec with Matchers
               }
             }
           """,
-        List(ValSymbol)
-      )
-      assert(sds === List(
-        (ValSymbol, "u"),
-        (ValSymbol, "v"),
-        (ValSymbol, "u")
-      ))
-    }
+      List(ValSymbol)
+    )
+    sds should ===(List(
+      (ValSymbol, "u"),
+      (ValSymbol, "v"),
+      (ValSymbol, "u")
+    ))
+  }
 
-    "highlight valFields" in withPresCompiler { (config, cc) =>
-      val sds = getSymbolDesignations(
-        config, cc, """
+  it should "highlight valFields" in withPresCompiler { (config, cc) =>
+    val sds = getSymbolDesignations(
+      config, cc, """
             package com.example
             class Test {
               val u= 1
@@ -345,19 +344,19 @@ class SemanticHighlightingSpec extends WordSpec with Matchers
               println((new Test).v)
             }
           """,
-        List(ValFieldSymbol)
-      )
-      assert(sds === List(
-        (ValFieldSymbol, "u"),
-        (ValFieldSymbol, "v"),
-        (ValFieldSymbol, "u"),
-        (ValFieldSymbol, "v")
-      ))
-    }
+      List(ValFieldSymbol)
+    )
+    sds should ===(List(
+      (ValFieldSymbol, "u"),
+      (ValFieldSymbol, "v"),
+      (ValFieldSymbol, "u"),
+      (ValFieldSymbol, "v")
+    ))
+  }
 
-    "highlight vars" in withPresCompiler { (config, cc) =>
-      val sds = getSymbolDesignations(
-        config, cc, """
+  it should "highlight vars" in withPresCompiler { (config, cc) =>
+    val sds = getSymbolDesignations(
+      config, cc, """
             package com.example
             class Test {
               def fun() = {
@@ -367,18 +366,18 @@ class SemanticHighlightingSpec extends WordSpec with Matchers
               }
             }
           """,
-        List(VarSymbol)
-      )
-      assert(sds === List(
-        (VarSymbol, "u"),
-        (VarSymbol, "v"),
-        (VarSymbol, "u")
-      ))
-    }
+      List(VarSymbol)
+    )
+    sds should ===(List(
+      (VarSymbol, "u"),
+      (VarSymbol, "v"),
+      (VarSymbol, "u")
+    ))
+  }
 
-    "highlight varFields" in withPresCompiler { (config, cc) =>
-      val sds = getSymbolDesignations(
-        config, cc, """
+  it should "highlight varFields" in withPresCompiler { (config, cc) =>
+    val sds = getSymbolDesignations(
+      config, cc, """
             package com.example
             class Test {
               var u= 1
@@ -389,19 +388,19 @@ class SemanticHighlightingSpec extends WordSpec with Matchers
               println((new Test).v)
             }
           """,
-        List(VarFieldSymbol)
-      )
-      assert(sds === List(
-        (VarFieldSymbol, "u"),
-        (VarFieldSymbol, "v"),
-        (VarFieldSymbol, "u"),
-        (VarFieldSymbol, "v")
-      ))
-    }
+      List(VarFieldSymbol)
+    )
+    sds should ===(List(
+      (VarFieldSymbol, "u"),
+      (VarFieldSymbol, "v"),
+      (VarFieldSymbol, "u"),
+      (VarFieldSymbol, "v")
+    ))
+  }
 
-    "highlight lazy val fields correctly as vals" in withPresCompiler { (config, cc) =>
-      val sds = getSymbolDesignations(
-        config, cc, """
+  it should "highlight lazy val fields correctly as vals" in withPresCompiler { (config, cc) =>
+    val sds = getSymbolDesignations(
+      config, cc, """
             package com.example
             class Test {
               lazy val u= 1
@@ -412,17 +411,17 @@ class SemanticHighlightingSpec extends WordSpec with Matchers
               println((new Test).v)
             }
           """,
-        List(ValFieldSymbol)
-      )
-      assert(sds === List(
-        (ValFieldSymbol, "u"),
-        (ValFieldSymbol, "v")
-      ))
-    }
+      List(ValFieldSymbol)
+    )
+    sds should ===(List(
+      (ValFieldSymbol, "u"),
+      (ValFieldSymbol, "v")
+    ))
+  }
 
-    "highlight setter operators" in withPresCompiler { (config, cc) =>
-      val sds = getSymbolDesignations(
-        config, cc, """
+  it should "highlight setter operators" in withPresCompiler { (config, cc) =>
+    val sds = getSymbolDesignations(
+      config, cc, """
             package com.example
             object Fubar {
                private var v: Int = 0
@@ -433,47 +432,47 @@ class SemanticHighlightingSpec extends WordSpec with Matchers
               Fubar.value = 1
             }
           """,
-        List(OperatorFieldSymbol)
-      )
-      assert(sds === List(
-        (OperatorFieldSymbol, "value")
-      ))
-    }
+      List(OperatorFieldSymbol)
+    )
+    sds should ===(List(
+      (OperatorFieldSymbol, "value")
+    ))
+  }
 
-    "not be confused by whitespace" in withPresCompiler { (config, cc) =>
-      val sds = getSymbolDesignations(
-        config, cc, """
+  it should "not be confused by whitespace" in withPresCompiler { (config, cc) =>
+    val sds = getSymbolDesignations(
+      config, cc, """
             package com.  example
           """,
-        List(PackageSymbol)
-      )
-      // only part of "example" is highlighted
-      assert(sds === List(
-        (PackageSymbol, "com"),
-        (PackageSymbol, "example")
-      ))
-    }
+      List(PackageSymbol)
+    )
+    // only part of "example" is highlighted
+    sds should ===(List(
+      (PackageSymbol, "com"),
+      (PackageSymbol, "example")
+    ))
+  }
 
-    "highlight negation operators" in withPresCompiler { (config, cc) =>
-      val sds = getSymbolDesignations(
-        config, cc, """
+  it should "highlight negation operators" in withPresCompiler { (config, cc) =>
+    val sds = getSymbolDesignations(
+      config, cc, """
             package com.example
             class Test {
               val x = !(3 == 4)
             }
           """,
-        List(OperatorFieldSymbol)
-      )
-      // Call to foo is missing
-      assert(sds === List(
-        (OperatorFieldSymbol, "!"),
-        (OperatorFieldSymbol, "==")
-      ))
-    }
+      List(OperatorFieldSymbol)
+    )
+    // Call to foo is missing
+    sds should ===(List(
+      (OperatorFieldSymbol, "!"),
+      (OperatorFieldSymbol, "==")
+    ))
+  }
 
-    "highlight implicit conversions" in withPresCompiler { (config, cc) =>
-      val sds = getSymbolDesignations(
-        config, cc, """
+  it should "highlight implicit conversions" in withPresCompiler { (config, cc) =>
+    val sds = getSymbolDesignations(
+      config, cc, """
             package com.example
             class Test {}
             object I {
@@ -482,16 +481,16 @@ class SemanticHighlightingSpec extends WordSpec with Matchers
               val u: Test  = StringToTest("y");
             }
           """,
-        List(ImplicitConversionSymbol)
-      )
-      assert(sds === List(
-        (ImplicitConversionSymbol, "\"sample\"")
-      ))
-    }
+      List(ImplicitConversionSymbol)
+    )
+    sds should ===(List(
+      (ImplicitConversionSymbol, "\"sample\"")
+    ))
+  }
 
-    "highlight implicit parameters" in withPresCompiler { (config, cc) =>
-      val sds = getSymbolDesignations(
-        config, cc, """
+  it should "highlight implicit parameters" in withPresCompiler { (config, cc) =>
+    val sds = getSymbolDesignations(
+      config, cc, """
             package com.example
             class Thing {}
             class Thong {}
@@ -502,16 +501,16 @@ class SemanticHighlightingSpec extends WordSpec with Matchers
               val t = zz(1)
             }
           """,
-        List(ImplicitParamsSymbol)
-      )
-      assert(sds === List(
-        (ImplicitParamsSymbol, "zz(1)")
-      ))
-    }
+      List(ImplicitParamsSymbol)
+    )
+    sds should ===(List(
+      (ImplicitParamsSymbol, "zz(1)")
+    ))
+  }
 
-    "highlight method calls after operators" in withPresCompiler { (config, cc) =>
-      val sds = getSymbolDesignations(
-        config, cc, """
+  it should "highlight method calls after operators" in withPresCompiler { (config, cc) =>
+    val sds = getSymbolDesignations(
+      config, cc, """
             package com.example
             class Test {
               def fun(u: Int, v: Int): Int = { u + v }
@@ -519,12 +518,11 @@ class SemanticHighlightingSpec extends WordSpec with Matchers
               fun(1, 2) + foo(4, 5)
             }
           """,
-        List(FunctionCallSymbol)
-      )
-      assert(sds === List(
-        (FunctionCallSymbol, "fun"),
-        (FunctionCallSymbol, "foo")
-      ))
-    }
+      List(FunctionCallSymbol)
+    )
+    sds should ===(List(
+      (FunctionCallSymbol, "fun"),
+      (FunctionCallSymbol, "foo")
+    ))
   }
 }

--- a/core/src/it/scala/org/ensime/core/StructureViewBuilderSpec.scala
+++ b/core/src/it/scala/org/ensime/core/StructureViewBuilderSpec.scala
@@ -4,10 +4,10 @@ package org.ensime.core
 
 import org.ensime.fixture._
 import org.ensime.api._
-import org.scalatest._
+import org.ensime.util.EnsimeSpec
 import scala.collection.mutable.ListBuffer
 
-class StructureViewBuilderSpec extends FlatSpec with Matchers
+class StructureViewBuilderSpec extends EnsimeSpec
     with IsolatedRichPresentationCompilerFixture
     with RichPresentationCompilerTestUtils
     with ReallyRichPresentationCompilerFixture {
@@ -39,11 +39,10 @@ class StructureViewBuilderSpec extends FlatSpec with Matchers
     result.toList
   }
 
-  behavior of "StructureViewBuilder"
-
-  it should "show top level classes and objects" in withPresCompiler { (config, cc) =>
-    val structure = getStructure(
-      config, cc, """
+  "StructureViewBuilder" should "show top level classes and objects" in {
+    withPresCompiler { (config, cc) =>
+      val structure = getStructure(
+        config, cc, """
             package com.example
             import org.scalatest._
             class Test {
@@ -53,14 +52,15 @@ class StructureViewBuilderSpec extends FlatSpec with Matchers
               def apply(x: String) { new Test(x) }
             }
           """
-    )
+      )
 
-    structure shouldBe List(
-      "(class)Test",
-      "(def)Test.fun",
-      "(object)Test",
-      "(def)Test.apply"
-    )
+      structure shouldBe List(
+        "(class)Test",
+        "(def)Test.fun",
+        "(object)Test",
+        "(def)Test.apply"
+      )
+    }
   }
 
   it should "show nested members" in withPresCompiler { (config, cc) =>

--- a/core/src/it/scala/org/ensime/indexer/SearchServiceSpec.scala
+++ b/core/src/it/scala/org/ensime/indexer/SearchServiceSpec.scala
@@ -3,156 +3,156 @@
 package org.ensime.indexer
 
 import org.ensime.fixture._
-import org.scalatest._
+import org.ensime.util.EnsimeSpec
 import org.ensime.util.file._
 
 import scala.concurrent._
 import scala.concurrent.duration._
 
-class SearchServiceSpec extends WordSpec with Matchers
+class SearchServiceSpec extends EnsimeSpec
     with SharedTestKitFixture
     with SharedSearchServiceFixture
     with SearchServiceTestUtils {
 
   def original = EnsimeConfigFixture.SimpleTestProject
 
-  "search refreshing" should {
-    "parse all files on a pristine structure" in withSearchService { implicit service =>
+  "search refreshing" should "parse all files on a pristine structure" in {
+    withSearchService { implicit service =>
       val (deleted, indexed) = refresh()
       deleted shouldBe 0
       indexed should be > 0
     }
+  }
 
-    "not refresh files that have not changed" in withSearchService { implicit service =>
+  it should "not refresh files that have not changed" in {
+    withSearchService { implicit service =>
       refresh() shouldBe ((0, 0))
     }
+  }
 
-    "refresh files that have 'changed'" in {
-      withSearchService { (config, service) =>
-        implicit val s = service
-        val now = System.currentTimeMillis()
-        for {
-          m <- config.modules.values
-          r <- m.targetDirs ++ m.testTargetDirs
-          f <- r.tree
-        } {
-          // simulate a full recompile
-          f.setLastModified(now)
-        }
-
-        val (deleted, indexed) = refresh()
-        deleted should be > 0
-        indexed should be > 0
+  it should "refresh files that have 'changed'" in {
+    withSearchService { (config, service) =>
+      implicit val s = service
+      val now = System.currentTimeMillis()
+      for {
+        m <- config.modules.values
+        r <- m.targetDirs ++ m.testTargetDirs
+        f <- r.tree
+      } {
+        // simulate a full recompile
+        f.setLastModified(now)
       }
-    }
 
-    "remove classfiles that have been deleted" in {
-      withSearchService { (config, service) =>
-        implicit val s = service
-        val classfile = config.subprojects.head.targetDirs.head / "org/example/Foo.class"
-
-        classfile shouldBe 'exists
-
-        classfile.delete()
-        refresh() shouldBe ((1, 0))
-      }
+      val (deleted, indexed) = refresh()
+      deleted should be > 0
+      indexed should be > 0
     }
   }
 
-  "class searching" should {
-    "return results from J2SE" in withSearchService { implicit service =>
-      searchesClasses(
+  it should "remove classfiles that have been deleted" in {
+    withSearchService { (config, service) =>
+      implicit val s = service
+      val classfile = config.subprojects.head.targetDirs.head / "org/example/Foo.class"
+
+      classfile shouldBe 'exists
+
+      classfile.delete()
+      refresh() shouldBe ((1, 0))
+    }
+  }
+
+  "class searching" should "return results from J2SE" in withSearchService { implicit service =>
+    searchesClasses(
+      "java.lang.String",
+      "String", "string",
+      "j.l.str", "j l str"
+    )
+  }
+
+  it should "return results from dependencies" in withSearchService { implicit service =>
+    searchesClasses(
+      "org.scalatest.FunSuite",
+      "FunSuite", "funsuite", "funsu",
+      "o s Fun"
+    )
+  }
+
+  it should "return results from the project" in withSearchService { implicit service =>
+    searchesClasses(
+      "org.example.Bloo",
+      "o e bloo"
+    )
+
+    searchesClasses(
+      "org.example.Blue$",
+      "o e blue"
+    )
+
+    searchesClasses(
+      "org.example.CaseClassWithCamelCaseName",
+      "CaseClassWith", "caseclasswith",
+      "o e Case", "o.e.caseclasswith",
+      "CCWC" // <= CamelCaseAwesomeNess
+    )
+  }
+
+  it should "return results from package objects" in withSearchService { implicit service =>
+    searchClasses(
+      "org.example.Blip$",
+      "Blip"
+    )
+
+    searchClasses(
+      "org.example.Blop",
+      "Blop"
+    )
+  }
+
+  "class and method searching" should "return results from classes" in {
+    withSearchService { implicit service =>
+      searchesClassesAndMethods(
         "java.lang.String",
         "String", "string",
         "j.l.str", "j l str"
       )
     }
-
-    "return results from dependencies" in withSearchService { implicit service =>
-      searchesClasses(
-        "org.scalatest.FunSuite",
-        "FunSuite", "funsuite", "funsu",
-        "o s Fun"
-      )
-    }
-
-    "return results from the project" in withSearchService { implicit service =>
-      searchesClasses(
-        "org.example.Bloo",
-        "o e bloo"
-      )
-
-      searchesClasses(
-        "org.example.Blue$",
-        "o e blue"
-      )
-
-      searchesClasses(
-        "org.example.CaseClassWithCamelCaseName",
-        "CaseClassWith", "caseclasswith",
-        "o e Case", "o.e.caseclasswith",
-        "CCWC" // <= CamelCaseAwesomeNess
-      )
-    }
-
-    "return results from package objects" in withSearchService { implicit service =>
-      searchClasses(
-        "org.example.Blip$",
-        "Blip"
-      )
-
-      searchClasses(
-        "org.example.Blop",
-        "Blop"
-      )
-    }
   }
 
-  "class and method searching" should {
-    "return results from classes" in withSearchService { implicit service =>
-      searchesClassesAndMethods(
-        "java.lang.String",
-        "String", "string",
-        "j.l.str", "j l str"
-      )
-    }
-
-    "return results from static fields" in withSearchService { implicit service =>
-      searchesEmpty(
-        "CASE_INSENSITIVE", "case_insensitive",
-        "case_"
-      )
-    }
-
-    "not return results from instance fields" in withSearchService { implicit service =>
-      searchesEmpty(
-        "java.awt.Point.x"
-      )
-    }
-
-    "return results from static methods" in withSearchService { implicit service =>
-      searchesClassesAndMethods(
-        "java.lang.Runtime.addShutdownHook",
-        "addShutdownHook"
-      )
-    }
-
-    "return results from instance methods" in withSearchService { implicit service =>
-      searchesClassesAndMethods(
-        "java.lang.Runtime.availableProcessors",
-        "availableProcessors", "availableP"
-      )
-    }
+  it should "return results from static fields" in withSearchService { implicit service =>
+    searchesEmpty(
+      "CASE_INSENSITIVE", "case_insensitive",
+      "case_"
+    )
   }
 
-  "exact searches" should {
-    "find type aliases" in withSearchService { implicit service =>
-      assert(service.findUnique("org.scalatest.fixture.ConfigMapFixture$FixtureParam").isDefined)
-    }
+  it should "not return results from instance fields" in withSearchService { implicit service =>
+    searchesEmpty(
+      "java.awt.Point.x"
+    )
+  }
+
+  it should "return results from static methods" in withSearchService { implicit service =>
+    searchesClassesAndMethods(
+      "java.lang.Runtime.addShutdownHook",
+      "addShutdownHook"
+    )
+  }
+
+  it should "return results from instance methods" in withSearchService { implicit service =>
+    searchesClassesAndMethods(
+      "java.lang.Runtime.availableProcessors",
+      "availableProcessors", "availableP"
+    )
+  }
+
+  "exact searches" should "find type aliases" in withSearchService { implicit service =>
+    service.findUnique("org.scalatest.fixture.ConfigMapFixture$FixtureParam") shouldBe defined
   }
 }
 
 trait SearchServiceTestUtils {
+  self: EnsimeSpec =>
+
   def refresh()(implicit service: SearchService): (Int, Int) =
     Await.result(service.refresh(), Duration.Inf)
 
@@ -160,12 +160,13 @@ trait SearchServiceTestUtils {
     val max = 10
     val info = s"'$query' expected '$expect')"
     val results = service.searchClasses(query, max)
-    assert(results.size <= max, s"${results.size} $info")
-    assert(results.nonEmpty, s"$info but was empty")
+
+    withClue(s"${results.size} $info")(results.size should be <= max)
+    withClue(s"$info but was empty")(results should not be empty)
     // when we improve the search quality, we could
     // make this really look only at #1
     val got = results.map(_.fqn)
-    assert(got contains expect, s"$info got '$got'")
+    withClue(s"$info got '$got'")(got should contain(expect))
     results
   }
 
@@ -176,19 +177,19 @@ trait SearchServiceTestUtils {
     val max = 10
     val info = s"'$query' expected '$expect')"
     val results = service.searchClassesMethods(List(query), max)
-    assert(results.size <= max, s"${results.size} $info")
-    assert(results.nonEmpty, s"$info but was empty")
+    withClue(s"${results.size} $info")(results.size should be <= max)
+    withClue(s"$info but was empty")(results should not be empty)
     // when we improve the search quality, we could
     // make this really look only at #1
     val got = results.map(_.fqn)
-    assert(got contains expect, s"$info got '$got'")
+    withClue(s"$info got '$got'")(got should contain(expect))
     results
   }
 
   def searchExpectEmpty(query: String)(implicit service: SearchService) = {
     val max = 1
     val results = service.searchClassesMethods(List(query), max)
-    assert(results.isEmpty, "expected empty results from %s".format(query))
+    withClue("expected empty results from %s".format(query))(results shouldBe empty)
     results
   }
 

--- a/core/src/it/scala/org/ensime/indexer/SourceResolverSpec.scala
+++ b/core/src/it/scala/org/ensime/indexer/SourceResolverSpec.scala
@@ -3,40 +3,40 @@
 package org.ensime.indexer
 
 import org.ensime.fixture._
-import org.scalatest._
+import org.ensime.util.EnsimeSpec
 import org.ensime.util.file._
 
-class SourceResolverSpec extends WordSpec with Matchers with SharedEnsimeVFSFixture
-    with SharedSourceResolverFixture with SourceResolverTestUtils {
+class SourceResolverSpec extends EnsimeSpec
+    with SharedEnsimeVFSFixture
+    with SharedSourceResolverFixture
+    with SourceResolverTestUtils {
 
   def original = EnsimeConfigFixture.SimpleTestProject
 
-  "SourceResolver" should {
-    "resolve java sources in J2SE" in withSourceResolver { implicit r =>
-      find("java.lang", "String.java") shouldBe Some("/java/lang/String.java")
-    }
+  "SourceResolver" should "resolve java sources in J2SE" in withSourceResolver { implicit r =>
+    find("java.lang", "String.java") shouldBe Some("/java/lang/String.java")
+  }
 
-    "resolve scala sources in the project dependencies" in withSourceResolver { implicit r =>
-      find("scala.collection.immutable", "List.scala") shouldBe
-        Some("/scala/collection/immutable/List.scala")
+  it should "resolve scala sources in the project dependencies" in withSourceResolver { implicit r =>
+    find("scala.collection.immutable", "List.scala") shouldBe
+      Some("/scala/collection/immutable/List.scala")
 
-      find("org.scalatest", "FunSpec.scala") shouldBe
-        Some("/org/scalatest/FunSpec.scala")
-    }
+    find("org.scalatest", "FunSpec.scala") shouldBe
+      Some("/org/scalatest/FunSpec.scala")
+  }
 
-    "resolve sources in the project" in withSourceResolver { (c, r) =>
-      implicit val config = c
-      implicit val resolver = r
-      find("org.example.Foo", "Foo.scala") shouldBe
-        Some((scalaMain / "org/example/Foo.scala").getAbsolutePath)
-    }
+  it should "resolve sources in the project" in withSourceResolver { (c, r) =>
+    implicit val config = c
+    implicit val resolver = r
+    find("org.example.Foo", "Foo.scala") shouldBe
+      Some((scalaMain / "org/example/Foo.scala").getAbsolutePath)
+  }
 
-    "should resolve files in parent directories in the project" in withSourceResolver { (c, r) =>
-      implicit val config = c
-      implicit val resolver = r
-      find("org.example", "bad-convention.scala") shouldBe
-        Some((scalaMain / "bad-convention.scala").getAbsolutePath)
-    }
+  it should "should resolve files in parent directories in the project" in withSourceResolver { (c, r) =>
+    implicit val config = c
+    implicit val resolver = r
+    find("org.example", "bad-convention.scala") shouldBe
+      Some((scalaMain / "bad-convention.scala").getAbsolutePath)
   }
 }
 

--- a/core/src/it/scala/org/ensime/intg/BasicWorkflow.scala
+++ b/core/src/it/scala/org/ensime/intg/BasicWorkflow.scala
@@ -2,225 +2,219 @@
 // Licence: http://www.gnu.org/licenses/gpl-3.0.en.html
 package org.ensime.intg
 
-import akka.event.slf4j.SLF4JLogging
 import org.ensime.api._
 import org.ensime.core._
 import org.ensime.fixture._
-import org.scalatest.{ Matchers, WordSpec }
+import org.ensime.util.EnsimeSpec
 import org.ensime.util.file._
 
-class BasicWorkflow extends WordSpec with Matchers
+class BasicWorkflow extends EnsimeSpec
     with IsolatedEnsimeConfigFixture
     with IsolatedTestKitFixture
-    with IsolatedProjectFixture
-    with SLF4JLogging {
+    with IsolatedProjectFixture {
 
   val original = EnsimeConfigFixture.SimpleTestProject
 
-  "ensime-server" should {
-    "open the simple test project" in {
-      withEnsimeConfig { implicit config =>
-        withTestKit { implicit testkit =>
-          withProject { (project, asyncHelper) =>
-            import testkit._
+  "ensime-server" should "open the simple test project" in {
+    withEnsimeConfig { implicit config =>
+      withTestKit { implicit testkit =>
+        withProject { (project, asyncHelper) =>
+          import testkit._
 
-            val sourceRoot = scalaMain(config)
-            val fooFile = sourceRoot / "org/example/Foo.scala"
-            val fooFilePath = fooFile.getAbsolutePath
-            val barFile = sourceRoot / "org/example/Bar.scala"
+          val sourceRoot = scalaMain(config)
+          val fooFile = sourceRoot / "org/example/Foo.scala"
+          val fooFilePath = fooFile.getAbsolutePath
+          val barFile = sourceRoot / "org/example/Bar.scala"
 
-            // trigger typeCheck
-            project ! TypecheckFilesReq(List(Left(fooFile)))
-            expectMsg(VoidResponse)
+          // trigger typeCheck
+          project ! TypecheckFilesReq(List(Left(fooFile)))
+          expectMsg(VoidResponse)
 
-            asyncHelper.expectMsg(FullTypeCheckCompleteEvent)
+          asyncHelper.expectMsg(FullTypeCheckCompleteEvent)
 
-            // Asking to typecheck mising file should report an error not kill system
+          // Asking to typecheck mising file should report an error not kill system
 
-            val missingFile = sourceRoot / "missing.scala"
-            val missingFilePath = missingFile.getAbsolutePath
-            project ! TypecheckFilesReq(List(Left(missingFile)))
-            expectMsg(EnsimeServerError(s"""file(s): "$missingFilePath" do not exist"""))
+          val missingFile = sourceRoot / "missing.scala"
+          val missingFilePath = missingFile.getAbsolutePath
+          project ! TypecheckFilesReq(List(Left(missingFile)))
+          expectMsg(EnsimeServerError(s"""file(s): "$missingFilePath" do not exist"""))
 
-            //-----------------------------------------------------------------------------------------------
-            // semantic highlighting
-            project ! SymbolDesignationsReq(Left(fooFile), -1, 299, SourceSymbol.allSymbols)
-            val designations = expectMsgType[SymbolDesignations]
-            designations.file shouldBe fooFile
-            designations.syms should contain(SymbolDesignation(12, 19, PackageSymbol))
-            // expected Symbols
-            // ((package 12 19) (package 8 11) (trait 40 43) (valField 69 70) (class 100 103) (param 125 126) (class 128 131) (param 133 134) (class 136 142) (operator 156 157) (param 154 155) (functionCall 160 166) (param 158 159) (valField 183 186) (class 193 199) (class 201 204) (valField 214 217) (class 224 227) (functionCall 232 239) (operator 250 251) (valField 256 257) (valField 252 255) (functionCall 261 268) (functionCall 273 283) (valField 269 272)))
+          //-----------------------------------------------------------------------------------------------
+          // semantic highlighting
+          project ! SymbolDesignationsReq(Left(fooFile), -1, 299, SourceSymbol.allSymbols)
+          val designations = expectMsgType[SymbolDesignations]
+          designations.file shouldBe fooFile
+          designations.syms should contain(SymbolDesignation(12, 19, PackageSymbol))
+          // expected Symbols
+          // ((package 12 19) (package 8 11) (trait 40 43) (valField 69 70) (class 100 103) (param 125 126) (class 128 131) (param 133 134) (class 136 142) (operator 156 157) (param 154 155) (functionCall 160 166) (param 158 159) (valField 183 186) (class 193 199) (class 201 204) (valField 214 217) (class 224 227) (functionCall 232 239) (operator 250 251) (valField 256 257) (valField 252 255) (functionCall 261 268) (functionCall 273 283) (valField 269 272)))
 
-            //-----------------------------------------------------------------------------------------------
-            // symbolAtPoint
-            project ! SymbolAtPointReq(Left(fooFile), 128)
-            val symbolAtPointOpt: Option[SymbolInfo] = expectMsgType[Option[SymbolInfo]]
+          //-----------------------------------------------------------------------------------------------
+          // symbolAtPoint
+          project ! SymbolAtPointReq(Left(fooFile), 128)
+          val symbolAtPointOpt: Option[SymbolInfo] = expectMsgType[Option[SymbolInfo]]
 
-            project ! TypeByNameReq("org.example.Foo")
-            val fooClassByNameOpt = expectMsgType[Option[TypeInfo]]
+          project ! TypeByNameReq("org.example.Foo")
+          val fooClassByNameOpt = expectMsgType[Option[TypeInfo]]
 
-            project ! TypeByNameReq("org.example.Foo$")
-            val fooObjectByNameOpt = expectMsgType[Option[TypeInfo]]
+          project ! TypeByNameReq("org.example.Foo$")
+          val fooObjectByNameOpt = expectMsgType[Option[TypeInfo]]
 
-            //-----------------------------------------------------------------------------------------------
-            // public symbol search - java.io.File
+          //-----------------------------------------------------------------------------------------------
+          // public symbol search - java.io.File
 
-            project ! PublicSymbolSearchReq(List("java", "io", "File"), 30)
-            val javaSearchSymbol = expectMsgType[SymbolSearchResults]
-            assert(javaSearchSymbol.syms.exists {
-              case TypeSearchResult("java.io.File", "File", DeclaredAs.Class, Some(_)) => true
-              case _ => false
-            })
+          project ! PublicSymbolSearchReq(List("java", "io", "File"), 30)
+          val javaSearchSymbol = expectMsgType[SymbolSearchResults]
+          assert(javaSearchSymbol.syms.exists {
+            case TypeSearchResult("java.io.File", "File", DeclaredAs.Class, Some(_)) => true
+            case _ => false
+          })
+          //-----------------------------------------------------------------------------------------------
+          // public symbol search - scala.util.Random
+          project ! PublicSymbolSearchReq(List("scala", "util", "Random"), 2)
+          expectMsgPF() {
+            case SymbolSearchResults(List(
+              TypeSearchResult("scala.util.Random", "Random", DeclaredAs.Class, Some(_)),
+              TypeSearchResult("scala.util.Random$", "Random$", DeclaredAs.Class, Some(_)))) =>
+            case SymbolSearchResults(List(
+              TypeSearchResult("java.util.Random", "Random", DeclaredAs.Class, Some(_)),
+              TypeSearchResult("scala.util.Random", "Random", DeclaredAs.Class, Some(_)))) =>
+            // this is a pretty ropey test at the best of times
+          }
 
-            //-----------------------------------------------------------------------------------------------
-            // public symbol search - scala.util.Random
-            project ! PublicSymbolSearchReq(List("scala", "util", "Random"), 2)
-            expectMsgPF() {
-              case SymbolSearchResults(List(
-                TypeSearchResult("scala.util.Random", "Random", DeclaredAs.Class, Some(_)),
-                TypeSearchResult("scala.util.Random$", "Random$", DeclaredAs.Class, Some(_)))) =>
-              case SymbolSearchResults(List(
-                TypeSearchResult("java.util.Random", "Random", DeclaredAs.Class, Some(_)),
-                TypeSearchResult("scala.util.Random", "Random", DeclaredAs.Class, Some(_)))) =>
-              // this is a pretty ropey test at the best of times
-            }
+          //-----------------------------------------------------------------------------------------------
+          // documentation for type at point
+          val intDocSig = DocSigPair(DocSig(DocFqn("scala", "Int"), None), DocSig(DocFqn("", "int"), None))
 
-            //-----------------------------------------------------------------------------------------------
-            // documentation for type at point
-            val intDocSig = DocSigPair(DocSig(DocFqn("scala", "Int"), None), DocSig(DocFqn("", "int"), None))
+          // NOTE these are handled as multi-phase queries in requesthandler
+          project ! DocUriAtPointReq(Left(fooFile), OffsetRange(128))
+          expectMsg(Some(intDocSig))
 
-            // NOTE these are handled as multi-phase queries in requesthandler
-            project ! DocUriAtPointReq(Left(fooFile), OffsetRange(128))
-            expectMsg(Some(intDocSig))
+          project ! DocUriForSymbolReq("scala.Int", None, None)
+          expectMsg(Some(intDocSig))
 
-            project ! DocUriForSymbolReq("scala.Int", None, None)
-            expectMsg(Some(intDocSig))
+          project ! intDocSig
+          expectMsgType[StringResponse].text should endWith("/index.html#scala.Int")
 
-            project ! intDocSig
-            expectMsgType[StringResponse].text should endWith("/index.html#scala.Int")
+          //-----------------------------------------------------------------------------------------------
+          // uses of symbol at point
 
-            //-----------------------------------------------------------------------------------------------
-            // uses of symbol at point
+          log.info("------------------------------------222-")
 
-            log.info("------------------------------------222-")
+          // FIXME: doing a fresh typecheck is needed to pass the next few tests. Why?
+          project ! TypecheckFilesReq(List(Left(fooFile)))
+          expectMsg(VoidResponse)
 
-            // FIXME: doing a fresh typecheck is needed to pass the next few tests. Why?
-            project ! TypecheckFilesReq(List(Left(fooFile)))
-            expectMsg(VoidResponse)
+          asyncHelper.expectMsg(FullTypeCheckCompleteEvent)
 
-            asyncHelper.expectMsg(FullTypeCheckCompleteEvent)
+          project ! UsesOfSymbolAtPointReq(Left(fooFile), 119) // point on testMethod
+          expectMsgPF() {
+            case ERangePositions(List(ERangePosition(`fooFilePath`, 114, 110, 172), ERangePosition(`fooFilePath`, 273, 269, 283))) =>
+          }
 
-            project ! UsesOfSymbolAtPointReq(Left(fooFile), 119) // point on testMethod
-            expectMsgPF() {
-              case ERangePositions(List(ERangePosition(`fooFilePath`, 114, 110, 172), ERangePosition(`fooFilePath`, 273, 269, 283))) =>
-            }
+          log.info("------------------------------------222-")
 
-            log.info("------------------------------------222-")
+          // note that the line numbers appear to have been stripped from the
+          // scala library classfiles, so offset/line comes out as zero unless
+          // loaded by the pres compiler
+          project ! SymbolAtPointReq(Left(fooFile), 276)
+          expectMsgPF() {
+            case Some(SymbolInfo("testMethod", "testMethod", Some(OffsetSourcePosition(`fooFile`, 114)), ArrowTypeInfo("(i: Int, s: String)Int", BasicTypeInfo("Int", DeclaredAs.Class, "scala.Int", List(), List(), None), List(ParamSectionInfo(List((i, BasicTypeInfo("Int", DeclaredAs.Class, "scala.Int", List(), List(), None)), (s, BasicTypeInfo("String", DeclaredAs.Class, "java.lang.String", List(), List(), None))), false))), true)) =>
+          }
 
-            // note that the line numbers appear to have been stripped from the
-            // scala library classfiles, so offset/line comes out as zero unless
-            // loaded by the pres compiler
-            project ! SymbolAtPointReq(Left(fooFile), 276)
-            expectMsgPF() {
-              case Some(SymbolInfo("testMethod", "testMethod", Some(OffsetSourcePosition(`fooFile`, 114)), ArrowTypeInfo("(i: Int, s: String)Int", BasicTypeInfo("Int", DeclaredAs.Class, "scala.Int", List(), List(), None), List(ParamSectionInfo(List((i, BasicTypeInfo("Int", DeclaredAs.Class, "scala.Int", List(), List(), None)), (s, BasicTypeInfo("String", DeclaredAs.Class, "java.lang.String", List(), List(), None))), false))), true)) =>
-            }
+          // M-.  external symbol
+          project ! SymbolAtPointReq(Left(fooFile), 190)
+          expectMsgPF() {
+            case Some(SymbolInfo("Map", "Map", Some(OffsetSourcePosition(_, _)),
+              BasicTypeInfo("Map$", DeclaredAs.Object, "scala.collection.immutable.Map$", List(), List(), None),
+              false)) =>
+          }
 
-            // M-.  external symbol
-            project ! SymbolAtPointReq(Left(fooFile), 190)
-            expectMsgPF() {
-              case Some(SymbolInfo("Map", "Map", Some(OffsetSourcePosition(_, _)),
-                BasicTypeInfo("Map$", DeclaredAs.Object, "scala.collection.immutable.Map$", List(), List(), None),
-                false)) =>
-            }
-
-            project ! SymbolAtPointReq(Left(fooFile), 343)
-            expectMsgPF() {
-              case Some(SymbolInfo("fn", "fn", Some(OffsetSourcePosition(`fooFile`, 304)),
-                BasicTypeInfo("Function1", DeclaredAs.Trait, "scala.Function1",
-                  List(
-                    BasicTypeInfo("String", DeclaredAs.Class, "java.lang.String", List(), List(), None),
-                    BasicTypeInfo("Int", DeclaredAs.Class, "scala.Int", List(), List(), None)),
-                  List(), None),
-                false)) =>
-            }
-
-            project ! SymbolAtPointReq(Left(barFile), 150)
-            expectMsgPF() {
-              case Some(SymbolInfo("apply", "apply", Some(OffsetSourcePosition(`barFile`, 59)),
-                ArrowTypeInfo("(bar: String, baz: Int)org.example.Bar.Foo",
-                  BasicTypeInfo("Foo", DeclaredAs.Class, "org.example.Bar$$Foo", List(), List(), None),
-                  List(ParamSectionInfo(
-                    List(
-                      ("bar", BasicTypeInfo("String", DeclaredAs.Class, "java.lang.String", List(), List(), None)),
-                      ("baz", BasicTypeInfo("Int", DeclaredAs.Class, "scala.Int", List(), List(), None))), false))),
-                true)) =>
-            }
-
-            project ! SymbolAtPointReq(Left(barFile), 193)
-            expectMsgPF() {
-              case Some(SymbolInfo("copy", "copy", Some(OffsetSourcePosition(`barFile`, 59)),
-                ArrowTypeInfo("(bar: String, baz: Int)org.example.Bar.Foo",
-                  BasicTypeInfo("Foo", DeclaredAs.Class, "org.example.Bar$$Foo", List(), List(), None),
-                  List(ParamSectionInfo(
-                    List(
-                      ("bar", BasicTypeInfo("String", DeclaredAs.Class, "java.lang.String", List(), List(), None)),
-                      ("baz", BasicTypeInfo("Int", DeclaredAs.Class, "scala.Int", List(), List(), None))), false))),
-                true)) =>
-            }
-
-            // C-c C-v p Inspect source of current package
-            project ! InspectPackageByPathReq("org.example")
-            expectMsgPF() {
-              case Some(PackageInfo("example", "org.example", List(
-                BasicTypeInfo("Bar", DeclaredAs.Class, "org.example.Bar", List(), List(), Some(_)),
-                BasicTypeInfo("Bar$", DeclaredAs.Object, "org.example.Bar$", List(), List(), Some(_)),
-                BasicTypeInfo("Bloo", DeclaredAs.Class, "org.example.Bloo", List(), List(), Some(_)),
-                BasicTypeInfo("Bloo$", DeclaredAs.Object, "org.example.Bloo$", List(), List(), Some(_)),
-                BasicTypeInfo("Blue", DeclaredAs.Class, "org.example.Blue", List(), List(), Some(_)),
-                BasicTypeInfo("Blue$", DeclaredAs.Object, "org.example.Blue$", List(), List(), Some(_)),
-                BasicTypeInfo("CaseClassWithCamelCaseName", DeclaredAs.Class, "org.example.CaseClassWithCamelCaseName", List(), List(), Some(_)),
-                BasicTypeInfo("CaseClassWithCamelCaseName$", DeclaredAs.Object, "org.example.CaseClassWithCamelCaseName$", List(), List(), Some(_)),
-                BasicTypeInfo("Foo", DeclaredAs.Class, "org.example.Foo", List(), List(), Some(_)),
-                BasicTypeInfo("Foo$", DeclaredAs.Object, "org.example.Foo$", List(), List(), Some(_)),
-                BasicTypeInfo("Test1", DeclaredAs.Class, "org.example.Test1", List(), List(), None),
-                BasicTypeInfo("Test1$", DeclaredAs.Object, "org.example.Test1$", List(), List(), None),
-                BasicTypeInfo("Test2", DeclaredAs.Class, "org.example.Test2", List(), List(), None),
-                BasicTypeInfo("Test2$", DeclaredAs.Object, "org.example.Test2$", List(), List(), None),
-                BasicTypeInfo("package$", DeclaredAs.Object, "org.example.package$", List(), List(), None),
-                BasicTypeInfo("package$", DeclaredAs.Object, "org.example.package$", List(), List(), None)))) =>
-            }
-
-            // expand selection around 'val foo'
-            project ! ExpandSelectionReq(fooFile, 215, 215)
-            val expandRange1 = expectMsgType[FileRange]
-            assert(expandRange1 == FileRange(fooFilePath, 214, 217))
-
-            project ! ExpandSelectionReq(fooFile, 214, 217)
-            val expandRange2 = expectMsgType[FileRange]
-            assert(expandRange2 == FileRange(fooFilePath, 210, 229))
-
-            // TODO get the before content of the file
-
-            project ! PrepareRefactorReq(1234, null, RenameRefactorDesc("bar", fooFile, 215, 215), false)
-            expectMsgPF() {
-              case RefactorEffect(
-                1234,
-                RefactorType.Rename,
+          project ! SymbolAtPointReq(Left(fooFile), 343)
+          expectMsgPF() {
+            case Some(SymbolInfo("fn", "fn", Some(OffsetSourcePosition(`fooFile`, 304)),
+              BasicTypeInfo("Function1", DeclaredAs.Trait, "scala.Function1",
                 List(
-                  TextEdit(`fooFile`, 214, 217, "bar"),
-                  TextEdit(`fooFile`, 252, 255, "bar"),
-                  TextEdit(`fooFile`, 269, 272, "bar")
-                  ), _) =>
-            }
+                  BasicTypeInfo("String", DeclaredAs.Class, "java.lang.String", List(), List(), None),
+                  BasicTypeInfo("Int", DeclaredAs.Class, "scala.Int", List(), List(), None)),
+                List(), None),
+              false)) =>
+          }
 
-            project ! ExecRefactorReq(1234, RefactorType.Rename)
-            expectMsgPF() {
-              case RefactorResult(1234, RefactorType.Rename, List(`fooFile`), _) =>
-            }
+          project ! SymbolAtPointReq(Left(barFile), 150)
+          expectMsgPF() {
+            case Some(SymbolInfo("apply", "apply", Some(OffsetSourcePosition(`barFile`, 59)),
+              ArrowTypeInfo("(bar: String, baz: Int)org.example.Bar.Foo",
+                BasicTypeInfo("Foo", DeclaredAs.Class, "org.example.Bar$$Foo", List(), List(), None),
+                List(ParamSectionInfo(
+                  List(
+                    ("bar", BasicTypeInfo("String", DeclaredAs.Class, "java.lang.String", List(), List(), None)),
+                    ("baz", BasicTypeInfo("Int", DeclaredAs.Class, "scala.Int", List(), List(), None))), false))),
+              true)) =>
+          }
+
+          project ! SymbolAtPointReq(Left(barFile), 193)
+          expectMsgPF() {
+            case Some(SymbolInfo("copy", "copy", Some(OffsetSourcePosition(`barFile`, 59)),
+              ArrowTypeInfo("(bar: String, baz: Int)org.example.Bar.Foo",
+                BasicTypeInfo("Foo", DeclaredAs.Class, "org.example.Bar$$Foo", List(), List(), None),
+                List(ParamSectionInfo(
+                  List(
+                    ("bar", BasicTypeInfo("String", DeclaredAs.Class, "java.lang.String", List(), List(), None)),
+                    ("baz", BasicTypeInfo("Int", DeclaredAs.Class, "scala.Int", List(), List(), None))), false))),
+              true)) =>
+          }
+
+          // C-c C-v p Inspect source of current package
+          project ! InspectPackageByPathReq("org.example")
+          expectMsgPF() {
+            case Some(PackageInfo("example", "org.example", List(
+              BasicTypeInfo("Bar", DeclaredAs.Class, "org.example.Bar", List(), List(), Some(_)),
+              BasicTypeInfo("Bar$", DeclaredAs.Object, "org.example.Bar$", List(), List(), Some(_)),
+              BasicTypeInfo("Bloo", DeclaredAs.Class, "org.example.Bloo", List(), List(), Some(_)),
+              BasicTypeInfo("Bloo$", DeclaredAs.Object, "org.example.Bloo$", List(), List(), Some(_)),
+              BasicTypeInfo("Blue", DeclaredAs.Class, "org.example.Blue", List(), List(), Some(_)),
+              BasicTypeInfo("Blue$", DeclaredAs.Object, "org.example.Blue$", List(), List(), Some(_)),
+              BasicTypeInfo("CaseClassWithCamelCaseName", DeclaredAs.Class, "org.example.CaseClassWithCamelCaseName", List(), List(), Some(_)),
+              BasicTypeInfo("CaseClassWithCamelCaseName$", DeclaredAs.Object, "org.example.CaseClassWithCamelCaseName$", List(), List(), Some(_)),
+              BasicTypeInfo("Foo", DeclaredAs.Class, "org.example.Foo", List(), List(), Some(_)),
+              BasicTypeInfo("Foo$", DeclaredAs.Object, "org.example.Foo$", List(), List(), Some(_)),
+              BasicTypeInfo("Test1", DeclaredAs.Class, "org.example.Test1", List(), List(), None),
+              BasicTypeInfo("Test1$", DeclaredAs.Object, "org.example.Test1$", List(), List(), None),
+              BasicTypeInfo("Test2", DeclaredAs.Class, "org.example.Test2", List(), List(), None),
+              BasicTypeInfo("Test2$", DeclaredAs.Object, "org.example.Test2$", List(), List(), None),
+              BasicTypeInfo("package$", DeclaredAs.Object, "org.example.package$", List(), List(), None),
+              BasicTypeInfo("package$", DeclaredAs.Object, "org.example.package$", List(), List(), None)))) =>
+          }
+
+          // expand selection around 'val foo'
+          project ! ExpandSelectionReq(fooFile, 215, 215)
+          val expandRange1 = expectMsgType[FileRange]
+          expandRange1 shouldBe FileRange(fooFilePath, 214, 217)
+
+          project ! ExpandSelectionReq(fooFile, 214, 217)
+          val expandRange2 = expectMsgType[FileRange]
+          expandRange2 shouldBe FileRange(fooFilePath, 210, 229)
+
+          // TODO get the before content of the file
+
+          project ! PrepareRefactorReq(1234, null, RenameRefactorDesc("bar", fooFile, 215, 215), false)
+          expectMsgPF() {
+            case RefactorEffect(
+              1234,
+              RefactorType.Rename,
+              List(
+                TextEdit(`fooFile`, 214, 217, "bar"),
+                TextEdit(`fooFile`, 252, 255, "bar"),
+                TextEdit(`fooFile`, 269, 272, "bar")
+                ), _) =>
+          }
+
+          project ! ExecRefactorReq(1234, RefactorType.Rename)
+          expectMsgPF() {
+            case RefactorResult(1234, RefactorType.Rename, List(`fooFile`), _) =>
           }
         }
       }
     }
   }
-
 }

--- a/core/src/it/scala/org/ensime/intg/CompileTimingTest.scala
+++ b/core/src/it/scala/org/ensime/intg/CompileTimingTest.scala
@@ -2,11 +2,10 @@
 // Licence: http://www.gnu.org/licenses/gpl-3.0.en.html
 package org.ensime.intg
 
-import akka.event.slf4j.SLF4JLogging
 import org.apache.commons.io.FileUtils
 import org.ensime.api._
 import org.ensime.fixture._
-import org.scalatest.{ Matchers, WordSpec }
+import org.ensime.util.EnsimeSpec
 import org.ensime.util.file._
 
 /**
@@ -14,74 +13,70 @@ import org.ensime.util.file._
  *
  * (which also tests the file watchers).
  */
-class CompileTimingTest extends WordSpec with Matchers
+class CompileTimingTest extends EnsimeSpec
     with IsolatedEnsimeConfigFixture
     with IsolatedTestKitFixture
-    with IsolatedProjectFixture
-    with SLF4JLogging {
+    with IsolatedProjectFixture {
 
   val original = EnsimeConfigFixture.TimingTestProject
 
-  "ensime-server" should {
-    "handle multiple sbt clean / compile" in {
-      withEnsimeConfig { implicit config =>
-        withTestKit { implicit testkit =>
-          withProject { (project, asyncHelper) =>
-            import testkit._
+  "ensime-server" should "handle multiple sbt clean / compile" in {
+    withEnsimeConfig { implicit config =>
+      withTestKit { implicit testkit =>
+        withProject { (project, asyncHelper) =>
+          import testkit._
 
-            val sourceRoot = scalaMain(config)
+          val sourceRoot = scalaMain(config)
 
-            val example = sourceRoot / "p1/Example.scala"
+          val example = sourceRoot / "p1/Example.scala"
 
-            val target = (mainTarget / "..").canon
-            val targetBak = (target / "../scala-classes.bak").canon
+          val target = (mainTarget / "..").canon
+          val targetBak = (target / "../scala-classes.bak").canon
 
-            val exampleDiskInfo = SourceFileInfo(example, None, None)
-            val exampleMemory = SourceFileInfo(example, None, Some(example))
+          val exampleDiskInfo = SourceFileInfo(example, None, None)
+          val exampleMemory = SourceFileInfo(example, None, Some(example))
 
-            FileUtils.copyDirectory(target, targetBak)
+          FileUtils.copyDirectory(target, targetBak)
 
-            project ! TypecheckFileReq(exampleDiskInfo)
-            expectMsg(VoidResponse)
-            asyncHelper.expectMsg(FullTypeCheckCompleteEvent)
+          project ! TypecheckFileReq(exampleDiskInfo)
+          expectMsg(VoidResponse)
+          asyncHelper.expectMsg(FullTypeCheckCompleteEvent)
 
-            // GUI usually responds to each typecheck by requesting symbols
-            project ! SymbolDesignationsReq(Right(exampleDiskInfo), 0, 70, SourceSymbol.allSymbols)
-            expectMsgType[SymbolDesignations]
+          // GUI usually responds to each typecheck by requesting symbols
+          project ! SymbolDesignationsReq(Right(exampleDiskInfo), 0, 70, SourceSymbol.allSymbols)
+          expectMsgType[SymbolDesignations]
 
-            // typecheck an in-memory version of the file
-            project ! TypecheckFileReq(exampleMemory)
-            expectMsg(VoidResponse)
+          // typecheck an in-memory version of the file
+          project ! TypecheckFileReq(exampleMemory)
+          expectMsg(VoidResponse)
 
-            asyncHelper.expectMsg(FullTypeCheckCompleteEvent)
-            project ! SymbolDesignationsReq(Right(exampleMemory), 0, 70, SourceSymbol.allSymbols)
-            expectMsgType[SymbolDesignations]
+          asyncHelper.expectMsg(FullTypeCheckCompleteEvent)
+          project ! SymbolDesignationsReq(Right(exampleMemory), 0, 70, SourceSymbol.allSymbols)
+          expectMsgType[SymbolDesignations]
 
-            // simulate sbt clean https://github.com/sbt/sbt/issues/106
-            FileUtils.deleteDirectory(target)
+          // simulate sbt clean https://github.com/sbt/sbt/issues/106
+          FileUtils.deleteDirectory(target)
 
-            asyncHelper.receiveN(2) should contain theSameElementsAs (Seq(
-              FullTypeCheckCompleteEvent,
-              CompilerRestartedEvent
-            ))
+          asyncHelper.receiveN(2) should contain theSameElementsAs (Seq(
+            FullTypeCheckCompleteEvent,
+            CompilerRestartedEvent
+          ))
 
-            project ! SymbolDesignationsReq(Right(exampleDiskInfo), 0, 70, SourceSymbol.allSymbols)
-            expectMsgType[SymbolDesignations]
+          project ! SymbolDesignationsReq(Right(exampleDiskInfo), 0, 70, SourceSymbol.allSymbols)
+          expectMsgType[SymbolDesignations]
 
-            // simulate sbt compile
-            FileUtils.copyDirectory(targetBak, target)
+          // simulate sbt compile
+          FileUtils.copyDirectory(targetBak, target)
 
-            asyncHelper.receiveN(2) should contain theSameElementsAs (Seq(
-              FullTypeCheckCompleteEvent,
-              CompilerRestartedEvent
-            ))
+          asyncHelper.receiveN(2) should contain theSameElementsAs (Seq(
+            FullTypeCheckCompleteEvent,
+            CompilerRestartedEvent
+          ))
 
-            project ! SymbolDesignationsReq(Right(exampleDiskInfo), 0, 70, SourceSymbol.allSymbols)
-            expectMsgType[SymbolDesignations]
-          }
+          project ! SymbolDesignationsReq(Right(exampleDiskInfo), 0, 70, SourceSymbol.allSymbols)
+          expectMsgType[SymbolDesignations]
         }
       }
     }
   }
-
 }

--- a/core/src/it/scala/org/ensime/intg/DebugTest.scala
+++ b/core/src/it/scala/org/ensime/intg/DebugTest.scala
@@ -8,11 +8,12 @@ import akka.testkit._
 import org.ensime.api._
 import org.ensime.core._
 import org.ensime.fixture._
-import org.scalatest._
+import org.ensime.util.EnsimeSpec
 import org.ensime.util.file._
+import org.scalatest.Matchers
 
 // must be refreshing as the tests don't clean up after themselves properly
-class DebugTest extends WordSpec with Matchers with Inside
+class DebugTest extends EnsimeSpec
     with IsolatedEnsimeConfigFixture
     with IsolatedTestKitFixture
     with IsolatedProjectFixture
@@ -22,258 +23,251 @@ class DebugTest extends WordSpec with Matchers with Inside
     javaLibs = Nil // no need to index the JRE
   )
 
-  "Debug - stepping" should {
-    // TODO This is broken because step in our case is stepping into
-    // the classloader for inner class rather than doing a user
-    // visible step.
-    "handle basic stepping" ignore
-      withEnsimeConfig { implicit config =>
-        withTestKit { implicit testkit =>
-          withProject { (project, asyncHelper) =>
-            implicit val p = (project, asyncHelper)
-            withDebugSession(
-              "stepping.ForComprehensionListString",
-              "stepping/ForComprehensionListString.scala",
-              9
-            ) { breakpointsFile =>
-                import testkit._
+  // TODO This is broken because step in our case is stepping into
+  // the classloader for inner class rather than doing a user
+  // visible step.
+  "Debug - stepping" should "handle basic stepping" ignore {
+    withEnsimeConfig { implicit config =>
+      withTestKit { implicit testkit =>
+        withProject { (project, asyncHelper) =>
+          implicit val p = (project, asyncHelper)
+          withDebugSession(
+            "stepping.ForComprehensionListString",
+            "stepping/ForComprehensionListString.scala",
+            9
+          ) { breakpointsFile =>
+              import testkit._
 
-                checkTopStackFrame("stepping.ForComprehensionListString$", "main", 9)
-                project ! DebugNextReq(DebugThreadId(1))
-                expectMsg(VoidResponse)
+              checkTopStackFrame("stepping.ForComprehensionListString$", "main", 9)
+              project ! DebugNextReq(DebugThreadId(1))
+              expectMsg(VoidResponse)
 
-                checkTopStackFrame("stepping.ForComprehensionListString$$anonfun$main$1", "apply", 10)
-              }
+              checkTopStackFrame("stepping.ForComprehensionListString$$anonfun$main$1", "apply", 10)
+            }
+        }
+      }
+    }
+  }
+
+  "Breakpoints" should "trigger/continue" in withEnsimeConfig { implicit config =>
+    withTestKit { implicit testkit =>
+      withProject { (project, asyncHelper) =>
+        implicit val p = (project, asyncHelper)
+        withDebugSession(
+          "breakpoints.Breakpoints",
+          "breakpoints/Breakpoints.scala",
+          32
+        ) { breakpointsFile =>
+            import testkit._
+            val breakpointsPath = breakpointsFile.getAbsolutePath
+
+            project ! DebugBacktraceReq(DebugThreadId(1), 0, 3)
+            expectMsgType[DebugBacktrace] should matchPattern {
+              case DebugBacktrace(List(
+                DebugStackFrame(0, List(), 0, "breakpoints.Breakpoints", "mainTest",
+                  LineSourcePosition(`breakpointsFile`, 32), _),
+                DebugStackFrame(1, List(
+                  DebugStackLocal(0, "args", "Array[]", "java.lang.String[]")
+                  ), 1, "breakpoints.Breakpoints$", "main",
+                  LineSourcePosition(`breakpointsFile`, 41), _),
+                DebugStackFrame(2, List(), 1, "breakpoints.Breakpoints", "main",
+                  LineSourcePosition(`breakpointsFile`, _), _)
+                ), DebugThreadId(1), "main") =>
+            }
+
+            //            val bp11 = session.addLineBreakpoint(BP_TYPENAME, 11)
+            project ! DebugSetBreakReq(breakpointsFile, 11)
+            expectMsg(TrueResponse)
+            //            val bp13 = session.addLineBreakpoint(BP_TYPENAME, 13)
+            project ! DebugSetBreakReq(breakpointsFile, 13)
+            expectMsg(TrueResponse)
+
+            //              session.waitForBreakpointsToBeEnabled(bp11, bp13)
+
+            //              session.resumetoSuspension()
+            //              session.checkStackFrame(BP_TYPENAME, "simple1()V", 11)
+
+            asyncHelper.expectMsg(DebugBreakEvent(DebugThreadId(1), "main", breakpointsFile, 32))
+
+            project ! DebugContinueReq(DebugThreadId(1))
+            expectMsg(TrueResponse)
+
+            asyncHelper.expectMsg(DebugBreakEvent(DebugThreadId(1), "main", breakpointsFile, 11))
+
+            //              session.resumetoSuspension()
+            //              session.checkStackFrame(BP_TYPENAME, "simple1()V", 13)
+
+            project ! DebugContinueReq(DebugThreadId(1))
+            expectMsg(TrueResponse)
+
+            asyncHelper.expectMsg(DebugBreakEvent(DebugThreadId(1), "main", breakpointsFile, 13))
+
+            //              bp11.setEnabled(false)
+            project ! DebugClearBreakReq(breakpointsFile, 11)
+            expectMsg(TrueResponse)
+
+            //              session.waitForBreakpointsToBeDisabled(bp11)
+            //
+            //              session.resumetoSuspension()
+            project ! DebugContinueReq(DebugThreadId(1))
+            expectMsg(TrueResponse)
+            //              session.checkStackFrame(BP_TYPENAME, "simple1()V", 13)
+            asyncHelper.expectMsg(DebugBreakEvent(DebugThreadId(1), "main", breakpointsFile, 13))
+            //
+            //              bp11.setEnabled(true); bp13.setEnabled(false)
+            project ! DebugSetBreakReq(breakpointsFile, 11)
+            expectMsg(TrueResponse)
+            project ! DebugClearBreakReq(breakpointsFile, 13)
+            expectMsg(TrueResponse)
+
+            //
+            //              session.waitForBreakpointsToBeEnabled(bp11)
+            //              session.waitForBreakpointsToBeDisabled(bp13)
+            //
+            //              session.resumetoSuspension()
+            //              session.checkStackFrame(BP_TYPENAME, "simple1()V", 11)
+            project ! DebugContinueReq(DebugThreadId(1))
+            expectMsg(TrueResponse)
+
+            asyncHelper.expectMsg(DebugBreakEvent(DebugThreadId(1), "main", breakpointsFile, 11))
+            //
+            //              session.resumetoSuspension()
+            //              session.checkStackFrame(BP_TYPENAME, "simple1()V", 11)
+            project ! DebugContinueReq(DebugThreadId(1))
+            expectMsg(TrueResponse)
+            asyncHelper.expectMsg(DebugBreakEvent(DebugThreadId(1), "main", breakpointsFile, 11))
+            //
+            project ! DebugContinueReq(DebugThreadId(1))
+            expectMsg(TrueResponse)
+
+            //asyncHelper.expectAsync(60 seconds, DebugVMDisconnectEvent)
+            //              session.resumeToCompletion()
+            //              bp11.delete()
+            //              bp13.delete()
           }
-        }
-      }
-  }
-
-  "Breakpoints" should {
-    "trigger/continue" in withEnsimeConfig { implicit config =>
-      withTestKit { implicit testkit =>
-        withProject { (project, asyncHelper) =>
-          implicit val p = (project, asyncHelper)
-          withDebugSession(
-            "breakpoints.Breakpoints",
-            "breakpoints/Breakpoints.scala",
-            32
-          ) { breakpointsFile =>
-              import testkit._
-              val breakpointsPath = breakpointsFile.getAbsolutePath
-
-              project ! DebugBacktraceReq(DebugThreadId(1), 0, 3)
-              expectMsgType[DebugBacktrace] should matchPattern {
-                case DebugBacktrace(List(
-                  DebugStackFrame(0, List(), 0, "breakpoints.Breakpoints", "mainTest",
-                    LineSourcePosition(`breakpointsFile`, 32), _),
-                  DebugStackFrame(1, List(
-                    DebugStackLocal(0, "args", "Array[]", "java.lang.String[]")
-                    ), 1, "breakpoints.Breakpoints$", "main",
-                    LineSourcePosition(`breakpointsFile`, 41), _),
-                  DebugStackFrame(2, List(), 1, "breakpoints.Breakpoints", "main",
-                    LineSourcePosition(`breakpointsFile`, _), _)
-                  ), DebugThreadId(1), "main") =>
-              }
-
-              //            val bp11 = session.addLineBreakpoint(BP_TYPENAME, 11)
-              project ! DebugSetBreakReq(breakpointsFile, 11)
-              expectMsg(TrueResponse)
-              //            val bp13 = session.addLineBreakpoint(BP_TYPENAME, 13)
-              project ! DebugSetBreakReq(breakpointsFile, 13)
-              expectMsg(TrueResponse)
-
-              //              session.waitForBreakpointsToBeEnabled(bp11, bp13)
-
-              //              session.resumetoSuspension()
-              //              session.checkStackFrame(BP_TYPENAME, "simple1()V", 11)
-
-              asyncHelper.expectMsg(DebugBreakEvent(DebugThreadId(1), "main", breakpointsFile, 32))
-
-              project ! DebugContinueReq(DebugThreadId(1))
-              expectMsg(TrueResponse)
-
-              asyncHelper.expectMsg(DebugBreakEvent(DebugThreadId(1), "main", breakpointsFile, 11))
-
-              //              session.resumetoSuspension()
-              //              session.checkStackFrame(BP_TYPENAME, "simple1()V", 13)
-
-              project ! DebugContinueReq(DebugThreadId(1))
-              expectMsg(TrueResponse)
-
-              asyncHelper.expectMsg(DebugBreakEvent(DebugThreadId(1), "main", breakpointsFile, 13))
-
-              //              bp11.setEnabled(false)
-              project ! DebugClearBreakReq(breakpointsFile, 11)
-              expectMsg(TrueResponse)
-
-              //              session.waitForBreakpointsToBeDisabled(bp11)
-              //
-              //              session.resumetoSuspension()
-              project ! DebugContinueReq(DebugThreadId(1))
-              expectMsg(TrueResponse)
-              //              session.checkStackFrame(BP_TYPENAME, "simple1()V", 13)
-              asyncHelper.expectMsg(DebugBreakEvent(DebugThreadId(1), "main", breakpointsFile, 13))
-              //
-              //              bp11.setEnabled(true); bp13.setEnabled(false)
-              project ! DebugSetBreakReq(breakpointsFile, 11)
-              expectMsg(TrueResponse)
-              project ! DebugClearBreakReq(breakpointsFile, 13)
-              expectMsg(TrueResponse)
-
-              //
-              //              session.waitForBreakpointsToBeEnabled(bp11)
-              //              session.waitForBreakpointsToBeDisabled(bp13)
-              //
-              //              session.resumetoSuspension()
-              //              session.checkStackFrame(BP_TYPENAME, "simple1()V", 11)
-              project ! DebugContinueReq(DebugThreadId(1))
-              expectMsg(TrueResponse)
-
-              asyncHelper.expectMsg(DebugBreakEvent(DebugThreadId(1), "main", breakpointsFile, 11))
-              //
-              //              session.resumetoSuspension()
-              //              session.checkStackFrame(BP_TYPENAME, "simple1()V", 11)
-              project ! DebugContinueReq(DebugThreadId(1))
-              expectMsg(TrueResponse)
-              asyncHelper.expectMsg(DebugBreakEvent(DebugThreadId(1), "main", breakpointsFile, 11))
-              //
-              project ! DebugContinueReq(DebugThreadId(1))
-              expectMsg(TrueResponse)
-
-              //asyncHelper.expectAsync(60 seconds, DebugVMDisconnectEvent)
-              //              session.resumeToCompletion()
-              //              bp11.delete()
-              //              bp13.delete()
-            }
-        }
-      }
-    }
-
-    "list/clear" in withEnsimeConfig { implicit config =>
-      withTestKit { implicit testkit =>
-        withProject { (project, asyncHelper) =>
-          implicit val p = (project, asyncHelper)
-          withDebugSession(
-            "breakpoints.Breakpoints",
-            "breakpoints/Breakpoints.scala",
-            32
-          ) { breakpointsFile =>
-              import testkit._
-              val breakpointsPath = breakpointsFile.getAbsolutePath
-
-              // TODO: test listing/clearing pending breakpoints (i.e. before we connect)
-
-              project ! DebugListBreakpointsReq
-              expectMsgType[BreakpointList] should matchPattern {
-                case BreakpointList(Nil, Nil) =>
-              }
-
-              // break in main
-              project ! DebugSetBreakReq(breakpointsFile, 11)
-              expectMsg(TrueResponse)
-              project ! DebugSetBreakReq(breakpointsFile, 13)
-              expectMsg(TrueResponse)
-
-              // breakpoints should now be active
-              project ! DebugListBreakpointsReq
-              inside(expectMsgType[BreakpointList]) {
-                case BreakpointList(activeBreakpoints, pendingBreakpoints) =>
-                  activeBreakpoints should contain theSameElementsAs Set(
-                    Breakpoint(breakpointsFile, 11), Breakpoint(breakpointsFile, 13)
-                  )
-                  pendingBreakpoints shouldBe empty
-              }
-
-              // check clear works again
-              project ! DebugClearAllBreaksReq
-              expectMsg(TrueResponse)
-              project ! DebugListBreakpointsReq
-              expectMsgType[BreakpointList] should matchPattern {
-                case BreakpointList(Nil, Nil) =>
-              }
-            }
-        }
       }
     }
   }
 
-  "Debug Inspect variables" should {
+  it should "list/clear" in withEnsimeConfig { implicit config =>
+    withTestKit { implicit testkit =>
+      withProject { (project, asyncHelper) =>
+        implicit val p = (project, asyncHelper)
+        withDebugSession(
+          "breakpoints.Breakpoints",
+          "breakpoints/Breakpoints.scala",
+          32
+        ) { breakpointsFile =>
+            import testkit._
+            val breakpointsPath = breakpointsFile.getAbsolutePath
 
-    // starting up a debug session for each variable is unneeded and wasteful of test time.
-    // this approach means that there is one test method, but it still explores all of the paths.
+            // TODO: test listing/clearing pending breakpoints (i.e. before we connect)
 
-    "inspect variables" in withEnsimeConfig { implicit config =>
-      withTestKit { implicit testkit =>
-        withProject { (project, asyncHelper) =>
-          implicit val p = (project, asyncHelper)
-          withDebugSession(
-            "debug.Variables",
-            "debug/Variables.scala",
-            21
-          ) { variablesFile =>
-              // boolean local
-              getVariableValue(DebugThreadId(1), "a") should matchPattern {
-                case DebugPrimitiveValue("true", "boolean") =>
-              }
-
-              // char local
-              getVariableValue(DebugThreadId(1), "b") should matchPattern {
-                case DebugPrimitiveValue("'c'", "char") =>
-              }
-
-              // short local
-              getVariableValue(DebugThreadId(1), "c") should matchPattern {
-                case DebugPrimitiveValue("3", "short") =>
-              }
-
-              // int local
-              getVariableValue(DebugThreadId(1), "d") should matchPattern {
-                case DebugPrimitiveValue("4", "int") =>
-              }
-
-              // long local
-              getVariableValue(DebugThreadId(1), "e") should matchPattern {
-                case DebugPrimitiveValue("5", "long") =>
-              }
-
-              // float local
-              getVariableValue(DebugThreadId(1), "f") should matchPattern {
-                case DebugPrimitiveValue("1.0", "float") =>
-              }
-
-              // double local
-              getVariableValue(DebugThreadId(1), "g") should matchPattern {
-                case DebugPrimitiveValue("2.0", "double") =>
-              }
-
-              // String local
-              inside(getVariableValue(DebugThreadId(1), "h")) {
-                case DebugStringInstance("\"test\"", debugFields, "java.lang.String", _) =>
-                  exactly(1, debugFields) should matchPattern {
-                    case DebugClassField(_, "value", "char[]", "Array['t', 'e', 's',...]") =>
-                  }
-              }
-
-              // primitive array local
-              getVariableValue(DebugThreadId(1), "i") should matchPattern {
-                case DebugArrayInstance(3, "int[]", "int", _) =>
-              }
-
-              // type local
-              inside(getVariableValue(DebugThreadId(1), "j")) {
-                case DebugObjectInstance("Instance of $colon$colon", debugFields, "scala.collection.immutable.$colon$colon", _) =>
-                  exactly(1, debugFields) should matchPattern {
-                    case DebugClassField(_, head, "java.lang.Object", "Instance of Integer") if head == "head" | head == "scala$collection$immutable$$colon$colon$$hd" =>
-                  }
-              }
-
-              // object array local
-              getVariableValue(DebugThreadId(1), "k") should matchPattern {
-                case DebugArrayInstance(3, "java.lang.Object[]", "java.lang.Object", _) =>
-              }
+            project ! DebugListBreakpointsReq
+            expectMsgType[BreakpointList] should matchPattern {
+              case BreakpointList(Nil, Nil) =>
             }
-        }
+
+            // break in main
+            project ! DebugSetBreakReq(breakpointsFile, 11)
+            expectMsg(TrueResponse)
+            project ! DebugSetBreakReq(breakpointsFile, 13)
+            expectMsg(TrueResponse)
+
+            // breakpoints should now be active
+            project ! DebugListBreakpointsReq
+            inside(expectMsgType[BreakpointList]) {
+              case BreakpointList(activeBreakpoints, pendingBreakpoints) =>
+                activeBreakpoints should contain theSameElementsAs Set(
+                  Breakpoint(breakpointsFile, 11), Breakpoint(breakpointsFile, 13)
+                )
+                pendingBreakpoints shouldBe empty
+            }
+
+            // check clear works again
+            project ! DebugClearAllBreaksReq
+            expectMsg(TrueResponse)
+            project ! DebugListBreakpointsReq
+            expectMsgType[BreakpointList] should matchPattern {
+              case BreakpointList(Nil, Nil) =>
+            }
+          }
+      }
+    }
+  }
+
+  // starting up a debug session for each variable is unneeded and wasteful of test time.
+  // this approach means that there is one test method, but it still explores all of the paths.
+  "Debug Inspect variables" should "inspect variables" in withEnsimeConfig { implicit config =>
+    withTestKit { implicit testkit =>
+      withProject { (project, asyncHelper) =>
+        implicit val p = (project, asyncHelper)
+        withDebugSession(
+          "debug.Variables",
+          "debug/Variables.scala",
+          21
+        ) { variablesFile =>
+            // boolean local
+            getVariableValue(DebugThreadId(1), "a") should matchPattern {
+              case DebugPrimitiveValue("true", "boolean") =>
+            }
+
+            // char local
+            getVariableValue(DebugThreadId(1), "b") should matchPattern {
+              case DebugPrimitiveValue("'c'", "char") =>
+            }
+
+            // short local
+            getVariableValue(DebugThreadId(1), "c") should matchPattern {
+              case DebugPrimitiveValue("3", "short") =>
+            }
+
+            // int local
+            getVariableValue(DebugThreadId(1), "d") should matchPattern {
+              case DebugPrimitiveValue("4", "int") =>
+            }
+
+            // long local
+            getVariableValue(DebugThreadId(1), "e") should matchPattern {
+              case DebugPrimitiveValue("5", "long") =>
+            }
+
+            // float local
+            getVariableValue(DebugThreadId(1), "f") should matchPattern {
+              case DebugPrimitiveValue("1.0", "float") =>
+            }
+
+            // double local
+            getVariableValue(DebugThreadId(1), "g") should matchPattern {
+              case DebugPrimitiveValue("2.0", "double") =>
+            }
+
+            // String local
+            inside(getVariableValue(DebugThreadId(1), "h")) {
+              case DebugStringInstance("\"test\"", debugFields, "java.lang.String", _) =>
+                exactly(1, debugFields) should matchPattern {
+                  case DebugClassField(_, "value", "char[]", "Array['t', 'e', 's',...]") =>
+                }
+            }
+
+            // primitive array local
+            getVariableValue(DebugThreadId(1), "i") should matchPattern {
+              case DebugArrayInstance(3, "int[]", "int", _) =>
+            }
+
+            // type local
+            inside(getVariableValue(DebugThreadId(1), "j")) {
+              case DebugObjectInstance("Instance of $colon$colon", debugFields, "scala.collection.immutable.$colon$colon", _) =>
+                exactly(1, debugFields) should matchPattern {
+                  case DebugClassField(_, head, "java.lang.Object", "Instance of Integer") if head == "head" | head == "scala$collection$immutable$$colon$colon$$hd" =>
+                }
+            }
+
+            // object array local
+            getVariableValue(DebugThreadId(1), "k") should matchPattern {
+              case DebugArrayInstance(3, "java.lang.Object[]", "java.lang.Object", _) =>
+            }
+          }
       }
     }
   }

--- a/core/src/it/scala/org/ensime/intg/ImplicitsWildcardImports.scala
+++ b/core/src/it/scala/org/ensime/intg/ImplicitsWildcardImports.scala
@@ -2,46 +2,42 @@
 // Licence: http://www.gnu.org/licenses/gpl-3.0.en.html
 package org.ensime.intg
 
-import akka.event.slf4j.SLF4JLogging
 import org.ensime.api._
 import org.ensime.fixture._
-import org.scalatest.{ Matchers, WordSpec }
+import org.ensime.util.EnsimeSpec
 import org.ensime.util.file._
 
 /**
  * This is a reproduction of https://github.com/ensime/ensime-server/issues/1176
  * which might be caused by https://github.com/scala/scala/pull/4777
  */
-class ImplicitsWildcardImports extends WordSpec with Matchers
+class ImplicitsWildcardImports extends EnsimeSpec
     with IsolatedEnsimeConfigFixture
     with IsolatedTestKitFixture
-    with IsolatedProjectFixture
-    with SLF4JLogging {
+    with IsolatedProjectFixture {
 
   val original = EnsimeConfigFixture.ImplicitsTestProject
 
-  "ensime-server" should {
-    "allow getting symbols also after marking implicits imported with a wildcard import" ignore {
-      withEnsimeConfig { implicit config =>
-        withTestKit { implicit testkit =>
-          withProject { (project, asyncHelper) =>
-            import testkit._
+  "ensime-server" should "allow getting symbols also after marking implicits imported with a wildcard import" ignore {
+    withEnsimeConfig { implicit config =>
+      withTestKit { implicit testkit =>
+        withProject { (project, asyncHelper) =>
+          import testkit._
 
-            val sourceRoot = scalaMain(config)
-            val exampleFile = sourceRoot / "org/example/Example.scala"
+          val sourceRoot = scalaMain(config)
+          val exampleFile = sourceRoot / "org/example/Example.scala"
 
-            log.info("Getting type the first time")
-            project ! SymbolAtPointReq(Left(exampleFile), 116)
-            expectMsgType[Option[SymbolInfo]].get.name should be("seconds")
+          log.info("Getting type the first time")
+          project ! SymbolAtPointReq(Left(exampleFile), 116)
+          expectMsgType[Option[SymbolInfo]].get.name should be("seconds")
 
-            log.info("Getting implicit info")
-            project ! ImplicitInfoReq(Left(exampleFile), OffsetRange(0, 121))
-            expectMsgType[ImplicitInfos]
+          log.info("Getting implicit info")
+          project ! ImplicitInfoReq(Left(exampleFile), OffsetRange(0, 121))
+          expectMsgType[ImplicitInfos]
 
-            log.info("Getting type the second time")
-            project ! SymbolAtPointReq(Left(exampleFile), 116)
-            expectMsgType[Option[SymbolInfo]].get.name should be("seconds")
-          }
+          log.info("Getting type the second time")
+          project ! SymbolAtPointReq(Left(exampleFile), 116)
+          expectMsgType[Option[SymbolInfo]].get.name should be("seconds")
         }
       }
     }

--- a/core/src/it/scala/org/ensime/intg/JavaWorkflow.scala
+++ b/core/src/it/scala/org/ensime/intg/JavaWorkflow.scala
@@ -2,41 +2,36 @@
 // Licence: http://www.gnu.org/licenses/gpl-3.0.en.html
 package org.ensime.intg
 
-import akka.event.slf4j.SLF4JLogging
 import org.ensime.api._
 import org.ensime.fixture._
-import org.scalatest.{ Matchers, WordSpec }
+import org.ensime.util.EnsimeSpec
 import org.ensime.util.file._
 
 // a pure java project, checking that how things behave without scala
-class JavaWorkflow extends WordSpec with Matchers
+class JavaWorkflow extends EnsimeSpec
     with IsolatedEnsimeConfigFixture
     with IsolatedTestKitFixture
-    with IsolatedProjectFixture
-    with SLF4JLogging {
+    with IsolatedProjectFixture {
 
   val original = EnsimeConfigFixture.JavaTestProject
 
-  "ensime-server" should {
-    "open the pure Java test project" in {
-      withEnsimeConfig { implicit config =>
-        withTestKit { implicit testkit =>
-          withProject { (project, asyncHelper) =>
-            import testkit._
+  "ensime-server" should "open the pure Java test project" in {
+    withEnsimeConfig { implicit config =>
+      withTestKit { implicit testkit =>
+        withProject { (project, asyncHelper) =>
+          import testkit._
 
-            val sourceRoot = javaMain(config)
-            val fooFile = sourceRoot / "pure/NoScalaHere.java"
-            val fooFilePath = fooFile.getAbsolutePath
+          val sourceRoot = javaMain(config)
+          val fooFile = sourceRoot / "pure/NoScalaHere.java"
+          val fooFilePath = fooFile.getAbsolutePath
 
-            project ! TypecheckFilesReq(List(Left(fooFile)))
-            expectMsg(VoidResponse)
+          project ! TypecheckFilesReq(List(Left(fooFile)))
+          expectMsg(VoidResponse)
 
-            project ! TypeAtPointReq(Left(fooFile), OffsetRange(30))
-            expectMsg(Some(BasicTypeInfo("pure.NoScalaHere", DeclaredAs.Class, "pure.NoScalaHere", Nil, Nil, Some(EmptySourcePosition()))))
-          }
+          project ! TypeAtPointReq(Left(fooFile), OffsetRange(30))
+          expectMsg(Some(BasicTypeInfo("pure.NoScalaHere", DeclaredAs.Class, "pure.NoScalaHere", Nil, Nil, Some(EmptySourcePosition()))))
         }
       }
     }
   }
-
 }

--- a/core/src/it/scala/org/ensime/intg/UnsavedFileTest.scala
+++ b/core/src/it/scala/org/ensime/intg/UnsavedFileTest.scala
@@ -6,53 +6,49 @@ import akka.event.slf4j.SLF4JLogging
 import org.apache.commons.io.FileUtils
 import org.ensime.api._
 import org.ensime.fixture._
-import org.scalatest.{ Matchers, WordSpec }
+import org.ensime.util.EnsimeSpec
 import org.ensime.util.file._
 
 /**
  * Verifies common operations work correctly for unsaved files.
  */
-class UnsavedFileTest extends WordSpec with Matchers
+class UnsavedFileTest extends EnsimeSpec
     with IsolatedEnsimeConfigFixture
     with IsolatedTestKitFixture
-    with IsolatedProjectFixture
-    with SLF4JLogging {
+    with IsolatedProjectFixture {
 
   val original = EnsimeConfigFixture.TimingTestProject
 
-  "ensime-server" should {
-    "handle unsaved files" in {
-      withEnsimeConfig { implicit config =>
-        withTestKit { implicit testkit =>
-          withProject { (project, asyncHelper) =>
-            import testkit._
+  "ensime-server" should "handle unsaved files" in {
+    withEnsimeConfig { implicit config =>
+      withTestKit { implicit testkit =>
+        withProject { (project, asyncHelper) =>
+          import testkit._
 
-            val sourceRoot = scalaMain(config)
-            val missing = sourceRoot / "p1/Missing.scala"
+          val sourceRoot = scalaMain(config)
+          val missing = sourceRoot / "p1/Missing.scala"
 
-            assert(!missing.exists)
+          assert(!missing.exists)
 
-            val inMemory = SourceFileInfo(
-              missing, Some("class Foo { def main = { System.out.println(1) } }"), None
-            )
+          val inMemory = SourceFileInfo(
+            missing, Some("class Foo { def main = { System.out.println(1) } }"), None
+          )
 
-            project ! TypecheckFileReq(inMemory)
-            expectMsg(VoidResponse)
-            asyncHelper.expectMsg(FullTypeCheckCompleteEvent)
+          project ! TypecheckFileReq(inMemory)
+          expectMsg(VoidResponse)
+          asyncHelper.expectMsg(FullTypeCheckCompleteEvent)
 
-            project ! SymbolDesignationsReq(Right(inMemory), 0, 50, SourceSymbol.allSymbols)
-            expectMsgPF() {
-              case SymbolDesignations(inMemory.file, syms: List[SymbolDesignation]) if syms.nonEmpty =>
-            }
+          project ! SymbolDesignationsReq(Right(inMemory), 0, 50, SourceSymbol.allSymbols)
+          expectMsgPF() {
+            case SymbolDesignations(inMemory.file, syms: List[SymbolDesignation]) if syms.nonEmpty =>
+          }
 
-            project ! CompletionsReq(inMemory, 27, 0, false, false)
-            expectMsgPF() {
-              case CompletionInfoList("Sy", candidates) if candidates.exists(_.name == "System") =>
-            }
+          project ! CompletionsReq(inMemory, 27, 0, false, false)
+          expectMsgPF() {
+            case CompletionInfoList("Sy", candidates) if candidates.exists(_.name == "System") =>
           }
         }
       }
     }
   }
-
 }

--- a/core/src/it/scala/org/ensime/model/SourcePositionSpec.scala
+++ b/core/src/it/scala/org/ensime/model/SourcePositionSpec.scala
@@ -6,38 +6,46 @@ import org.ensime.api._
 import org.ensime.fixture._
 import org.ensime.indexer.DatabaseService.FqnSymbol
 import org.ensime.vfs._
-import org.scalatest._
+import org.ensime.util.EnsimeSpec
 import org.ensime.util.file._
 
-class SourcePositionSpec extends WordSpec with Matchers
-    with SharedEnsimeConfigFixture with SharedEnsimeVFSFixture {
+class SourcePositionSpec extends EnsimeSpec
+    with SharedEnsimeConfigFixture
+    with SharedEnsimeVFSFixture {
+
   val original = EnsimeConfigFixture.SimpleTestProject.copy(
     javaLibs = Nil
   )
 
-  "org.ensime.model.SourcePosition" should {
-    "resolve FqnSymbols for local files with no line number" in withEnsimeConfig { implicit config =>
+  "SourcePosition" should "resolve FqnSymbols for local files with no line number" in {
+    withEnsimeConfig { implicit config =>
       lookup(knownFile) match {
         case Some(LineSourcePosition(name, 0)) if name.isFile =>
         case o => fail(s"not resolved $o")
       }
     }
+  }
 
-    "resolve FqnSymbols for local with a line number" in withEnsimeConfig { implicit config =>
+  it should "resolve FqnSymbols for local with a line number" in {
+    withEnsimeConfig { implicit config =>
       lookup(knownFile, Some(100)) match {
         case Some(LineSourcePosition(name, 100)) if name.isFile =>
         case o => fail(s"not resolved $o")
       }
     }
+  }
 
-    "resolve FqnSymbols for archive entries with no line number" in withEnsimeConfig { implicit config =>
+  it should "resolve FqnSymbols for archive entries with no line number" in {
+    withEnsimeConfig { implicit config =>
       lookup(knownJarEntry) match {
         case Some(LineSourcePosition(name, 0)) if name.isFile =>
         case o => fail(s"not resolved $o")
       }
     }
+  }
 
-    "resolve FqnSymbols for archive entries with a line number" in withEnsimeConfig { implicit config =>
+  it should "resolve FqnSymbols for archive entries with a line number" in {
+    withEnsimeConfig { implicit config =>
       lookup(knownJarEntry, Some(100)) match {
         case Some(LineSourcePosition(name, 100)) if name.isFile =>
         case o => fail(s"not resolved $o")

--- a/core/src/it/scala/org/ensime/util/DiffUtilSpec.scala
+++ b/core/src/it/scala/org/ensime/util/DiffUtilSpec.scala
@@ -3,37 +3,34 @@
 package org.ensime.util
 
 import java.io.File
-import org.scalatest._
 
-class DiffUtilSpec extends WordSpec with Matchers {
-  "DiffUtil" should {
-    "compare original and revised contents and produce a diff in the unified format" in {
-      val originalContent =
-        """|line1
-           |line2
-           |line3"""
-          .stripMargin.lines.toSeq
+class DiffUtilSpec extends EnsimeSpec {
+  "DiffUtil" should "compare original and revised contents and produce a diff in the unified format" in {
+    val originalContent =
+      """|line1
+         |line2
+         |line3"""
+        .stripMargin.lines.toSeq
 
-      val revisedContent =
-        """|line1
-           |new-line2
-           |line3"""
-          .stripMargin.lines.toSeq
-      val a = new File("a").getAbsolutePath()
-      val b = new File("b").getAbsolutePath()
-      val expectedDiff =
-        s"""|--- $a	1970-01-01 12:00:00 +0000
-            |+++ $b	1970-01-01 12:00:00 +0000
-            |@@ -1,3 +1,3 @@
-            | line1
-            |-line2
-            |+new-line2
-            | line3
-            |""".stripMargin
+    val revisedContent =
+      """|line1
+         |new-line2
+         |line3"""
+        .stripMargin.lines.toSeq
+    val a = new File("a").getAbsolutePath()
+    val b = new File("b").getAbsolutePath()
+    val expectedDiff =
+      s"""|--- $a	1970-01-01 12:00:00 +0000
+          |+++ $b	1970-01-01 12:00:00 +0000
+          |@@ -1,3 +1,3 @@
+          | line1
+          |-line2
+          |+new-line2
+          | line3
+          |""".stripMargin
 
-      val diff = DiffUtil.compareContents(originalContent, revisedContent)
+    val diff = DiffUtil.compareContents(originalContent, revisedContent)
 
-      assert(diff === expectedDiff)
-    }
+    diff should ===(expectedDiff)
   }
 }

--- a/core/src/test/scala/org/ensime/config/EnsimeConfigSpec.scala
+++ b/core/src/test/scala/org/ensime/config/EnsimeConfigSpec.scala
@@ -2,16 +2,15 @@
 // Licence: http://www.gnu.org/licenses/gpl-3.0.en.html
 package org.ensime.config
 
-import org.scalatest.{ FunSpec, Matchers }
 import org.ensime.util.file._
-import org.ensime.util.EscapingStringInterpolation
+import org.ensime.util.{ EnsimeSpec, EscapingStringInterpolation }
 
 import org.ensime.api._
 
 import scala.util.Properties
 import scala.util.Try
 
-class EnsimeConfigSpec extends FunSpec with Matchers {
+class EnsimeConfigSpec extends EnsimeSpec {
 
   import EscapingStringInterpolation._
 
@@ -19,18 +18,15 @@ class EnsimeConfigSpec extends FunSpec with Matchers {
     testFn(EnsimeConfigProtocol.parse(contents))
   }
 
-  describe("ProjectConfigSpec") {
+  "EnsimeConfig" should "parse a simple config" in withTempDir { dir =>
+    val abc = dir / "abc"
+    val cache = dir / ".ensime_cache"
+    val javaHome = File(Properties.javaHome)
 
-    it("should parse a simple config") {
-      withTempDir { dir =>
-        val abc = dir / "abc"
-        val cache = dir / ".ensime_cache"
-        val javaHome = File(Properties.javaHome)
+    abc.mkdirs()
+    cache.mkdirs()
 
-        abc.mkdirs()
-        cache.mkdirs()
-
-        test(dir, s"""
+    test(dir, s"""
 (:name "project"
  :scala-version "2.10.4"
  :java-home "$javaHome"
@@ -49,18 +45,45 @@ class EnsimeConfigSpec extends FunSpec with Matchers {
                 :runtime-deps ()
                 :test-deps ())))""", { implicit config =>
 
-          assert(config.name == "project")
-          assert(config.scalaVersion == "2.10.4")
-          val module1 = config.modules("module1")
-          assert(module1.name == "module1")
-          assert(module1.dependencies.isEmpty)
-          assert(!config.sourceMode)
-          assert(config.debugVMArgs === List("-Dthis=that"))
-        })
-      }
-    }
+      config.name shouldBe "project"
+      config.scalaVersion shouldBe "2.10.4"
+      val module1 = config.modules("module1")
+      module1.name shouldBe "module1"
+      module1.dependencies shouldBe empty
+      config.sourceMode shouldBe false
+      config.debugVMArgs shouldBe List("-Dthis=that")
+    })
+  }
 
-    it("should parse a minimal config for a binary only project") {
+  it should "parse a minimal config for a binary only project" in withTempDir { dir =>
+    val abc = dir / "abc"
+    val cache = dir / ".ensime_cache"
+    val javaHome = File(Properties.javaHome)
+
+    abc.mkdirs()
+    cache.mkdirs()
+
+    test(dir, s"""
+(:name "project"
+ :scala-version "2.10.4"
+ :java-home "$javaHome"
+ :root-dir "$dir"
+ :cache-dir "$cache"
+ :subprojects ((:name "module1"
+                :scala-version "2.10.4"
+                :targets ("$abc"))))""", { implicit config =>
+
+      config.name shouldBe "project"
+      config.scalaVersion shouldBe "2.10.4"
+      val module1 = config.modules("module1")
+      module1.name shouldBe "module1"
+      module1.dependencies shouldBe empty
+      module1.targetDirs should have size 1
+    })
+  }
+
+  it should "base class paths on source-mode value" in {
+    List(true, false) foreach { (sourceMode: Boolean) =>
       withTempDir { dir =>
         val abc = dir / "abc"
         val cache = dir / ".ensime_cache"
@@ -75,47 +98,16 @@ class EnsimeConfigSpec extends FunSpec with Matchers {
  :java-home "$javaHome"
  :root-dir "$dir"
  :cache-dir "$cache"
- :subprojects ((:name "module1"
-                :scala-version "2.10.4"
-                :targets ("$abc"))))""", { implicit config =>
-
-          assert(config.name == "project")
-          assert(config.scalaVersion == "2.10.4")
-          val module1 = config.modules("module1")
-          assert(module1.name == "module1")
-          assert(module1.dependencies.isEmpty)
-          assert(module1.targetDirs.size === 1)
-        })
-      }
-    }
-
-    it("should base class paths on source-mode value") {
-      List(true, false) foreach { (sourceMode: Boolean) =>
-        withTempDir { dir =>
-          val abc = dir / "abc"
-          val cache = dir / ".ensime_cache"
-          val javaHome = File(Properties.javaHome)
-
-          abc.mkdirs()
-          cache.mkdirs()
-
-          test(dir, s"""
-(:name "project"
- :scala-version "2.10.4"
- :java-home "$javaHome"
- :root-dir "$dir"
- :cache-dir "$cache"
  :source-mode ${if (sourceMode) "t" else "nil"}
  :subprojects ((:name "module1"
                 :scala-version "2.10.4"
                 :targets ("$abc"))))""", { implicit config =>
-            assert(config.sourceMode == sourceMode)
-            assert(config.runtimeClasspath == Set(abc), config)
-            assert(config.compileClasspath == (
-              if (sourceMode) Set.empty else Set(abc)
-            ))
-          })
-        }
+          config.sourceMode shouldBe sourceMode
+          config.runtimeClasspath shouldBe Set(abc)
+          config.compileClasspath shouldBe (
+            if (sourceMode) Set.empty else Set(abc)
+          )
+        })
       }
     }
   }

--- a/core/src/test/scala/org/ensime/config/ScalariformFormatSpec.scala
+++ b/core/src/test/scala/org/ensime/config/ScalariformFormatSpec.scala
@@ -2,14 +2,13 @@
 // Licence: http://www.gnu.org/licenses/gpl-3.0.en.html
 package org.ensime.config
 
-import org.scalatest._
-
 import org.ensime.sexp._
 import org.ensime.sexp.formats._
+import org.ensime.util.EnsimeSpec
 
 import scalariform.formatter.preferences._
 
-class ScalariformFormatSpec extends FlatSpec {
+class ScalariformFormatSpec extends EnsimeSpec {
 
   object ScalariformProtocol extends DefaultSexpProtocol with ScalariformFormat
   import ScalariformProtocol._
@@ -22,11 +21,11 @@ class ScalariformFormatSpec extends FlatSpec {
     val text = """(:doubleIndentClassDeclaration t
                      :indentSpaces 13)"""
     val recover = text.parseSexp.convertTo[FormattingPreferences]
-    assert(recover.preferencesMap == prefs.preferencesMap)
+    recover.preferencesMap shouldBe prefs.preferencesMap
   }
 
   it should "create valid output" in {
-    assert(prefs.toSexp === SexpList(
+    prefs.toSexp should ===(SexpList(
       SexpSymbol(":doubleIndentClassDeclaration"), SexpSymbol("t"),
       SexpSymbol(":indentSpaces"), SexpNumber(13)
     ))

--- a/core/src/test/scala/org/ensime/core/BroadcasterSpec.scala
+++ b/core/src/test/scala/org/ensime/core/BroadcasterSpec.scala
@@ -4,13 +4,17 @@ package org.ensime.core
 
 import akka.testkit._
 import scala.concurrent.duration._
+import org.ensime.fixture.SharedTestKitFixture
+import org.ensime.fixture.TestKitFix
+import org.ensime.util.EnsimeSpec
 
-class BroadcasterSpec extends AkkaFlatSpec {
+class BroadcasterSpec extends EnsimeSpec with SharedTestKitFixture {
   import Broadcaster._
 
   val ping = "ping"
 
-  "Broadcaster" should "send messages to subscribers" in {
+  "Broadcaster" should "send messages to subscribers" in withTestKit { fix =>
+    import fix._
     val broadcaster = TestActorRef[Broadcaster]
     val sub1 = TestProbe()
     val sub2 = TestProbe()
@@ -26,7 +30,8 @@ class BroadcasterSpec extends AkkaFlatSpec {
     sub2.lastSender shouldBe self
   }
 
-  it should "not send messages after unregister" in {
+  it should "not send messages after unregister" in withTestKit { fix =>
+    import fix._
     val broadcaster = TestActorRef[Broadcaster]
     val sub1 = TestProbe()
     val sub2 = TestProbe()
@@ -39,7 +44,8 @@ class BroadcasterSpec extends AkkaFlatSpec {
     sub1.expectNoMsg(3 seconds)
   }
 
-  it should "send persistent messages on registration" in {
+  it should "send persistent messages on registration" in withTestKit { fix =>
+    import fix._
     val broadcaster = TestActorRef[Broadcaster]
     val sub1 = TestProbe()
 

--- a/core/src/test/scala/org/ensime/core/CanonSpec.scala
+++ b/core/src/test/scala/org/ensime/core/CanonSpec.scala
@@ -3,14 +3,13 @@
 package org.ensime.core
 
 import java.io.File
-import org.scalatest._
 import org.ensime.util.file._
-
+import org.ensime.util.EnsimeSpec
 import org.ensime.api._
 
 // this test is mostly showing what Canon can do, we're testing
 // shapeless more than our specific Poly1.
-class CanonSpec extends FlatSpec with Matchers {
+class CanonSpec extends EnsimeSpec {
 
   val file = new File(".")
   val canon = file.canon

--- a/core/src/test/scala/org/ensime/indexer/ClassNameSpec.scala
+++ b/core/src/test/scala/org/ensime/indexer/ClassNameSpec.scala
@@ -2,20 +2,18 @@
 // Licence: http://www.gnu.org/licenses/gpl-3.0.en.html
 package org.ensime.indexer
 
-import org.scalatest._
+import org.ensime.util.EnsimeSpec
 
-class ClassNameSpec extends WordSpec with Matchers {
-  "ClassName" should {
-    "remove \"package\" from FQNs" in {
-      ClassName(PackageName(List("org", "example")), s"package$$Class").fqnString shouldBe "org.example.Class"
-      ClassName(PackageName(List("org", "example")), "package$Class$Subclass").fqnString shouldBe "org.example.Class$Subclass"
-      ClassName(PackageName(List("org", "example", "package")), "Class").fqnString shouldBe "org.example.Class"
-      ClassName(PackageName(List("org", "example", "package$")), "Class").fqnString shouldBe "org.example.Class"
-    }
+class ClassNameSpec extends EnsimeSpec {
+  "ClassName" should "remove \"package\" from FQNs" in {
+    ClassName(PackageName(List("org", "example")), s"package$$Class").fqnString shouldBe "org.example.Class"
+    ClassName(PackageName(List("org", "example")), "package$Class$Subclass").fqnString shouldBe "org.example.Class$Subclass"
+    ClassName(PackageName(List("org", "example", "package")), "Class").fqnString shouldBe "org.example.Class"
+    ClassName(PackageName(List("org", "example", "package$")), "Class").fqnString shouldBe "org.example.Class"
+  }
 
-    "preserve the FQN of package objects" in {
-      ClassName(PackageName(List("org.example")), "package").fqnString shouldBe "org.example.package$"
-      ClassName(PackageName(List("org.example")), "package$").fqnString shouldBe "org.example.package$"
-    }
+  it should "preserve the FQN of package objects" in {
+    ClassName(PackageName(List("org.example")), "package").fqnString shouldBe "org.example.package$"
+    ClassName(PackageName(List("org.example")), "package$").fqnString shouldBe "org.example.package$"
   }
 }

--- a/core/src/test/scala/org/ensime/indexer/ClassfileDepicklerSpec.scala
+++ b/core/src/test/scala/org/ensime/indexer/ClassfileDepicklerSpec.scala
@@ -2,10 +2,11 @@
 // Licence: http://www.gnu.org/licenses/gpl-3.0.en.html
 package org.ensime.indexer
 
-import org.scalatest.{ BeforeAndAfterAll, FunSpec, Matchers }
+import org.scalatest.BeforeAndAfterAll
+import org.ensime.util.EnsimeSpec
 import org.ensime.vfs._
 
-class ClassfileDepicklerSpec extends FunSpec with Matchers with BeforeAndAfterAll {
+class ClassfileDepicklerSpec extends EnsimeSpec with BeforeAndAfterAll {
 
   var vfs: EnsimeVFS = _
 
@@ -17,27 +18,25 @@ class ClassfileDepicklerSpec extends FunSpec with Matchers with BeforeAndAfterAl
     vfs.close()
   }
 
-  describe("ClassfileDepickler") {
-    it("don't depickle J2SE classes") {
-      assert(new ClassfileDepickler(vfs.vres("java/lang/String.class")).scalasig === None)
-    }
+  "ClassfileDepickler" should "not depickle J2SE classes" in {
+    new ClassfileDepickler(vfs.vres("java/lang/String.class")).scalasig should ===(None)
+  }
 
-    it("support typical Scala classes") {
-      assert(new ClassfileDepickler(vfs.vres("scala/collection/immutable/List.class")).scalasig.nonEmpty)
-    }
+  it should "support typical Scala classes" in {
+    new ClassfileDepickler(vfs.vres("scala/collection/immutable/List.class")).scalasig shouldBe defined
+  }
 
-    it("don't expect anything in companions") {
-      assert(new ClassfileDepickler(vfs.vres("scala/collection/immutable/List$.class")).scalasig === None)
-    }
+  it should "not expect anything in companions" in {
+    new ClassfileDepickler(vfs.vres("scala/collection/immutable/List$.class")).scalasig should ===(None)
+  }
 
-    it("don't expect anything in closures") {
-      assert(new ClassfileDepickler(vfs.vres("scala/io/Source$$anonfun$1.class")).scalasig === None)
-    }
+  it should "not expect anything in closures" in {
+    new ClassfileDepickler(vfs.vres("scala/io/Source$$anonfun$1.class")).scalasig should ===(None)
+  }
 
-    it("can find type aliases") {
-      assert(new ClassfileDepickler(vfs.vres("scala/Predef.class")).getTypeAliases.contains(
-        RawType(s"scala.Predef$$String", Public)
-      ))
-    }
+  it should "find type aliases" in {
+    new ClassfileDepickler(vfs.vres("scala/Predef.class")).getTypeAliases should contain(
+      RawType(s"scala.Predef$$String", Public)
+    )
   }
 }

--- a/core/src/test/scala/org/ensime/indexer/MethodNameSpec.scala
+++ b/core/src/test/scala/org/ensime/indexer/MethodNameSpec.scala
@@ -2,13 +2,11 @@
 // Licence: http://www.gnu.org/licenses/gpl-3.0.en.html
 package org.ensime.indexer
 
-import org.scalatest._
+import org.ensime.util.EnsimeSpec
 
-class MemberNameSpec extends WordSpec with Matchers {
-  "MemberName" should {
-    "remove \"package\" from FQNs" in {
-      MemberName(ClassName(PackageName(List("org", "example")), "package"), "member").fqnString shouldBe "org.example.member"
-      MemberName(ClassName(PackageName(List("org", "example")), "package$"), "member").fqnString shouldBe "org.example.member"
-    }
+class MemberNameSpec extends EnsimeSpec {
+  "MemberName" should "remove \"package\" from FQNs" in {
+    MemberName(ClassName(PackageName(List("org", "example")), "package"), "member").fqnString shouldBe "org.example.member"
+    MemberName(ClassName(PackageName(List("org", "example")), "package$"), "member").fqnString shouldBe "org.example.member"
   }
 }

--- a/core/src/test/scala/org/ensime/indexer/lucene/DynamicSynonymFilterSpec.scala
+++ b/core/src/test/scala/org/ensime/indexer/lucene/DynamicSynonymFilterSpec.scala
@@ -5,12 +5,11 @@ package org.ensime.indexer.lucene
 import java.io.StringReader
 import org.apache.lucene.analysis.core.KeywordTokenizer
 import org.apache.lucene.analysis.tokenattributes.CharTermAttribute
-import org.scalatest.FunSpec
-import org.scalatest.Matchers
+import org.ensime.util.EnsimeSpec
 import DynamicSynonymFilter._
 import scala.collection.mutable
 
-class DynamicSynonymFilterSpec extends FunSpec with Matchers {
+class DynamicSynonymFilterSpec extends EnsimeSpec {
 
   val cleese = Set(
     "resting", "stunned", "deceased", "passed on",
@@ -41,15 +40,13 @@ class DynamicSynonymFilterSpec extends FunSpec with Matchers {
     words.toList.sorted
   }
 
-  describe("DynamicSynonymFilter") {
-    it("should not add synonyms where there are none") {
-      val term = "Norwegian Blue"
-      assert(applyEngineToTerm(term, engine) === List(term))
-    }
+  "DynamicSynonymFilter" should "not add synonyms where there are none" in {
+    val term = "Norwegian Blue"
+    applyEngineToTerm(term, engine) should ===(List(term))
+  }
 
-    it("should report known synonyms") {
-      val term = "dead"
-      assert(applyEngineToTerm(term, engine) === (cleese + term).toList.sorted)
-    }
+  it should "report known synonyms" in {
+    val term = "dead"
+    applyEngineToTerm(term, engine) should ===((cleese + term).toList.sorted)
   }
 }

--- a/core/src/test/scala/org/ensime/indexer/lucene/LuceneSerializationSpec.scala
+++ b/core/src/test/scala/org/ensime/indexer/lucene/LuceneSerializationSpec.scala
@@ -4,14 +4,14 @@ package org.ensime.indexer.lucene
 
 import org.apache.lucene.document.Field._
 import org.apache.lucene.document._
-import org.scalatest.{ FunSpec, Matchers }
+import org.ensime.util.EnsimeSpec
 
-class LuceneSerializationSpec extends FunSpec with Matchers {
+class LuceneSerializationSpec extends EnsimeSpec {
 
   def thereAndBackAgain[T](t: T)(implicit p: DocumentProvider[T], r: DocumentRecovery[T]): Unit = {
     val doc = p.toDocument(t)
     val back = r.toEntity(doc)
-    assert(t === back)
+    t should ===(back)
   }
 
   case class SimpleThing(id: String, b: String) extends Entity
@@ -22,11 +22,9 @@ class LuceneSerializationSpec extends FunSpec with Matchers {
       SimpleThing(doc.get("ID"), doc.get("b"))
   }
 
-  describe("Lucene Entity Serialisation") {
-    it("should serialise and deserialise a simple type") {
-      val t = SimpleThing("hello", "world")
-      thereAndBackAgain(t)
-    }
+  "Lucene Entity Serialisation" should "serialise and deserialise a simple type" in {
+    val t = SimpleThing("hello", "world")
+    thereAndBackAgain(t)
   }
 
 }

--- a/project/EnsimeBuild.scala
+++ b/project/EnsimeBuild.scala
@@ -199,7 +199,8 @@ object EnsimeBuild extends Build {
   )
 
   lazy val s_express = Project("s-express", file("s-express")) settings(commonSettings) dependsOn (
-    util
+    util,
+    testutil % "test"
   ) settings (
       libraryDependencies ++= Seq(
         "org.parboiled" %% "parboiled" % "2.1.0" intransitive() exclude("com.chuusai", "shapeless_2.10.4"),

--- a/protocol-jerky/src/test/scala/org/ensime/jerk/JerkFormatsSpec.scala
+++ b/protocol-jerky/src/test/scala/org/ensime/jerk/JerkFormatsSpec.scala
@@ -2,12 +2,10 @@
 // Licence: http://www.gnu.org/licenses/gpl-3.0.en.html
 package org.ensime.jerk
 
-import org.scalatest._
 import org.ensime.api._
-import org.ensime.util.EscapingStringInterpolation
+import org.ensime.util.{ EnsimeSpec, EscapingStringInterpolation }
 
-class JerkFormatsSpec extends FlatSpec with Matchers
-    with SprayJsonTestSupport with EnsimeTestData {
+class JerkFormatsSpec extends EnsimeSpec with SprayJsonTestSupport with EnsimeTestData {
 
   import JerkFormats._
   import JerkEnvelopeFormats._

--- a/protocol-swanky/src/test/scala/org/ensime/server/protocol/swank/FormatSpec.scala
+++ b/protocol-swanky/src/test/scala/org/ensime/server/protocol/swank/FormatSpec.scala
@@ -2,13 +2,13 @@
 // Licence: http://www.gnu.org/licenses/gpl-3.0.en.html
 package org.ensime.server.protocol.swank
 
-import org.scalatest.FunSpec
 import org.ensime.sexp._
+import org.ensime.util.EnsimeSpec
 
 // copied from S-Express to avoid a dependency on sexp:test
-trait FormatSpec extends FunSpec {
+trait FormatSpec extends EnsimeSpec {
   def assertFormat[T: SexpFormat](start: T, expect: Sexp): Unit = {
-    assert(start.toSexp === expect)
-    assert(expect.convertTo[T] === start)
+    start.toSexp should ===(expect)
+    expect.convertTo[T] should ===(start)
   }
 }

--- a/protocol-swanky/src/test/scala/org/ensime/server/protocol/swank/SwankFormatsSpec.scala
+++ b/protocol-swanky/src/test/scala/org/ensime/server/protocol/swank/SwankFormatsSpec.scala
@@ -3,13 +3,12 @@
 package org.ensime.server.protocol.swank
 
 import java.io.File
-import org.scalatest._
 
 import org.ensime.sexp._
 import org.ensime.api._
-import org.ensime.util.EscapingStringInterpolation
+import org.ensime.util.{ EnsimeSpec, EscapingStringInterpolation }
 
-class SwankFormatsSpec extends FlatSpec with Matchers with EnsimeTestData {
+class SwankFormatsSpec extends EnsimeSpec with EnsimeTestData {
   import SwankFormats._
   import SwankTestData._
 

--- a/s-express/src/test/scala/org/ensime/sexp/SexpCompactPrinterSpec.scala
+++ b/s-express/src/test/scala/org/ensime/sexp/SexpCompactPrinterSpec.scala
@@ -2,38 +2,36 @@
 // Licence: http://www.gnu.org/licenses/gpl-3.0.en.html
 package org.ensime.sexp
 
-import org.scalatest.FunSpec
+import org.ensime.util.EnsimeSpec
 
-class SexpCompactPrinterSpec extends FunSpec {
+class SexpCompactPrinterSpec extends EnsimeSpec {
 
   private val foo = SexpString("foo")
   private val foosym = SexpSymbol("foo")
   private val barsym = SexpSymbol("bar")
   private def assertPrinter(sexp: Sexp, expect: String): Unit = {
-    assert(SexpCompactPrinter(sexp) === expect)
+    SexpCompactPrinter(sexp) should ===(expect)
   }
 
-  describe("CompactPrinter") {
-    it("should handle nil or empty lists/data") {
-      assertPrinter(SexpNil, "nil")
-      assertPrinter(SexpList(Nil), "nil")
-    }
-
-    it("should output lists of atoms") {
-      assertPrinter(SexpList(foo, SexpNumber(13), foosym), """("foo" 13 foo)""")
-    }
-
-    it("should output lists of lists") {
-      assertPrinter(SexpList(SexpList(foo), SexpList(foo)), """(("foo") ("foo"))""")
-    }
-
-    it("should output cons") {
-      assertPrinter(SexpCons(foosym, barsym), "(foo . bar)")
-    }
-
-    it("should output escaped characters") {
-      assertPrinter(SexpString("""C:\my\folder"""), """"C:\\my\\folder"""")
-    }
-
+  "CompactPrinter" should "handle nil or empty lists/data" in {
+    assertPrinter(SexpNil, "nil")
+    assertPrinter(SexpList(Nil), "nil")
   }
+
+  it should "output lists of atoms" in {
+    assertPrinter(SexpList(foo, SexpNumber(13), foosym), """("foo" 13 foo)""")
+  }
+
+  it should "output lists of lists" in {
+    assertPrinter(SexpList(SexpList(foo), SexpList(foo)), """(("foo") ("foo"))""")
+  }
+
+  it should "output cons" in {
+    assertPrinter(SexpCons(foosym, barsym), "(foo . bar)")
+  }
+
+  it should "output escaped characters" in {
+    assertPrinter(SexpString("""C:\my\folder"""), """"C:\\my\\folder"""")
+  }
+
 }

--- a/s-express/src/test/scala/org/ensime/sexp/SexpParserCheck.scala
+++ b/s-express/src/test/scala/org/ensime/sexp/SexpParserCheck.scala
@@ -4,16 +4,16 @@ package org.ensime.sexp
 
 import org.scalacheck.Arbitrary
 import org.scalacheck.Gen
-import org.scalatest.FunSpec
 import org.scalatest.prop.GeneratorDrivenPropertyChecks
+import org.ensime.util.EnsimeSpec
 
-class SexpParserCheck extends FunSpec
+class SexpParserCheck extends EnsimeSpec
     with GeneratorDrivenPropertyChecks
     with ArbitrarySexp {
 
   import SexpParser.parse
 
-  it("should round-trip Sexp <=> String") {
+  "SexpParser" should "round-trip Sexp <=> String" in {
     forAll { (sexp: Sexp) =>
       val compact = SexpCompactPrinter(sexp)
       //println(compact)
@@ -21,8 +21,8 @@ class SexpParserCheck extends FunSpec
       // it might be worthwhile creating a test-only printer that adds
       // superfluous whitespace/comments
 
-      assert(parse(compact) === sexp, compact)
-      assert(parse(pretty) === sexp, pretty)
+      withClue(compact)(parse(compact) should ===(sexp))
+      withClue(pretty)(parse(pretty) should ===(sexp))
     }
   }
 }

--- a/s-express/src/test/scala/org/ensime/sexp/SexpParserSpec.scala
+++ b/s-express/src/test/scala/org/ensime/sexp/SexpParserSpec.scala
@@ -2,9 +2,9 @@
 // Licence: http://www.gnu.org/licenses/gpl-3.0.en.html
 package org.ensime.sexp
 
-import org.scalatest._
+import org.ensime.util.EnsimeSpec
 
-class SexpParserSpec extends WordSpec with Matchers {
+class SexpParserSpec extends EnsimeSpec {
   import SexpParser.parse
 
   val foo = SexpString("foo")
@@ -18,81 +18,77 @@ class SexpParserSpec extends WordSpec with Matchers {
   val fookey = SexpSymbol(":foo")
   val barkey = SexpSymbol(":bar")
 
-  "EnrichedString" should {
-    "use the parser" in {
-      "nil".parseSexp shouldBe SexpNil
-    }
+  "EnrichedString" should "use the parser" in {
+    "nil".parseSexp shouldBe SexpNil
   }
 
-  "Sexp Parser" should {
-    "parse nil" in {
-      parse("nil") shouldBe SexpNil
-      parse("()") shouldBe SexpNil
-      parse("( )") shouldBe SexpNil
-      parse("(;blah\n)") shouldBe SexpNil
-    }
+  "Sexp Parser" should "parse nil" in {
+    parse("nil") shouldBe SexpNil
+    parse("()") shouldBe SexpNil
+    parse("( )") shouldBe SexpNil
+    parse("(;blah\n)") shouldBe SexpNil
+  }
 
-    "parse lists of strings" in {
-      parse("""("foo" "bar")""") shouldBe SexpList(foo, bar)
-    }
+  it should "parse lists of strings" in {
+    parse("""("foo" "bar")""") shouldBe SexpList(foo, bar)
+  }
 
-    "parse escaped chars in strings" in {
-      parse(""""z \\ \" \t \\t \\\t x\ x"""") shouldBe SexpString("z \\ \" \t \\t \\\t xx")
+  it should "parse escaped chars in strings" in {
+    parse(""""z \\ \" \t \\t \\\t x\ x"""") shouldBe SexpString("z \\ \" \t \\t \\\t xx")
 
-      parse(""""import foo\n\n\nexport bar\n"""") shouldBe SexpString("import foo\n\n\nexport bar\n")
+    parse(""""import foo\n\n\nexport bar\n"""") shouldBe SexpString("import foo\n\n\nexport bar\n")
 
-      parse(""""C:\\my\\folder"""") shouldBe SexpString("""C:\my\folder""")
-    }
+    parse(""""C:\\my\\folder"""") shouldBe SexpString("""C:\my\folder""")
+  }
 
-    "parse unescaped chars in strings" in {
-      parse("\"import foo\n\n\nexport bar\n\"") shouldBe SexpString("import foo\n\n\nexport bar\n")
-    }
+  it should "parse unescaped chars in strings" in {
+    parse("\"import foo\n\n\nexport bar\n\"") shouldBe SexpString("import foo\n\n\nexport bar\n")
+  }
 
-    "parse lists of chars" in {
-      parse("""(?f ?b)""") shouldBe SexpList(SexpChar('f'), SexpChar('b'))
-    }
+  it should "parse lists of chars" in {
+    parse("""(?f ?b)""") shouldBe SexpList(SexpChar('f'), SexpChar('b'))
+  }
 
-    "parse lists of symbols" in {
-      parse("(foo bar is?)") shouldBe SexpList(foosym, barsym, SexpSymbol("is?"))
-    }
+  it should "parse lists of symbols" in {
+    parse("(foo bar is?)") shouldBe SexpList(foosym, barsym, SexpSymbol("is?"))
+  }
 
-    "parse lists of numbers" in {
-      parse("(1 -2 3.14 4e+16)") shouldBe SexpList(one, negtwo, pi, fourexp)
-    }
+  it should "parse lists of numbers" in {
+    parse("(1 -2 3.14 4e+16)") shouldBe SexpList(one, negtwo, pi, fourexp)
+  }
 
-    "parse NaN" in {
-      parse("0.0e+NaN") shouldBe SexpNaN
-      parse("-0.0e+NaN") shouldBe SexpNaN
-    }
+  it should "parse NaN" in {
+    parse("0.0e+NaN") shouldBe SexpNaN
+    parse("-0.0e+NaN") shouldBe SexpNaN
+  }
 
-    "parse infinity" in {
-      parse("1.0e+INF") shouldBe SexpPosInf
-      parse("-1.0e+INF") shouldBe SexpNegInf
-    }
+  it should "parse infinity" in {
+    parse("1.0e+INF") shouldBe SexpPosInf
+    parse("-1.0e+INF") shouldBe SexpNegInf
+  }
 
-    "parse lists within lists" in {
-      parse("""((foo))""") shouldBe SexpList(SexpList(foosym))
-      parse("""((foo) foo)""") shouldBe SexpList(SexpList(foosym), foosym)
-    }
+  it should "parse lists within lists" in {
+    parse("""((foo))""") shouldBe SexpList(SexpList(foosym))
+    parse("""((foo) foo)""") shouldBe SexpList(SexpList(foosym), foosym)
+  }
 
-    "parse quoted expressions" in {
-      parse("""'(:foo "foo" :bar "bar")""") shouldBe
-        SexpCons(SexpSymbol("quote"), SexpList(fookey, foo, barkey, bar))
+  it should "parse quoted expressions" in {
+    parse("""'(:foo "foo" :bar "bar")""") shouldBe
+      SexpCons(SexpSymbol("quote"), SexpList(fookey, foo, barkey, bar))
 
-      parse("'foo") shouldBe SexpCons(SexpSymbol("quote"), foosym)
-    }
+    parse("'foo") shouldBe SexpCons(SexpSymbol("quote"), foosym)
+  }
 
-    "parse cons" in {
-      parse("(foo . bar)") shouldBe SexpCons(foosym, barsym)
-    }
+  it should "parse cons" in {
+    parse("(foo . bar)") shouldBe SexpCons(foosym, barsym)
+  }
 
-    "parse symbols with dots in their name" in {
-      parse("foo.bar") shouldBe SexpSymbol("foo.bar")
-      parse(":foo.bar") shouldBe SexpSymbol(":foo.bar")
-    }
+  it should "parse symbols with dots in their name" in {
+    parse("foo.bar") shouldBe SexpSymbol("foo.bar")
+    parse(":foo.bar") shouldBe SexpSymbol(":foo.bar")
+  }
 
-    "parse symbols starting with nil in their name" in {
-      parse("nilsamisanidiot") shouldBe SexpSymbol("nilsamisanidiot")
-    }
+  it should "parse symbols starting with nil in their name" in {
+    parse("nilsamisanidiot") shouldBe SexpSymbol("nilsamisanidiot")
   }
 }

--- a/s-express/src/test/scala/org/ensime/sexp/SexpPrettyPrinterSpec.scala
+++ b/s-express/src/test/scala/org/ensime/sexp/SexpPrettyPrinterSpec.scala
@@ -2,9 +2,9 @@
 // Licence: http://www.gnu.org/licenses/gpl-3.0.en.html
 package org.ensime.sexp
 
-import org.scalatest.FunSpec
+import org.ensime.util.EnsimeSpec
 
-class SexpPrettyPrinterSpec extends FunSpec {
+class SexpPrettyPrinterSpec extends EnsimeSpec {
 
   private val foo = SexpString("foo")
   private val foosym = SexpSymbol("foo")
@@ -14,46 +14,45 @@ class SexpPrettyPrinterSpec extends FunSpec {
   private def assertPrinter(sexp: Sexp, expect: String): Unit = {
     //    println("GOT\n" + SexpPrettyPrinter(sexp))
     //    println("EXPECT\n" + expect)
-    assert(SexpPrettyPrinter(sexp) === expect.replace("\r", ""))
+    SexpPrettyPrinter(sexp) should ===(expect.replace("\r", ""))
   }
 
-  describe("CompactPrinter") {
-    it("should handle nil or empty lists/data") {
-      assertPrinter(SexpNil, "nil")
-      assertPrinter(SexpList(Nil), "nil")
-    }
+  "CompactPrinter" should "handle nil or empty lists/data" in {
+    assertPrinter(SexpNil, "nil")
+    assertPrinter(SexpList(Nil), "nil")
+  }
 
-    it("should output lists of atoms") {
-      assertPrinter(
-        SexpList(foo, SexpNumber(13), foosym),
-        """("foo"
+  it should "output lists of atoms" in {
+    assertPrinter(
+      SexpList(foo, SexpNumber(13), foosym),
+      """("foo"
           |  13
           |  foo)""".stripMargin
-      )
-    }
+    )
+  }
 
-    it("should output lists of lists") {
-      assertPrinter(
-        SexpList(SexpList(foo), SexpList(foo)),
-        """(("foo")
+  it should "output lists of lists" in {
+    assertPrinter(
+      SexpList(SexpList(foo), SexpList(foo)),
+      """(("foo")
           |  ("foo"))""".stripMargin
-      )
-    }
+    )
+  }
 
-    it("should output data") {
-      assertPrinter(
-        SexpData(fookey -> foosym, barkey -> foosym),
-        """(
+  it should "output data" in {
+    assertPrinter(
+      SexpData(fookey -> foosym, barkey -> foosym),
+      """(
   :foo foo
   :bar foo
 )"""
-      )
+    )
 
-      val datum = SexpData(fookey -> foo, barkey -> foo)
-      assertPrinter(SexpData(
-        fookey -> datum,
-        barkey -> datum
-      ), """(
+    val datum = SexpData(fookey -> foo, barkey -> foo)
+    assertPrinter(SexpData(
+      fookey -> datum,
+      barkey -> datum
+    ), """(
   :foo (
     :foo "foo"
     :bar "foo"
@@ -63,11 +62,11 @@ class SexpPrettyPrinterSpec extends FunSpec {
     :bar "foo"
   )
 )""")
-    }
-
-    it("should output cons") {
-      assertPrinter(SexpCons(foosym, barsym), "(foo .\n  bar)")
-    }
-
   }
+
+  it should "output cons" in {
+    assertPrinter(SexpCons(foosym, barsym), "(foo .\n  bar)")
+  }
+
 }
+

--- a/s-express/src/test/scala/org/ensime/sexp/SexpSpec.scala
+++ b/s-express/src/test/scala/org/ensime/sexp/SexpSpec.scala
@@ -2,9 +2,9 @@
 // Licence: http://www.gnu.org/licenses/gpl-3.0.en.html
 package org.ensime.sexp
 
-import org.scalatest._
+import org.ensime.util.EnsimeSpec
 
-class SexpSpec extends FunSpec with Matchers {
+class SexpSpec extends EnsimeSpec {
 
   val foostring = SexpString("foo")
   val barstring = SexpString("bar")
@@ -13,65 +13,48 @@ class SexpSpec extends FunSpec with Matchers {
   val fookey = SexpSymbol(":foo")
   val barkey = SexpSymbol(":bar")
 
-  describe("SexpList") {
-    it("should create from varargs") {
-      assert(SexpList(foosym, barsym) === SexpList(List(foosym, barsym)))
+  "SexpList" should "create from varargs" in {
+    SexpList(foosym, barsym) should ===(SexpList(List(foosym, barsym)))
+  }
+
+  it should "unroll as basic" in {
+    SexpList(Nil) should ===(SexpNil)
+
+    SexpList(foosym) should ===(SexpCons(foosym, SexpNil))
+
+    SexpList(foosym, barsym) === (SexpCons(foosym, SexpCons(barsym, SexpNil)))
+  }
+
+  it should "match lists" in {
+    SexpCons(foosym, SexpNil) match {
+      case SexpList(els) if els == List(foosym) =>
+      case _ => fail()
     }
-
-    it("should unroll as basic") {
-      assert(SexpList(Nil) === SexpNil)
-
-      assert(SexpList(foosym) ===
-        SexpCons(foosym, SexpNil))
-
-      assert(SexpList(foosym, barsym) ===
-        SexpCons(foosym, SexpCons(barsym, SexpNil)))
+    SexpCons(foosym, SexpCons(barsym, SexpNil)) match {
+      case SexpList(els) if els == List(foosym, barsym) =>
+      case _ => fail()
     }
-
-    it("should match lists") {
-      SexpCons(foosym, SexpNil) match {
-        case SexpList(els) if els == List(foosym) =>
-        case _ => fail()
-      }
-      SexpCons(foosym, SexpCons(barsym, SexpNil)) match {
-        case SexpList(els) if els == List(foosym, barsym) =>
-        case _ => fail()
-      }
-      SexpNil match {
-        case SexpList(_) => fail()
-        case _ =>
-      }
+    SexpNil match {
+      case SexpList(_) => fail()
+      case _ =>
     }
   }
 
-  describe("SexpData") {
-    it("should create from varargs") {
-      assert(SexpData(
-        fookey -> barsym,
-        barkey -> foosym
-      ) === SexpList(
-          fookey, barsym,
-          barkey, foosym
-        ))
-    }
+  "SexpData" should "create from varargs" in {
+    SexpData(
+      fookey -> barsym,
+      barkey -> foosym
+    ) should ===(SexpList(
+        fookey, barsym,
+        barkey, foosym
+      ))
+  }
 
-    it("should unroll as basic") {
-      assert(SexpData(
-        fookey -> barsym,
-        barkey -> foosym
-      ) === SexpCons(
-          fookey, SexpCons(
-          barsym, SexpCons(
-          barkey, SexpCons(
-          foosym, SexpNil
-        )
-        )
-        )
-        ))
-    }
-
-    it("should match SexpData") {
-      SexpCons(
+  it should "unroll as basic" in {
+    SexpData(
+      fookey -> barsym,
+      barkey -> foosym
+    ) should ===(SexpCons(
         fookey, SexpCons(
         barsym, SexpCons(
         barkey, SexpCons(
@@ -79,24 +62,35 @@ class SexpSpec extends FunSpec with Matchers {
       )
       )
       )
-      ) match {
-        case SexpData(kvs) if kvs.size == 2 =>
-        case _ => fail()
-      }
+      ))
+  }
 
-      SexpNil match {
-        case SexpData(_) => fail()
-        case _ =>
-      }
+  it should "match SexpData" in {
+    SexpCons(
+      fookey, SexpCons(
+      barsym, SexpCons(
+      barkey, SexpCons(
+      foosym, SexpNil
+    )
+    )
+    )
+    ) match {
+      case SexpData(kvs) if kvs.size == 2 =>
+      case _ => fail()
+    }
+
+    SexpNil match {
+      case SexpData(_) => fail()
+      case _ =>
     }
   }
 
-  describe("SexpCons") {
-    it("should unroll as fully basic") {
-      val a = SexpList(foosym)
-      val b = SexpList(barsym)
-      assert(SexpCons(a, b) ===
-        SexpCons(SexpCons(foosym, SexpNil), SexpCons(barsym, SexpNil)))
-    }
+  "SexpCons" should "unroll as fully basic" in {
+    val a = SexpList(foosym)
+    val b = SexpList(barsym)
+    SexpCons(a, b) should ===(SexpCons(
+      SexpCons(foosym, SexpNil),
+      SexpCons(barsym, SexpNil)
+    ))
   }
 }

--- a/s-express/src/test/scala/org/ensime/sexp/formats/BasicFormatsSpec.scala
+++ b/s-express/src/test/scala/org/ensime/sexp/formats/BasicFormatsSpec.scala
@@ -5,67 +5,65 @@ package org.ensime.sexp.formats
 import org.ensime.sexp._
 
 class BasicFormatsSpec extends FormatSpec with BasicFormats {
-  describe("BasicFormats") {
-    it("should support Int") {
-      assertFormat(13, SexpNumber(13))
-      assertFormat(-1, SexpNumber(-1))
-      assertFormat(0, SexpNumber(0))
-      assertFormat(Int.MaxValue, SexpNumber(Int.MaxValue))
-      assertFormat(Int.MinValue, SexpNumber(Int.MinValue))
-    }
 
-    it("should support Long") {
-      assertFormat(13L, SexpNumber(13))
-      assertFormat(-1L, SexpNumber(-1))
-      assertFormat(0L, SexpNumber(0))
-      assertFormat(Long.MaxValue, SexpNumber(Long.MaxValue))
-      assertFormat(Long.MinValue, SexpNumber(Long.MinValue))
-    }
-
-    it("should support Float") {
-      assertFormat(13.0f, SexpNumber(13.0f))
-      assertFormat(-1.0f, SexpNumber(-1.0f))
-      assertFormat(0.0f, SexpNumber(0.0f))
-      assertFormat(Float.MaxValue, SexpNumber(Float.MaxValue))
-      //assertFormat(Float.MinValue, SexpNumber(Float.MinValue)) // implicit widening?
-      assertFormat(Float.NegativeInfinity, SexpNegInf)
-      assertFormat(Float.PositiveInfinity, SexpPosInf)
-
-      // remember NaN != NaN
-      assert(Float.NaN.toSexp === SexpNaN)
-      assert(SexpNaN.convertTo[Float].isNaN)
-    }
-
-    it("should support Double") {
-      assertFormat(13.0d, SexpNumber(13.0d))
-      assertFormat(-1.0d, SexpNumber(-1.0d))
-      assertFormat(0.0d, SexpNumber(0.0d))
-      assertFormat(Double.MaxValue, SexpNumber(Double.MaxValue))
-      assertFormat(Double.MinValue, SexpNumber(Double.MinValue))
-      assertFormat(Double.NegativeInfinity, SexpNegInf)
-      assertFormat(Double.PositiveInfinity, SexpPosInf)
-
-      // remember NaN != NaN
-      assert(Double.NaN.toSexp === SexpNaN)
-      assert(SexpNaN.convertTo[Double].isNaN)
-    }
-
-    it("should support Boolean") {
-      assertFormat(true, SexpSymbol("t"))
-      assertFormat(false, SexpNil)
-    }
-
-    it("should support Char") {
-      assertFormat('t', SexpChar('t'))
-    }
-
-    it("should support Unit") {
-      assertFormat((), SexpNil)
-    }
-
-    it("should support Symbol") {
-      assertFormat('blah, SexpString("blah"))
-    }
+  "BasicFormats" should "support Int" in {
+    assertFormat(13, SexpNumber(13))
+    assertFormat(-1, SexpNumber(-1))
+    assertFormat(0, SexpNumber(0))
+    assertFormat(Int.MaxValue, SexpNumber(Int.MaxValue))
+    assertFormat(Int.MinValue, SexpNumber(Int.MinValue))
   }
 
+  it should "support Long" in {
+    assertFormat(13L, SexpNumber(13))
+    assertFormat(-1L, SexpNumber(-1))
+    assertFormat(0L, SexpNumber(0))
+    assertFormat(Long.MaxValue, SexpNumber(Long.MaxValue))
+    assertFormat(Long.MinValue, SexpNumber(Long.MinValue))
+  }
+
+  it should "support Float" in {
+    assertFormat(13.0f, SexpNumber(13.0f))
+    assertFormat(-1.0f, SexpNumber(-1.0f))
+    assertFormat(0.0f, SexpNumber(0.0f))
+    assertFormat(Float.MaxValue, SexpNumber(Float.MaxValue))
+    //assertFormat(Float.MinValue, SexpNumber(Float.MinValue)) // implicit widening?
+    assertFormat(Float.NegativeInfinity, SexpNegInf)
+    assertFormat(Float.PositiveInfinity, SexpPosInf)
+
+    // remember NaN != NaN
+    Float.NaN.toSexp should ===(SexpNaN)
+    SexpNaN.convertTo[Float].isNaN shouldBe true
+  }
+
+  it should "support Double" in {
+    assertFormat(13.0d, SexpNumber(13.0d))
+    assertFormat(-1.0d, SexpNumber(-1.0d))
+    assertFormat(0.0d, SexpNumber(0.0d))
+    assertFormat(Double.MaxValue, SexpNumber(Double.MaxValue))
+    assertFormat(Double.MinValue, SexpNumber(Double.MinValue))
+    assertFormat(Double.NegativeInfinity, SexpNegInf)
+    assertFormat(Double.PositiveInfinity, SexpPosInf)
+
+    // remember NaN != NaN
+    Double.NaN.toSexp should ===(SexpNaN)
+    SexpNaN.convertTo[Double].isNaN shouldBe true
+  }
+
+  it should "support Boolean" in {
+    assertFormat(true, SexpSymbol("t"))
+    assertFormat(false, SexpNil)
+  }
+
+  it should "support Char" in {
+    assertFormat('t', SexpChar('t'))
+  }
+
+  it should "support Unit" in {
+    assertFormat((), SexpNil)
+  }
+
+  it should "support Symbol" in {
+    assertFormat('blah, SexpString("blah"))
+  }
 }

--- a/s-express/src/test/scala/org/ensime/sexp/formats/BigIntConvertorSpec.scala
+++ b/s-express/src/test/scala/org/ensime/sexp/formats/BigIntConvertorSpec.scala
@@ -4,11 +4,11 @@ package org.ensime.sexp.formats
 
 import BigIntConvertor._
 import org.scalacheck.{ Arbitrary, Gen }
-import org.scalatest._
 import org.scalatest.prop.GeneratorDrivenPropertyChecks
 import scala.collection.immutable.BitSet
+import org.ensime.util.EnsimeSpec
 
-class BigIntConvertorSpec extends FunSpec {
+class BigIntConvertorSpec extends EnsimeSpec {
   private val examples = List(
     BitSet() -> BigInt(0),
     BitSet(0) -> BigInt(1),
@@ -18,20 +18,20 @@ class BigIntConvertorSpec extends FunSpec {
     BitSet(1, 64) -> BigInt("18446744073709551618")
   )
 
-  it("should convert basic BigSet to BitInt") {
+  "BigIntConvertor" should "convert basic BigSet to BitInt" in {
     examples foreach {
-      case (bitset, bigint) => assert(fromBitSet(bitset) === bigint)
+      case (bitset, bigint) => fromBitSet(bitset) should ===(bigint)
     }
   }
 
-  it("should convert basic BigInt to BitSet") {
+  it should "convert basic BigInt to BitSet" in {
     examples foreach {
-      case (bitset, bigint) => assert(toBitSet(bigint) === bitset)
+      case (bitset, bigint) => toBitSet(bigint) should ===(bitset)
     }
   }
 }
 
-class BigIntConvertorCheck extends FunSpec with GeneratorDrivenPropertyChecks {
+class BigIntConvertorCheck extends EnsimeSpec with GeneratorDrivenPropertyChecks {
 
   def positiveIntStream: Arbitrary[Stream[Int]] = Arbitrary {
     Gen.containerOf[Stream, Int](Gen.chooseNum(0, 2 * Short.MaxValue))
@@ -41,20 +41,20 @@ class BigIntConvertorCheck extends FunSpec with GeneratorDrivenPropertyChecks {
     for (seq <- positiveIntStream.arbitrary) yield BitSet(seq: _*)
   }
 
-  it("should round-trip BigInt <=> BitSet") {
+  "BigIntConvertor" should "round-trip BigInt <=> BitSet" in {
     forAll { (bigint: BigInt) =>
       whenever(bigint >= 0) {
         // the exact rules for which negative numbers are allowed
         // seems to be quite complex, but certainly it is sometimes
         // valid.
-        assert(fromBitSet(toBitSet(bigint)) === bigint)
+        fromBitSet(toBitSet(bigint)) should ===(bigint)
       }
     }
   }
 
-  it("should round-trip BitSet <=> BigInt") {
+  it should "round-trip BitSet <=> BigInt" in {
     forAll { (bitset: BitSet) =>
-      assert(toBitSet(fromBitSet(bitset)) === bitset)
+      toBitSet(fromBitSet(bitset)) should ===(bitset)
     }
   }
 }

--- a/s-express/src/test/scala/org/ensime/sexp/formats/CollectionFormatsSpec.scala
+++ b/s-express/src/test/scala/org/ensime/sexp/formats/CollectionFormatsSpec.scala
@@ -10,173 +10,168 @@ import org.ensime.sexp._
 class CollectionFormatsSpec extends FormatSpec
     with ProductFormats with CollectionFormats with BasicFormats {
 
+  val foo = SexpString("foo")
   val foos: List[String] = List("foo", "foo")
   val expect = SexpList(foo, foo)
 
-  describe("CollectionFormats traits") {
-    it("should support Traversable") {
-      assertFormat(collection.Traversable[String](), SexpNil)
-      assertFormat(collection.Traversable(foos: _*), expect)
-    }
-
-    it("should support Iterable") {
-      assertFormat(collection.Iterable[String](), SexpNil)
-      assertFormat(collection.Iterable(foos: _*), expect)
-    }
-
-    it("should support Seq") {
-      assertFormat(collection.Seq[String](), SexpNil)
-      assertFormat(collection.Seq(foos: _*), expect)
-    }
-
-    it("should support IndexedSeq") {
-      assertFormat(collection.IndexedSeq[String](), SexpNil)
-      assertFormat(collection.IndexedSeq(foos: _*), expect)
-    }
-
-    it("should support LinearSeq") {
-      assertFormat(collection.LinearSeq[String](), SexpNil)
-      assertFormat(collection.LinearSeq(foos: _*), expect)
-    }
-
-    it("should support Set") {
-      assertFormat(collection.Set[String](), SexpNil)
-      assertFormat(collection.Set(foos: _*), SexpList(foo)) // dupes removed
-    }
-
-    it("should support SortedSet") {
-      assertFormat(collection.SortedSet[String](), SexpNil)
-      assertFormat(collection.SortedSet(foos: _*), SexpList(foo)) // dupes removed
-    }
-
-    it("should support BitSet") {
-      assertFormat(collection.BitSet(), SexpNil)
-      assertFormat(collection.BitSet(0, 1), SexpString("16#3"))
-      assertFormat(collection.BitSet(64), SexpString("16#10000000000000000"))
-      assertFormat(collection.BitSet(0, 64), SexpString("16#10000000000000001"))
-      assertFormat(collection.BitSet(1, 64), SexpString("16#10000000000000002"))
-    }
-
-    it("should support Map") {
-      assertFormat(collection.Map[String, String](), SexpNil)
-      assertFormat(collection.Map("foo" -> "foo"), SexpList(SexpList(foo, foo)))
-    }
-
-    it("should support SortedMap") {
-      assertFormat(collection.SortedMap[String, String](), SexpNil)
-      assertFormat(collection.SortedMap("foo" -> "foo"), SexpList(SexpList(foo, foo)))
-    }
+  "CollectionFormats traits" should "support Traversable" in {
+    assertFormat(collection.Traversable[String](), SexpNil)
+    assertFormat(collection.Traversable(foos: _*), expect)
   }
 
-  describe("CollectionFormats immutable variants of the traits") {
-    it("should support Traversable") {
-      assertFormat(im.Traversable[String](), SexpNil)
-      assertFormat(im.Traversable(foos: _*), expect)
-    }
-
-    it("should support Iterable") {
-      assertFormat(im.Iterable[String](), SexpNil)
-      assertFormat(im.Iterable(foos: _*), expect)
-    }
-
-    it("should support Seq") {
-      assertFormat(im.Seq[String](), SexpNil)
-      assertFormat(im.Seq(foos: _*), expect)
-    }
-
-    it("should support IndexedSeq") {
-      assertFormat(im.IndexedSeq[String](), SexpNil)
-      assertFormat(im.IndexedSeq(foos: _*), expect)
-    }
-
-    it("should support LinearSeq") {
-      assertFormat(im.LinearSeq[String](), SexpNil)
-      assertFormat(im.LinearSeq(foos: _*), expect)
-    }
-
-    it("should support Set") {
-      assertFormat(im.Set[String](), SexpNil)
-      assertFormat(im.Set(foos: _*), SexpList(foo)) // dupes removed
-    }
-
-    it("should support SortedSet") {
-      assertFormat(im.SortedSet[String](), SexpNil)
-      assertFormat(im.SortedSet(foos: _*), SexpList(foo)) // dupes removed
-    }
-
-    it("should support BitSet") {
-      assertFormat(im.BitSet(), SexpNil)
-      assertFormat(im.BitSet(0, 1), SexpString("16#3"))
-      assertFormat(collection.BitSet(64), SexpString("16#10000000000000000"))
-      assertFormat(collection.BitSet(0, 64), SexpString("16#10000000000000001"))
-      assertFormat(collection.BitSet(1, 64), SexpString("16#10000000000000002"))
-    }
-
-    it("should support Map") {
-      assertFormat(im.Map[String, String](), SexpNil)
-      assertFormat(im.Map("foo" -> "foo"), SexpList(SexpList(foo, foo)))
-    }
-
-    it("should support SortedMap") {
-      assertFormat(im.SortedMap[String, String](), SexpNil)
-      assertFormat(im.SortedMap("foo" -> "foo"), SexpList(SexpList(foo, foo)))
-    }
+  it should "support Iterable" in {
+    assertFormat(collection.Iterable[String](), SexpNil)
+    assertFormat(collection.Iterable(foos: _*), expect)
   }
 
-  describe("CollectionFormats immutable specific implementations") {
-    it("should support im.List") {
-      assertFormat(im.List[String](), SexpNil)
-      assertFormat(im.List(foos: _*), expect)
-    }
-
-    it("should support im.Vector") {
-      assertFormat(im.Vector[String](), SexpNil)
-      assertFormat(im.Vector(foos: _*), expect)
-    }
-
-    it("should support im.Range") {
-      assertFormat(
-        im.Range(-100, 100),
-        SexpList(
-          SexpSymbol(":start"), SexpNumber(-100),
-          SexpSymbol(":end"), SexpNumber(100),
-          SexpSymbol(":step"), SexpNumber(1)
-        )
-      )
-
-      assertFormat(
-        im.Range(-100, 100, 2),
-        SexpList(
-          SexpSymbol(":start"), SexpNumber(-100),
-          SexpSymbol(":end"), SexpNumber(100),
-          SexpSymbol(":step"), SexpNumber(2)
-        )
-      )
-    }
-
-    it("should support im.NumericRange") {
-      implicit val DoubleIntegral = Numeric.DoubleAsIfIntegral
-
-      assertFormat(
-        -100.0 to 100.0 by 1.5,
-        SexpData(
-          SexpSymbol(":start") -> SexpNumber(-100),
-          SexpSymbol(":end") -> SexpNumber(100),
-          SexpSymbol(":step") -> SexpNumber(1.5),
-          SexpSymbol(":inclusive") -> SexpSymbol("t")
-        )
-      )
-
-      assertFormat(
-        -100.0 until 100.0 by 1.5,
-        SexpData(
-          SexpSymbol(":start") -> SexpNumber(-100),
-          SexpSymbol(":end") -> SexpNumber(100),
-          SexpSymbol(":step") -> SexpNumber(1.5),
-          SexpSymbol(":inclusive") -> SexpNil
-        )
-      )
-    }
-
+  it should "support Seq" in {
+    assertFormat(collection.Seq[String](), SexpNil)
+    assertFormat(collection.Seq(foos: _*), expect)
   }
+
+  it should "support IndexedSeq" in {
+    assertFormat(collection.IndexedSeq[String](), SexpNil)
+    assertFormat(collection.IndexedSeq(foos: _*), expect)
+  }
+
+  it should "support LinearSeq" in {
+    assertFormat(collection.LinearSeq[String](), SexpNil)
+    assertFormat(collection.LinearSeq(foos: _*), expect)
+  }
+
+  it should "support Set" in {
+    assertFormat(collection.Set[String](), SexpNil)
+    assertFormat(collection.Set(foos: _*), SexpList(foo)) // dupes removed
+  }
+
+  it should "support SortedSet" in {
+    assertFormat(collection.SortedSet[String](), SexpNil)
+    assertFormat(collection.SortedSet(foos: _*), SexpList(foo)) // dupes removed
+  }
+
+  it should "support BitSet" in {
+    assertFormat(collection.BitSet(), SexpNil)
+    assertFormat(collection.BitSet(0, 1), SexpString("16#3"))
+    assertFormat(collection.BitSet(64), SexpString("16#10000000000000000"))
+    assertFormat(collection.BitSet(0, 64), SexpString("16#10000000000000001"))
+    assertFormat(collection.BitSet(1, 64), SexpString("16#10000000000000002"))
+  }
+
+  it should "support Map" in {
+    assertFormat(collection.Map[String, String](), SexpNil)
+    assertFormat(collection.Map("foo" -> "foo"), SexpList(SexpList(foo, foo)))
+  }
+
+  it should "support SortedMap" in {
+    assertFormat(collection.SortedMap[String, String](), SexpNil)
+    assertFormat(collection.SortedMap("foo" -> "foo"), SexpList(SexpList(foo, foo)))
+  }
+
+  "CollectionFormats immutable variants of the traits" should "support Traversable" in {
+    assertFormat(im.Traversable[String](), SexpNil)
+    assertFormat(im.Traversable(foos: _*), expect)
+  }
+
+  it should "support Iterable" in {
+    assertFormat(im.Iterable[String](), SexpNil)
+    assertFormat(im.Iterable(foos: _*), expect)
+  }
+
+  it should "support Seq" in {
+    assertFormat(im.Seq[String](), SexpNil)
+    assertFormat(im.Seq(foos: _*), expect)
+  }
+
+  it should "support IndexedSeq" in {
+    assertFormat(im.IndexedSeq[String](), SexpNil)
+    assertFormat(im.IndexedSeq(foos: _*), expect)
+  }
+
+  it should "support LinearSeq" in {
+    assertFormat(im.LinearSeq[String](), SexpNil)
+    assertFormat(im.LinearSeq(foos: _*), expect)
+  }
+
+  it should "support Set" in {
+    assertFormat(im.Set[String](), SexpNil)
+    assertFormat(im.Set(foos: _*), SexpList(foo)) // dupes removed
+  }
+
+  it should "support SortedSet" in {
+    assertFormat(im.SortedSet[String](), SexpNil)
+    assertFormat(im.SortedSet(foos: _*), SexpList(foo)) // dupes removed
+  }
+
+  it should "support BitSet" in {
+    assertFormat(im.BitSet(), SexpNil)
+    assertFormat(im.BitSet(0, 1), SexpString("16#3"))
+    assertFormat(collection.BitSet(64), SexpString("16#10000000000000000"))
+    assertFormat(collection.BitSet(0, 64), SexpString("16#10000000000000001"))
+    assertFormat(collection.BitSet(1, 64), SexpString("16#10000000000000002"))
+  }
+
+  it should "support Map" in {
+    assertFormat(im.Map[String, String](), SexpNil)
+    assertFormat(im.Map("foo" -> "foo"), SexpList(SexpList(foo, foo)))
+  }
+
+  it should "support SortedMap" in {
+    assertFormat(im.SortedMap[String, String](), SexpNil)
+    assertFormat(im.SortedMap("foo" -> "foo"), SexpList(SexpList(foo, foo)))
+  }
+
+  "CollectionFormats immutable specific implementations" should "support im.List" in {
+    assertFormat(im.List[String](), SexpNil)
+    assertFormat(im.List(foos: _*), expect)
+  }
+
+  it should "support im.Vector" in {
+    assertFormat(im.Vector[String](), SexpNil)
+    assertFormat(im.Vector(foos: _*), expect)
+  }
+
+  it should "support im.Range" in {
+    assertFormat(
+      im.Range(-100, 100),
+      SexpList(
+        SexpSymbol(":start"), SexpNumber(-100),
+        SexpSymbol(":end"), SexpNumber(100),
+        SexpSymbol(":step"), SexpNumber(1)
+      )
+    )
+
+    assertFormat(
+      im.Range(-100, 100, 2),
+      SexpList(
+        SexpSymbol(":start"), SexpNumber(-100),
+        SexpSymbol(":end"), SexpNumber(100),
+        SexpSymbol(":step"), SexpNumber(2)
+      )
+    )
+  }
+
+  it should "support im.NumericRange" in {
+    implicit val DoubleIntegral = Numeric.DoubleAsIfIntegral
+
+    assertFormat(
+      -100.0 to 100.0 by 1.5,
+      SexpData(
+        SexpSymbol(":start") -> SexpNumber(-100),
+        SexpSymbol(":end") -> SexpNumber(100),
+        SexpSymbol(":step") -> SexpNumber(1.5),
+        SexpSymbol(":inclusive") -> SexpSymbol("t")
+      )
+    )
+
+    assertFormat(
+      -100.0 until 100.0 by 1.5,
+      SexpData(
+        SexpSymbol(":start") -> SexpNumber(-100),
+        SexpSymbol(":end") -> SexpNumber(100),
+        SexpSymbol(":step") -> SexpNumber(1.5),
+        SexpSymbol(":inclusive") -> SexpNil
+      )
+    )
+  }
+
 }

--- a/s-express/src/test/scala/org/ensime/sexp/formats/DefaultSexpProtocolSpec.scala
+++ b/s-express/src/test/scala/org/ensime/sexp/formats/DefaultSexpProtocolSpec.scala
@@ -8,45 +8,42 @@ import org.ensime.sexp._
 // interactions between the different formats.
 class DefaultSexpProtocolSpec extends FormatSpec {
 
-  describe("DefaultSexpProtocol") {
+  "DefaultSexpProtocol" should "support String as SexpString, not via IsTraversableLike" in {
+    import DefaultSexpProtocol._
+    assertFormat("hello", SexpString("hello"))
+  }
+
+  it should "round-trip Option[List[T]]" in {
     import DefaultSexpProtocol._
 
-    it("should support String as SexpString, not via IsTraversableLike") {
-      assertFormat("hello", SexpString("hello"))
-    }
+    val none: Option[List[String]] = None
+    val empty: Option[List[String]] = Some(Nil)
+    val list: Option[List[String]] = Some(List("boo"))
 
-    it("should round-trip Option[List[T]]") {
-      val none: Option[List[String]] = None
-      val empty: Option[List[String]] = Some(Nil)
-      val list: Option[List[String]] = Some(List("boo"))
-
-      assertFormat(none, SexpNil)
-      assertFormat(empty, SexpList(SexpNil))
-      assertFormat(list, SexpList(SexpList(SexpString("boo"))))
-      assert(SexpNil.convertTo[Option[List[String]]] === None)
-      assert(SexpNil.convertTo[List[Option[String]]] === Nil)
-    }
+    assertFormat(none, SexpNil)
+    assertFormat(empty, SexpList(SexpNil))
+    assertFormat(list, SexpList(SexpList(SexpString("boo"))))
+    SexpNil.convertTo[Option[List[String]]] should ===(None)
+    SexpNil.convertTo[List[Option[String]]] should ===(Nil)
   }
 
-  describe("DefaultSexpProtocol with OptionAltFormat") {
-    object AlternativeProtocol extends DefaultSexpProtocol with OptionAltFormat
+  object AlternativeProtocol extends DefaultSexpProtocol with OptionAltFormat
+
+  "DefaultSexpProtocol with OptionAltFormat" should "predictably fail to round-trip Option[List[T]]" in {
     import AlternativeProtocol._
 
-    it("should predictably fail to round-trip Option[List[T]]") {
+    val none: Option[List[String]] = None
+    val empty: Option[List[String]] = Some(Nil)
+    val list: Option[List[String]] = Some(List("boo"))
 
-      val none: Option[List[String]] = None
-      val empty: Option[List[String]] = Some(Nil)
-      val list: Option[List[String]] = Some(List("boo"))
+    none.toSexp should ===(SexpNil)
+    empty.toSexp should ===(SexpNil)
+    list.toSexp should ===(SexpList(SexpString("boo")))
 
-      assert(none.toSexp === SexpNil)
-      assert(empty.toSexp === SexpNil)
-      assert(list.toSexp === SexpList(SexpString("boo")))
+    SexpNil.convertTo[Option[List[String]]] should ===(None)
 
-      assert(SexpNil.convertTo[Option[List[String]]] === None)
-
-      // and Lists of Options give empty lists, muahahaha
-      assert(SexpNil.convertTo[List[Option[String]]] === Nil)
-    }
-
+    // and Lists of Options give empty lists, muahahaha
+    SexpNil.convertTo[List[Option[String]]] should ===(Nil)
   }
+
 }

--- a/s-express/src/test/scala/org/ensime/sexp/formats/FamilyFormatsSpec.scala
+++ b/s-express/src/test/scala/org/ensime/sexp/formats/FamilyFormatsSpec.scala
@@ -7,109 +7,108 @@ import org.ensime.sexp._
 class FamilyFormatsSpec extends FormatSpec with FamilyFormats {
 
   case object Bloo
-  describe("FamilyFormats") {
-    it("should support case objects") {
-      assertFormat(Bloo, SexpNil)
-    }
 
-    it("should support an example ADT") {
-      import DefaultSexpProtocol._
-      import ExampleAst._
+  "FamilyFormats" should "support case objects" in {
+    assertFormat(Bloo, SexpNil)
+  }
 
-      // performance improvement - avoids creating afresh at each call
-      // site (only possible for the non-recursive classes)
-      // implicit val FieldTermF = SexpFormat[FieldTerm]
-      // implicit val BoundedTermF = SexpFormat[BoundedTerm]
-      // implicit val UnparsedF = SexpFormat[Unparsed]
-      // implicit val IgnoredF = SexpFormat[Ignored]
-      // implicit val UnclearF = SexpFormat[Unclear]
-      // implicit val InTermF = SexpFormat[InTerm]
-      // implicit val LikeTermF = SexpFormat[LikeTerm]
-      // implicit val QualifierTokenF = SexpFormat[QualifierToken]
+  it should "support an example ADT" in {
+    import DefaultSexpProtocol._
+    import ExampleAst._
 
-      /////////////////// START OF BOILERPLATE /////////////////
-      implicit object TokenTreeFormat extends TraitFormat[TokenTree] {
-        // get a performance improvement by creating as many implicit vals
-        // for TypeHint[T] as possible, e.g.
-        // implicit val FieldTermTH = typehint[FieldTerm]
-        // implicit val BoundedTermTH = typehint[BoundedTerm]
-        // implicit val UnparsedTH = typehint[Unparsed]
-        // implicit val IgnoredTH = typehint[Ignored]
-        // implicit val UnclearTH = typehint[Unclear]
-        // implicit val InTermTH = typehint[InTerm]
-        // implicit val LikeTermTH = typehint[LikeTerm]
-        // implicit val OrConditionTH = typehint[OrCondition]
-        // implicit val AndConditionTH = typehint[AndCondition]
-        // implicit val PreferTokenTH = typehint[PreferToken]
-        // implicit val QualifierTokenTH = typehint[QualifierToken]
+    // performance improvement - avoids creating afresh at each call
+    // site (only possible for the non-recursive classes)
+    // implicit val FieldTermF = SexpFormat[FieldTerm]
+    // implicit val BoundedTermF = SexpFormat[BoundedTerm]
+    // implicit val UnparsedF = SexpFormat[Unparsed]
+    // implicit val IgnoredF = SexpFormat[Ignored]
+    // implicit val UnclearF = SexpFormat[Unclear]
+    // implicit val InTermF = SexpFormat[InTerm]
+    // implicit val LikeTermF = SexpFormat[LikeTerm]
+    // implicit val QualifierTokenF = SexpFormat[QualifierToken]
 
-        def write(obj: TokenTree): Sexp = obj match {
-          case f: FieldTerm => wrap(f)
-          case b: BoundedTerm => wrap(b)
-          case u: Unparsed => wrap(u)
-          case i: Ignored => wrap(i)
-          case u: Unclear => wrap(u)
-          case i: InTerm => wrap(i)
-          case like: LikeTerm => wrap(like)
-          case a: AndCondition => wrap(a)
-          case o: OrCondition => wrap(o)
-          case prefer: PreferToken => wrap(prefer)
-          case q: QualifierToken => wrap(q)
-          case SpecialToken => wrap(SpecialToken)
-        }
+    /////////////////// START OF BOILERPLATE /////////////////
+    implicit object TokenTreeFormat extends TraitFormat[TokenTree] {
+      // get a performance improvement by creating as many implicit vals
+      // for TypeHint[T] as possible, e.g.
+      // implicit val FieldTermTH = typehint[FieldTerm]
+      // implicit val BoundedTermTH = typehint[BoundedTerm]
+      // implicit val UnparsedTH = typehint[Unparsed]
+      // implicit val IgnoredTH = typehint[Ignored]
+      // implicit val UnclearTH = typehint[Unclear]
+      // implicit val InTermTH = typehint[InTerm]
+      // implicit val LikeTermTH = typehint[LikeTerm]
+      // implicit val OrConditionTH = typehint[OrCondition]
+      // implicit val AndConditionTH = typehint[AndCondition]
+      // implicit val PreferTokenTH = typehint[PreferToken]
+      // implicit val QualifierTokenTH = typehint[QualifierToken]
 
-        def read(hint: SexpSymbol, value: Sexp): TokenTree = hint match {
-          case s if s == implicitly[TypeHint[FieldTerm]].hint => value.convertTo[FieldTerm]
-          case s if s == implicitly[TypeHint[BoundedTerm]].hint => value.convertTo[BoundedTerm]
-          case s if s == implicitly[TypeHint[Unparsed]].hint => value.convertTo[Unparsed]
-          case s if s == implicitly[TypeHint[Ignored]].hint => value.convertTo[Ignored]
-          case s if s == implicitly[TypeHint[Unclear]].hint => value.convertTo[Unclear]
-          case s if s == implicitly[TypeHint[InTerm]].hint => value.convertTo[InTerm]
-          case s if s == implicitly[TypeHint[LikeTerm]].hint => value.convertTo[LikeTerm]
-          case s if s == implicitly[TypeHint[AndCondition]].hint => value.convertTo[AndCondition]
-          case s if s == implicitly[TypeHint[OrCondition]].hint => value.convertTo[OrCondition]
-          case s if s == implicitly[TypeHint[PreferToken]].hint => value.convertTo[PreferToken]
-          case s if s == implicitly[TypeHint[QualifierToken]].hint => value.convertTo[QualifierToken]
-          case s if s == implicitly[TypeHint[SpecialToken.type]].hint => value.convertTo[SpecialToken.type]
-          // SAD FACE --- compiler doesn't catch typos on matches or missing impls
-          case _ => deserializationError(hint)
-        }
+      def write(obj: TokenTree): Sexp = obj match {
+        case f: FieldTerm => wrap(f)
+        case b: BoundedTerm => wrap(b)
+        case u: Unparsed => wrap(u)
+        case i: Ignored => wrap(i)
+        case u: Unclear => wrap(u)
+        case i: InTerm => wrap(i)
+        case like: LikeTerm => wrap(like)
+        case a: AndCondition => wrap(a)
+        case o: OrCondition => wrap(o)
+        case prefer: PreferToken => wrap(prefer)
+        case q: QualifierToken => wrap(q)
+        case SpecialToken => wrap(SpecialToken)
       }
-      /////////////////// END OF BOILERPLATE /////////////////
 
-      assertFormat(SpecialToken, SexpNil)
-      assertFormat(SpecialToken: TokenTree, SexpList(SexpSymbol(":SpecialToken")))
-
-      val fieldTerm = FieldTerm("thing is ten", DatabaseField("THING"), "10")
-      val expectField = SexpData(
-        SexpSymbol(":text") -> SexpString("thing is ten"),
-        SexpSymbol(":field") -> SexpData(
-          SexpSymbol(":column") -> SexpString("THING")
-        ),
-        SexpSymbol(":value") -> SexpString("10")
-      )
-
-      // confirm that the wrapper is picked up for a specific case class
-      assertFormat(fieldTerm, expectField)
-
-      val expectFieldTree = SexpData(SexpSymbol(":FieldTerm") -> expectField)
-
-      // confirm that the trait level formatter works
-      assertFormat(fieldTerm: TokenTree, expectFieldTree)
-
-      // confirm recursive works
-      val and = AndCondition(fieldTerm, fieldTerm, "wibble")
-      val expectAnd = SexpData(
-        SexpSymbol(":left") -> expectFieldTree,
-        SexpSymbol(":right") -> expectFieldTree,
-        SexpSymbol(":text") -> SexpString("wibble")
-      )
-      assertFormat(and, expectAnd)
-
-      val expectAndTree = SexpData(SexpSymbol(":AndCondition") -> expectAnd)
-
-      // and that the recursive type works as a trait
-      assertFormat(and: TokenTree, expectAndTree)
+      def read(hint: SexpSymbol, value: Sexp): TokenTree = hint match {
+        case s if s == implicitly[TypeHint[FieldTerm]].hint => value.convertTo[FieldTerm]
+        case s if s == implicitly[TypeHint[BoundedTerm]].hint => value.convertTo[BoundedTerm]
+        case s if s == implicitly[TypeHint[Unparsed]].hint => value.convertTo[Unparsed]
+        case s if s == implicitly[TypeHint[Ignored]].hint => value.convertTo[Ignored]
+        case s if s == implicitly[TypeHint[Unclear]].hint => value.convertTo[Unclear]
+        case s if s == implicitly[TypeHint[InTerm]].hint => value.convertTo[InTerm]
+        case s if s == implicitly[TypeHint[LikeTerm]].hint => value.convertTo[LikeTerm]
+        case s if s == implicitly[TypeHint[AndCondition]].hint => value.convertTo[AndCondition]
+        case s if s == implicitly[TypeHint[OrCondition]].hint => value.convertTo[OrCondition]
+        case s if s == implicitly[TypeHint[PreferToken]].hint => value.convertTo[PreferToken]
+        case s if s == implicitly[TypeHint[QualifierToken]].hint => value.convertTo[QualifierToken]
+        case s if s == implicitly[TypeHint[SpecialToken.type]].hint => value.convertTo[SpecialToken.type]
+        // SAD FACE --- compiler doesn't catch typos on matches or missing impls
+        case _ => deserializationError(hint)
+      }
     }
+    /////////////////// END OF BOILERPLATE /////////////////
+
+    assertFormat(SpecialToken, SexpNil)
+    assertFormat(SpecialToken: TokenTree, SexpList(SexpSymbol(":SpecialToken")))
+
+    val fieldTerm = FieldTerm("thing is ten", DatabaseField("THING"), "10")
+    val expectField = SexpData(
+      SexpSymbol(":text") -> SexpString("thing is ten"),
+      SexpSymbol(":field") -> SexpData(
+        SexpSymbol(":column") -> SexpString("THING")
+      ),
+      SexpSymbol(":value") -> SexpString("10")
+    )
+
+    // confirm that the wrapper is picked up for a specific case class
+    assertFormat(fieldTerm, expectField)
+
+    val expectFieldTree = SexpData(SexpSymbol(":FieldTerm") -> expectField)
+
+    // confirm that the trait level formatter works
+    assertFormat(fieldTerm: TokenTree, expectFieldTree)
+
+    // confirm recursive works
+    val and = AndCondition(fieldTerm, fieldTerm, "wibble")
+    val expectAnd = SexpData(
+      SexpSymbol(":left") -> expectFieldTree,
+      SexpSymbol(":right") -> expectFieldTree,
+      SexpSymbol(":text") -> SexpString("wibble")
+    )
+    assertFormat(and, expectAnd)
+
+    val expectAndTree = SexpData(SexpSymbol(":AndCondition") -> expectAnd)
+
+    // and that the recursive type works as a trait
+    assertFormat(and: TokenTree, expectAndTree)
   }
 }

--- a/s-express/src/test/scala/org/ensime/sexp/formats/FormatSpec.scala
+++ b/s-express/src/test/scala/org/ensime/sexp/formats/FormatSpec.scala
@@ -2,15 +2,12 @@
 // Licence: http://www.gnu.org/licenses/gpl-3.0.en.html
 package org.ensime.sexp.formats
 
-import org.scalatest.FunSpec
 import org.ensime.sexp._
+import org.ensime.util.EnsimeSpec
 
-trait FormatSpec extends FunSpec {
-  val foo = SexpString("foo")
-  val bar = SexpSymbol("bar")
-
+trait FormatSpec extends EnsimeSpec {
   def assertFormat[T: SexpFormat](start: T, expect: Sexp): Unit = {
-    assert(start.toSexp === expect)
-    assert(expect.convertTo[T] === start)
+    start.toSexp should ===(expect)
+    expect.convertTo[T] should ===(start)
   }
 }

--- a/s-express/src/test/scala/org/ensime/sexp/formats/ProductFormatsSpec.scala
+++ b/s-express/src/test/scala/org/ensime/sexp/formats/ProductFormatsSpec.scala
@@ -12,84 +12,79 @@ class ProductFormatsSpec extends FormatSpec
   case class Baz()
   case class Wibble(thing: String, thong: Int, bling: Option[String])
 
-  describe("ProductFormats case classes") {
-    val foo = Foo(13, "foo")
-    val fooexpect = SexpData(
-      SexpSymbol(":i") -> SexpNumber(13),
-      SexpSymbol(":s") -> SexpString("foo")
-    )
+  val foo = Foo(13, "foo")
+  val fooexpect = SexpData(
+    SexpSymbol(":i") -> SexpNumber(13),
+    SexpSymbol(":s") -> SexpString("foo")
+  )
 
-    it("should support primitive types") {
-      // will create the marshaller every time assertFormat is called
-      assertFormat(foo, fooexpect)
-      assertFormat(foo, fooexpect)
-      assertFormat(foo, fooexpect)
-    }
-
-    it("should support 'fast' case classes") {
-      // can't really test - its a side effect optimisation
-      implicit val FastFooFormat = SexpFormat[Foo]
-      assertFormat(foo, fooexpect)
-      assertFormat(foo, fooexpect)
-      assertFormat(foo, fooexpect)
-    }
-
-    it("should support nested case classes") {
-      val bar = Bar(foo)
-      val expect = SexpData(
-        SexpSymbol(":foo") -> fooexpect
-      )
-
-      // (this is actually a really big deal, thank you shapeless!)
-      assertFormat(bar, expect)
-    }
-
-    it("should support zero content case classes") {
-      assertFormat(Baz(), SexpNil)
-    }
-
-    it("should support missing fields as SexpNil / None") {
-      val wibble = Wibble("wibble", 13, Some("fork"))
-
-      assertFormat(wibble, SexpData(
-        SexpSymbol(":thing") -> SexpString("wibble"),
-        SexpSymbol(":thong") -> SexpNumber(13),
-        SexpSymbol(":bling") -> SexpList(SexpString("fork"))
-      ))
-
-      val wobble = Wibble("wibble", 13, None)
-
-      // write out None as SexpNil
-      assertFormat(wobble, SexpData(
-        SexpSymbol(":thing") -> SexpString("wibble"),
-        SexpSymbol(":thong") -> SexpNumber(13),
-        SexpSymbol(":bling") -> SexpNil
-      ))
-
-      // but tolerate missing entries
-      assert(SexpData(
-        SexpSymbol(":thing") -> SexpString("wibble"),
-        SexpSymbol(":thong") -> SexpNumber(13)
-      ).convertTo[Wibble] === wobble)
-    }
+  "ProductFormats case classes" should "support primitive types" in {
+    // will create the marshaller every time assertFormat is called
+    assertFormat(foo, fooexpect)
+    assertFormat(foo, fooexpect)
+    assertFormat(foo, fooexpect)
   }
 
-  describe("ProductFormat tuples") {
-    val foo = (13, "foo")
-    val fooexpect = SexpList(SexpNumber(13), SexpString("foo"))
+  it should "support 'fast' case classes" in {
+    // can't really test - its a side effect optimisation
+    implicit val FastFooFormat = SexpFormat[Foo]
+    assertFormat(foo, fooexpect)
+    assertFormat(foo, fooexpect)
+    assertFormat(foo, fooexpect)
+  }
 
-    it("should support primitive types") {
-      assertFormat(foo, fooexpect)
-    }
+  it should "support nested case classes" in {
+    val bar = Bar(foo)
+    val expect = SexpData(
+      SexpSymbol(":foo") -> fooexpect
+    )
 
-    it("should support 'fast' tuples") {
-      // can't really test - its a side effect optimisation
-      implicit val FastFooFormat = SexpFormat[(Int, String)]
-      assertFormat(foo, fooexpect)
-      assertFormat(foo, fooexpect)
-      assertFormat(foo, fooexpect)
-    }
+    // (this is actually a really big deal, thank you shapeless!)
+    assertFormat(bar, expect)
+  }
 
+  it should "support zero content case classes" in {
+    assertFormat(Baz(), SexpNil)
+  }
+
+  it should "support missing fields as SexpNil / None" in {
+    val wibble = Wibble("wibble", 13, Some("fork"))
+
+    assertFormat(wibble, SexpData(
+      SexpSymbol(":thing") -> SexpString("wibble"),
+      SexpSymbol(":thong") -> SexpNumber(13),
+      SexpSymbol(":bling") -> SexpList(SexpString("fork"))
+    ))
+
+    val wobble = Wibble("wibble", 13, None)
+
+    // write out None as SexpNil
+    assertFormat(wobble, SexpData(
+      SexpSymbol(":thing") -> SexpString("wibble"),
+      SexpSymbol(":thong") -> SexpNumber(13),
+      SexpSymbol(":bling") -> SexpNil
+    ))
+
+    // but tolerate missing entries
+    SexpData(
+      SexpSymbol(":thing") -> SexpString("wibble"),
+      SexpSymbol(":thong") -> SexpNumber(13)
+    ).convertTo[Wibble] should ===(wobble)
+  }
+
+  val bar = (13, "bar")
+  val barexpect = SexpList(SexpNumber(13), SexpString("bar"))
+
+  "ProductFormat tuples" should "support primitive types" in {
+    assertFormat(bar, barexpect)
+  }
+
+  it should "support 'fast' tuples" in {
+    // can't really test - its a side effect optimisation
+    implicit val FastBarormat = SexpFormat[(Int, String)]
+    assertFormat(bar, barexpect)
+    assertFormat(bar, barexpect)
+    assertFormat(bar, barexpect)
   }
 }
 
@@ -99,12 +94,10 @@ class CustomisedProductFormatsSpec extends FormatSpec
 
   case class Foo(AThingyMaBob: Int, HTML: String)
 
-  describe("ProductFormats with overloaded toWireName") {
-    it("should support custom field names") {
-      assertFormat(Foo(13, "foo"), SexpData(
-        SexpSymbol(":a-thingy-ma-bob") -> SexpNumber(13),
-        SexpSymbol(":h-t-m-l") -> SexpString("foo")
-      ))
-    }
+  "ProductFormats with overloaded toWireName" should "support custom field names" in {
+    assertFormat(Foo(13, "foo"), SexpData(
+      SexpSymbol(":a-thingy-ma-bob") -> SexpNumber(13),
+      SexpSymbol(":h-t-m-l") -> SexpString("foo")
+    ))
   }
 }

--- a/s-express/src/test/scala/org/ensime/sexp/formats/SexpFormatUtilsSpec.scala
+++ b/s-express/src/test/scala/org/ensime/sexp/formats/SexpFormatUtilsSpec.scala
@@ -9,65 +9,66 @@ import org.ensime.sexp._
 class SexpFormatUtilsSpec extends FormatSpec with SexpFormats {
   import SexpFormatUtils._
 
-  describe("SexpFormatUtils") {
-    it("should lift writers") {
-      val lifted = lift(new SexpWriter[SexpString] {
-        def write(o: SexpString) = o
-      })
-      assert(foo.toSexp(lifted) === foo)
-      intercept[UnsupportedOperationException] {
-        foo.convertTo[SexpString](lifted)
-      }
+  val foo = SexpString("foo")
+  val bar = SexpSymbol("bar")
+
+  "SexpFormatUtils" should "lift writers" in {
+    val lifted = lift(new SexpWriter[SexpString] {
+      def write(o: SexpString) = o
+    })
+    foo.toSexp(lifted) should ===(foo)
+    intercept[UnsupportedOperationException] {
+      foo.convertTo[SexpString](lifted)
+    }
+  }
+
+  it should "lift readers" in {
+    val lifted = lift(new SexpReader[SexpString] {
+      def read(o: Sexp) = o.asInstanceOf[SexpString]
+    })
+    foo.convertTo[SexpString](lifted) should ===(foo)
+    intercept[UnsupportedOperationException] {
+      foo.toSexp(lifted)
+    }
+  }
+
+  it should "combine readers and writers" in {
+    val reader = new SexpReader[SexpString] {
+      def read(o: Sexp) = o.asInstanceOf[SexpString]
+    }
+    val writer = new SexpWriter[SexpString] {
+      def write(o: SexpString) = o
+    }
+    val combo = sexpFormat(reader, writer)
+
+    foo.convertTo[SexpString](combo) should ===(foo)
+    foo.toSexp(combo) should ===(foo)
+  }
+
+  it should "support lazy formats" in {
+    var init = false
+    val lazyF = lazyFormat {
+      init = true
+      SexpStringFormat
     }
 
-    it("should lift readers") {
-      val lifted = lift(new SexpReader[SexpString] {
-        def read(o: Sexp) = o.asInstanceOf[SexpString]
-      })
-      assert(foo.convertTo[SexpString](lifted) === foo)
-      intercept[UnsupportedOperationException] {
-        foo.toSexp(lifted)
-      }
-    }
+    assert(!init)
+    SexpString("foo").convertTo[SexpString](lazyF) should ===(SexpString("foo"))
+    assert(init)
+    SexpString("foo").toSexp(lazyF) should ===(SexpString("foo"))
+  }
 
-    it("should combine readers and writers") {
-      val reader = new SexpReader[SexpString] {
-        def read(o: Sexp) = o.asInstanceOf[SexpString]
-      }
-      val writer = new SexpWriter[SexpString] {
-        def write(o: SexpString) = o
-      }
-      val combo = sexpFormat(reader, writer)
-
-      assert(foo.convertTo[SexpString](combo) === foo)
-      assert(foo.toSexp(combo) === foo)
-    }
-
-    it("should support lazy formats") {
-      var init = false
-      val lazyF = lazyFormat {
-        init = true
-        SexpStringFormat
-      }
-
-      assert(!init)
-      assert(SexpString("foo").convertTo[SexpString](lazyF) === SexpString("foo"))
-      assert(init)
-      assert(SexpString("foo").toSexp(lazyF) === SexpString("foo"))
-    }
-
-    it("should support safe readers") {
-      val safe = safeReader(
-        new SexpReader[SexpString] {
-          def read(value: Sexp) = value match {
-            case s: SexpString => s
-            case x => deserializationError(x)
-          }
+  it should "support safe readers" in {
+    val safe = safeReader(
+      new SexpReader[SexpString] {
+        def read(value: Sexp) = value match {
+          case s: SexpString => s
+          case x => deserializationError(x)
         }
-      )
+      }
+    )
 
-      assert(foo.convertTo[Try[SexpString]](safe) === Success(foo))
-      assert(bar.convertTo[Try[SexpString]](safe).isInstanceOf[Failure[_]])
-    }
+    foo.convertTo[Try[SexpString]](safe) should ===(Success(foo))
+    bar.convertTo[Try[SexpString]](safe) shouldBe a[Failure[_]]
   }
 }

--- a/s-express/src/test/scala/org/ensime/sexp/formats/SexpFormatsSpec.scala
+++ b/s-express/src/test/scala/org/ensime/sexp/formats/SexpFormatsSpec.scala
@@ -6,25 +6,27 @@ import org.ensime.sexp._
 
 class SexpFormatsSpec extends FormatSpec with SexpFormats {
 
+  val foo = SexpString("foo")
+  val bar = SexpSymbol("bar")
+
   def assertFormat(sexp: Sexp): Unit = assertFormat(sexp, sexp)
 
-  describe("SexpFormats") {
-    it("should support SexpAtoms") {
-      assertFormat(SexpNil)
-      assertFormat(SexpPosInf)
-      assertFormat(SexpNegInf)
-      assertFormat(SexpNaN)
-      assertFormat(SexpNumber(1))
-      assertFormat(SexpString("hello"))
-      assertFormat(SexpSymbol("hello"))
-    }
+  "SexpFormats" should "support SexpAtoms" in {
+    assertFormat(SexpNil)
+    assertFormat(SexpPosInf)
+    assertFormat(SexpNegInf)
+    assertFormat(SexpNaN)
+    assertFormat(SexpNumber(1))
+    assertFormat(SexpString("hello"))
+    assertFormat(SexpSymbol("hello"))
+  }
 
-    it("should support SexpList") {
-      assertFormat(SexpList(foo, bar))
-    }
+  it should "support SexpList" in {
+    assertFormat(SexpList(foo, bar))
+  }
 
-    it("should support SexpCons") {
-      assertFormat(SexpCons(foo, bar))
-    }
+  it should "support SexpCons" in {
+    assertFormat(SexpCons(foo, bar))
   }
 }
+

--- a/s-express/src/test/scala/org/ensime/sexp/formats/StandardFormatsSpec.scala
+++ b/s-express/src/test/scala/org/ensime/sexp/formats/StandardFormatsSpec.scala
@@ -10,56 +10,55 @@ import java.util.UUID
 import org.ensime.sexp._
 
 class StandardFormatsSpec extends FormatSpec with StandardFormats with BasicFormats {
-  describe("StandardFormats") {
-    it("should support Option") {
-      val some = Some("thing")
-      assertFormat(some: Option[String], SexpList(SexpString("thing")))
-      assertFormat(None: Option[String], SexpNil)
-    }
 
-    it("should support Either") {
-      val left = Left(13)
-      val right = Right("thirteen")
-      assertFormat(
-        left: Either[Int, String],
-        SexpNumber(13)
-      )
-      assertFormat(
-        right: Either[Int, String],
-        SexpString("thirteen")
-      )
-    }
+  "StandardFormats" should "support Option" in {
+    val some = Some("thing")
+    assertFormat(some: Option[String], SexpList(SexpString("thing")))
+    assertFormat(None: Option[String], SexpNil)
+  }
 
-    it("should support UUID") {
-      val uuid = UUID.randomUUID()
-      assertFormat(uuid, SexpString(uuid.toString))
-    }
+  it should "support Either" in {
+    val left = Left(13)
+    val right = Right("thirteen")
+    assertFormat(
+      left: Either[Int, String],
+      SexpNumber(13)
+    )
+    assertFormat(
+      right: Either[Int, String],
+      SexpString("thirteen")
+    )
+  }
 
-    // it("should support URL") {
-    //   val github = "http://github.com/ensime/"
-    //   val url = new URL(github)
-    //   // hack to avoid calling URL.equals, which talks to the interwebz
-    //   assert(url.toSexp === SexpString(github))
-    //   assert(SexpString(github).convertTo[URL].toExternalForm === github)
-    // }
+  it should "support UUID" in {
+    val uuid = UUID.randomUUID()
+    assertFormat(uuid, SexpString(uuid.toString))
+  }
 
-    it("should support URI") {
-      val github = "http://github.com/ensime/"
-      val url = new URI(github)
-      assertFormat(url, SexpString(github))
-    }
+  // it should "support URL" in {
+  //   val github = "http://github.com/ensime/"
+  //   val url = new URL(github)
+  //   // hack to avoid calling URL.equals, which talks to the interwebz
+  //   url.toSexp should === (SexpString(github))
+  //   SexpString(github).convertTo[URL].toExternalForm should === (github)
+  // }
 
-    it("should support File") {
-      val file = new File("foo")
-      assertFormat(file, SexpString("foo"))
-    }
+  it should "support URI" in {
+    val github = "http://github.com/ensime/"
+    val url = new URI(github)
+    assertFormat(url, SexpString(github))
+  }
 
-    it("should support Date") {
-      val date = new Date(1414326493000L)
-      assertFormat(date, SexpString("2014-10-26T12:28:13+00:00"))
+  it should "support File" in {
+    val file = new File("foo")
+    assertFormat(file, SexpString("foo"))
+  }
 
-      val unix = new Date(0L)
-      assertFormat(unix, SexpString("1970-01-01T00:00:00+00:00"))
-    }
+  it should "support Date" in {
+    val date = new Date(1414326493000L)
+    assertFormat(date, SexpString("2014-10-26T12:28:13+00:00"))
+
+    val unix = new Date(0L)
+    assertFormat(unix, SexpString("1970-01-01T00:00:00+00:00"))
   }
 }

--- a/server/src/test/scala/org/ensime/server/FramedStringProtocolSpec.scala
+++ b/server/src/test/scala/org/ensime/server/FramedStringProtocolSpec.scala
@@ -4,36 +4,37 @@ package org.ensime.server
 
 import akka.util.ByteString
 import org.ensime.api._
-import org.scalatest._
+import org.ensime.util.EnsimeSpec
 
-class FramedStringProtocolSpec extends FlatSpec with Matchers
-    with FramedStringProtocol {
+class FramedStringProtocolSpec extends EnsimeSpec {
+
   // subclassed FramedStringProtocol so we can get access we want to test
+  trait Proto extends FramedStringProtocol {
+    override def decode(bytes: ByteString): (Option[RpcRequestEnvelope], ByteString) = ???
+    override def encode(msg: RpcResponseEnvelope): ByteString = ???
+  }
 
-  override def decode(bytes: ByteString): (Option[RpcRequestEnvelope], ByteString) = ???
-  override def encode(msg: RpcResponseEnvelope): ByteString = ???
-
-  "FramedStringProtocol" should "write framed strings" in {
+  "FramedStringProtocol" should "write framed strings" in new Proto {
     val buffer = writeString("foobar")
     val written = buffer.utf8String
 
     written shouldBe "000006foobar"
   }
 
-  it should "write multi-byte UTF-8 strings" in {
+  it should "write multi-byte UTF-8 strings" in new Proto {
     val buffer = writeString("€")
     val written = buffer.utf8String
 
     written shouldBe "000003€"
   }
 
-  it should "read framed strings" in {
+  it should "read framed strings" in new Proto {
     val read = tryReadString(ByteString("000006foobar", "UTF-8"))
 
     read shouldBe ((Some("foobar"), ByteString()))
   }
 
-  it should "read multi-byte UTF-8 strings" in {
+  it should "read multi-byte UTF-8 strings" in new Proto {
     val read = tryReadString(ByteString("000003€000003€", "UTF-8"))
 
     read shouldBe ((Some("€"), ByteString("000003€", "UTF-8")))

--- a/testutil/src/main/scala/org/ensime/fixture/TestKitFixture.scala
+++ b/testutil/src/main/scala/org/ensime/fixture/TestKitFixture.scala
@@ -16,7 +16,7 @@ import akka.testkit._
  * in a suite, but sometimes isolation of the system is needed on a
  * per-test basis, this fixture adds support for that.
  *
- * Instead of extending TestKit, use withActorSystem and import
+ * Instead of extending TestKit, use withTestKit and import
  * the parameter for all implicits.
  *
  * Inspired by https://gist.github.com/derekwyatt/3138807

--- a/testutil/src/main/scala/org/ensime/util/EnsimeSpec.scala
+++ b/testutil/src/main/scala/org/ensime/util/EnsimeSpec.scala
@@ -8,6 +8,7 @@ import java.util.concurrent.TimeUnit
 import org.scalatest._
 import org.scalatest.time._
 import org.scalatest.concurrent.Eventually
+import org.scalactic.TypeCheckedTripleEquals
 import org.slf4j.LoggerFactory
 import org.slf4j.bridge.SLF4JBridgeHandler
 import scala.concurrent.duration._
@@ -15,7 +16,15 @@ import scala.concurrent.duration._
 /**
  * Boilerplate remover and preferred testing style in ENSIME.
  */
-trait EnsimeSpec extends FlatSpec with Matchers with Inside with Retries with Eventually {
+trait EnsimeSpec extends FlatSpec
+    with Matchers
+    with Inside
+    with Retries
+    with Eventually
+    with TryValues
+    with Inspectors
+    with TypeCheckedTripleEquals {
+
   SLF4JBridgeHandler.removeHandlersForRootLogger()
   SLF4JBridgeHandler.install()
   val log = LoggerFactory.getLogger(this.getClass)

--- a/testutil/src/test/scala/org/ensime/util/EscapingStringInterpolationSpec.scala
+++ b/testutil/src/test/scala/org/ensime/util/EscapingStringInterpolationSpec.scala
@@ -4,9 +4,7 @@ package org.ensime.util
 
 import java.io.File
 
-import org.scalatest._
-
-class EscapingStringInterpolationSpec extends FlatSpec with Matchers {
+class EscapingStringInterpolationSpec extends EnsimeSpec {
 
   import EscapingStringInterpolation._
 


### PR DESCRIPTION
Issue #1245
Migrated all tests to become EnsimeSpec and changed asserts to should machers where it was possible. Didn't play with EnsimeVFS yet. I'd prefer to move tests from Int into test with another pr, as this one is already huge. Same for deprecated AkkaFlatSpec. Thanks.