### PR TITLE
Add sbt-buildinfo

### DIFF
--- a/core/src/main/scala/org/ensime/config/Environment.scala
+++ b/core/src/main/scala/org/ensime/config/Environment.scala
@@ -1,17 +1,22 @@
 // Copyright: 2010 - 2016 https://github.com/ensime/ensime-server/graphs
 // Licence: http://www.gnu.org/licenses/gpl-3.0.en.html
-package org.ensime.config
+package org.ensime
+package config
 
 import java.net.{ JarURLConnection, URL }
 
 object Environment {
-  def info: String = """
+  def info: String = s"""
     |Environment:
-    |  OS : %s
-    |  Java : %s
-    |  Scala : %s
-    |  Ensime : %s
-  """.trim.stripMargin.format(osVersion, javaVersion, scalaVersion, ensimeVersion)
+    |  OS : $osVersion
+    |  Java : $javaVersion
+    |  Scala version: $scalaVersion
+    |  Ensime : $ensimeVersion
+    |  Built with Scala version: ${BuildInfo.scalaVersion}
+    |  Built with sbt version: ${BuildInfo.sbtVersion}
+    |  Built from git sha: ${BuildInfo.gitSha}
+    |  Built on: ${BuildInfo.builtAtString}
+  """.trim.stripMargin
 
   private def osVersion: String =
     System.getProperty("os.name")
@@ -26,13 +31,7 @@ object Environment {
     scala.util.Properties.versionString
 
   private def ensimeVersion: String =
-    try {
-      val pathToEnsimeJar = getClass.getProtectionDomain.getCodeSource.getLocation
-      val ensimeJar = new URL("jar:" + pathToEnsimeJar.toString + "!/").openConnection().asInstanceOf[JarURLConnection].getJarFile
-      ensimeJar.getManifest.getMainAttributes.getValue("Implementation-Version")
-    } catch {
-      case _: Exception => "unknown"
-    }
+    BuildInfo.version
 
   def shutdownOnDisconnectFlag: Boolean = {
     Option(System.getProperty("ensime.explode.on.disconnect")).isDefined

--- a/project/EnsimeBuild.scala
+++ b/project/EnsimeBuild.scala
@@ -9,6 +9,7 @@ import sbtassembly.{ AssemblyKeys, MergeStrategy, PathList }
 import sbtassembly.AssemblyKeys._
 import scala.util.{ Properties, Try }
 import org.ensime.EnsimePlugin.JdkDir
+import sbtbuildinfo.BuildInfoPlugin, BuildInfoPlugin.autoImport._
 
 object EnsimeBuild extends Build {
   ////////////////////////////////////////////////
@@ -319,6 +320,10 @@ object EnsimeBuild extends Build {
           "commons-lang" % "commons-lang" % "2.6",
           "com.googlecode.java-diff-utils" % "diffutils" % "1.3.0"
         ) ++ logback ++ testLibs(scalaVersion.value, "it,test")
+      ) enablePlugins BuildInfoPlugin settings (
+        buildInfoPackage := "org.ensime",
+        buildInfoKeys += BuildInfoKey.action("gitSha")(Try("git rev-parse --verify HEAD".!! dropRight 1) getOrElse "n/a"),
+        buildInfoOptions += BuildInfoOption.BuildTime
       )
 
   lazy val server = Project("server", file("server")).dependsOn(

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -21,3 +21,5 @@ scalacOptions in Compile ++= Seq("-feature", "-deprecation")
 
 // sbt, STFU...
 ivyLoggingLevel := UpdateLogging.Quiet
+
+addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.5.0")


### PR DESCRIPTION
Fixes #894

---

This generates a file at `server/target/scala-2.11/src_managed/main/sbt-buildinfo/BuildInfo.scala`

with contents:

```scala
package org.ensime.server

import java.io.File
import java.lang.String
import java.net.URL
import scala._; import Predef._

/** This object was generated by sbt-buildinfo. */
case object BuildInfo {
  /** The value is "server". */
  val name: String = "server"
  /** The value is "0.9.10-SNAPSHOT". */
  val version: String = "0.9.10-SNAPSHOT"
  /** The value is "2.11.7". */
  val scalaVersion: String = "2.11.7"
  /** The value is "0.13.9". */
  val sbtVersion: String = "0.13.9"
  override val toString: String = {
    "name: %s, version: %s, scalaVersion: %s, sbtVersion: %s" format (
      name, version, scalaVersion, sbtVersion
    )
  }
}
```

Let me know if you want to add or change anything, I'm happy to iterate (and yak-shave).

Also let me know if you have a way for testing for this addition.