### PR TITLE
FQNs with double dollars are of no value now

### DIFF
--- a/core/src/main/scala/org/ensime/indexer/SearchService.scala
+++ b/core/src/main/scala/org/ensime/indexer/SearchService.scala
@@ -175,7 +175,7 @@ class SearchService(
   }
 
   private val blacklist = Set("sun/", "sunw/", "com/sun/")
-  private val ignore = Set("$$anon$", "$$anonfun$", "$worker$")
+  private val ignore = Set("$$", "$worker$")
   import org.ensime.util.RichFileObject._
   private def extractSymbols(container: FileObject, f: FileObject): List[FqnSymbol] = {
     f.pathWithinArchive match {


### PR DESCRIPTION
when we can relate scala names to FQNs, maybe this will be useful, but let's face it nobody ever wants to import anything with two dollars in the name and I'm seeing a lot of noise like this in a work project.