### PR TITLE
fix #1221 Tolerate unsaved empty file requests

### DIFF
--- a/api/src/main/scala/org/ensime/api/common.scala
+++ b/api/src/main/scala/org/ensime/api/common.scala
@@ -81,3 +81,12 @@ object RefactorType {
 
   def allTypes = Seq(Rename, ExtractMethod, ExtractLocal, InlineLocal, OrganizeImports, AddImport)
 }
+
+case class SourceFileInfo(
+    file: File,
+    contents: Option[String] = None,
+    contentsIn: Option[File] = None
+) {
+  // keep the log file sane for unsaved files
+  override def toString = s"SourceFileInfo($file,${contents.map(_ => "...")},$contentsIn)"
+}

--- a/api/src/main/scala/org/ensime/api/outgoing.scala
+++ b/api/src/main/scala/org/ensime/api/outgoing.scala
@@ -188,15 +188,6 @@ case class OrganiseImportsRefactorDesc(file: File) extends RefactorDesc(Refactor
 case class AddImportRefactorDesc(qualifiedName: String, file: File)
   extends RefactorDesc(RefactorType.AddImport)
 
-case class SourceFileInfo(
-    file: File,
-    contents: Option[String] = None,
-    contentsIn: Option[File] = None
-) {
-  // keep the log file sane for unsaved files
-  override def toString = s"SourceFileInfo($file,${contents.map(_ => "...")},$contentsIn)"
-}
-
 sealed trait PatchOp {
   def start: Int
 }


### PR DESCRIPTION
Fix for #1221. 

1. `SourceFileInfo` moved to `common.scala`

1. `TypecheckFileReq`, `SymbolDesignationsReq`, `CompletionsReq` and `UsesOfSymbolAtPointReq` return rpc error for unsaved empty file now.
