### PR TITLE
FIXME: eliminate all the Option responses

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -4,7 +4,7 @@ build:
   environment:
     - SONATYPE_USERNAME=$$SONATYPE_USERNAME
     - SONATYPE_PASSWORD=$$SONATYPE_PASSWORD
-    - EMACS=/opt/emacs-24.4/bin/emacs
+    - EMACS=/opt/emacs-24.5/bin/emacs
     - AKKA_TEST_TIMEFACTOR=10
   commands:
     - git log | head -n 20

--- a/core/src/it/scala/org/ensime/intg/BasicWorkflow.scala
+++ b/core/src/it/scala/org/ensime/intg/BasicWorkflow.scala
@@ -51,13 +51,13 @@ class BasicWorkflow extends EnsimeSpec
           //-----------------------------------------------------------------------------------------------
           // symbolAtPoint
           project ! SymbolAtPointReq(Left(fooFile), 128)
-          val symbolAtPointOpt: Option[SymbolInfo] = expectMsgType[Option[SymbolInfo]]
+          val symbolAtPointOpt: SymbolInfo = expectMsgType[SymbolInfo]
 
           project ! TypeByNameReq("org.example.Foo")
-          val fooClassByNameOpt = expectMsgType[Option[TypeInfo]]
+          val fooClassByNameOpt = expectMsgType[TypeInfo]
 
           project ! TypeByNameReq("org.example.Foo$")
-          val fooObjectByNameOpt = expectMsgType[Option[TypeInfo]]
+          val fooObjectByNameOpt = expectMsgType[TypeInfo]
 
           //-----------------------------------------------------------------------------------------------
           // public symbol search - java.io.File
@@ -118,56 +118,56 @@ class BasicWorkflow extends EnsimeSpec
           // loaded by the pres compiler
           project ! SymbolAtPointReq(Left(fooFile), 276)
           expectMsgPF() {
-            case Some(SymbolInfo("testMethod", "testMethod", Some(OffsetSourcePosition(`fooFile`, 114)), ArrowTypeInfo("(i: Int, s: String)Int", BasicTypeInfo("Int", DeclaredAs.Class, "scala.Int", List(), List(), None), List(ParamSectionInfo(List((i, BasicTypeInfo("Int", DeclaredAs.Class, "scala.Int", List(), List(), None)), (s, BasicTypeInfo("String", DeclaredAs.Class, "java.lang.String", List(), List(), None))), false))), true)) =>
+            case SymbolInfo("testMethod", "testMethod", Some(OffsetSourcePosition(`fooFile`, 114)), ArrowTypeInfo("(i: Int, s: String)Int", BasicTypeInfo("Int", DeclaredAs.Class, "scala.Int", List(), List(), None), List(ParamSectionInfo(List((i, BasicTypeInfo("Int", DeclaredAs.Class, "scala.Int", List(), List(), None)), (s, BasicTypeInfo("String", DeclaredAs.Class, "java.lang.String", List(), List(), None))), false))), true) =>
           }
 
           // M-.  external symbol
           project ! SymbolAtPointReq(Left(fooFile), 190)
           expectMsgPF() {
-            case Some(SymbolInfo("Map", "Map", Some(OffsetSourcePosition(_, _)),
+            case SymbolInfo("Map", "Map", Some(OffsetSourcePosition(_, _)),
               BasicTypeInfo("Map$", DeclaredAs.Object, "scala.collection.immutable.Map$", List(), List(), None),
-              false)) =>
+              false) =>
           }
 
           project ! SymbolAtPointReq(Left(fooFile), 343)
           expectMsgPF() {
-            case Some(SymbolInfo("fn", "fn", Some(OffsetSourcePosition(`fooFile`, 304)),
+            case SymbolInfo("fn", "fn", Some(OffsetSourcePosition(`fooFile`, 304)),
               BasicTypeInfo("Function1", DeclaredAs.Trait, "scala.Function1",
                 List(
                   BasicTypeInfo("String", DeclaredAs.Class, "java.lang.String", List(), List(), None),
                   BasicTypeInfo("Int", DeclaredAs.Class, "scala.Int", List(), List(), None)),
                 List(), None),
-              false)) =>
+              false) =>
           }
 
           project ! SymbolAtPointReq(Left(barFile), 150)
           expectMsgPF() {
-            case Some(SymbolInfo("apply", "apply", Some(OffsetSourcePosition(`barFile`, 59)),
+            case SymbolInfo("apply", "apply", Some(OffsetSourcePosition(`barFile`, 59)),
               ArrowTypeInfo("(bar: String, baz: Int)org.example.Bar.Foo",
                 BasicTypeInfo("Foo", DeclaredAs.Class, "org.example.Bar$$Foo", List(), List(), None),
                 List(ParamSectionInfo(
                   List(
                     ("bar", BasicTypeInfo("String", DeclaredAs.Class, "java.lang.String", List(), List(), None)),
                     ("baz", BasicTypeInfo("Int", DeclaredAs.Class, "scala.Int", List(), List(), None))), false))),
-              true)) =>
+              true) =>
           }
 
           project ! SymbolAtPointReq(Left(barFile), 193)
           expectMsgPF() {
-            case Some(SymbolInfo("copy", "copy", Some(OffsetSourcePosition(`barFile`, 59)),
+            case SymbolInfo("copy", "copy", Some(OffsetSourcePosition(`barFile`, 59)),
               ArrowTypeInfo("(bar: String, baz: Int)org.example.Bar.Foo",
                 BasicTypeInfo("Foo", DeclaredAs.Class, "org.example.Bar$$Foo", List(), List(), None),
                 List(ParamSectionInfo(
                   List(
                     ("bar", BasicTypeInfo("String", DeclaredAs.Class, "java.lang.String", List(), List(), None)),
                     ("baz", BasicTypeInfo("Int", DeclaredAs.Class, "scala.Int", List(), List(), None))), false))),
-              true)) =>
+              true) =>
           }
 
           // C-c C-v p Inspect source of current package
           project ! InspectPackageByPathReq("org.example")
           expectMsgPF() {
-            case Some(PackageInfo("example", "org.example", List(
+            case PackageInfo("example", "org.example", List(
               BasicTypeInfo("Bar", DeclaredAs.Class, "org.example.Bar", List(), List(), Some(_)),
               BasicTypeInfo("Bar$", DeclaredAs.Object, "org.example.Bar$", List(), List(), Some(_)),
               BasicTypeInfo("Bloo", DeclaredAs.Class, "org.example.Bloo", List(), List(), Some(_)),
@@ -183,7 +183,7 @@ class BasicWorkflow extends EnsimeSpec
               BasicTypeInfo("Test2", DeclaredAs.Class, "org.example.Test2", List(), List(), None),
               BasicTypeInfo("Test2$", DeclaredAs.Object, "org.example.Test2$", List(), List(), None),
               BasicTypeInfo("package$", DeclaredAs.Object, "org.example.package$", List(), List(), None),
-              BasicTypeInfo("package$", DeclaredAs.Object, "org.example.package$", List(), List(), None)))) =>
+              BasicTypeInfo("package$", DeclaredAs.Object, "org.example.package$", List(), List(), None))) =>
           }
 
           // expand selection around 'val foo'

--- a/core/src/it/scala/org/ensime/intg/JavaWorkflow.scala
+++ b/core/src/it/scala/org/ensime/intg/JavaWorkflow.scala
@@ -29,7 +29,7 @@ class JavaWorkflow extends EnsimeSpec
           expectMsg(VoidResponse)
 
           project ! TypeAtPointReq(Left(fooFile), OffsetRange(30))
-          expectMsg(Some(BasicTypeInfo("pure.NoScalaHere", DeclaredAs.Class, "pure.NoScalaHere", Nil, Nil, Some(EmptySourcePosition()))))
+          expectMsg(BasicTypeInfo("pure.NoScalaHere", DeclaredAs.Class, "pure.NoScalaHere", Nil, Nil, Some(EmptySourcePosition())))
         }
       }
     }

--- a/core/src/main/scala/org/ensime/core/Analyzer.scala
+++ b/core/src/main/scala/org/ensime/core/Analyzer.scala
@@ -202,17 +202,21 @@ class Analyzer(
       val members = scalaCompiler.askCompletePackageMember(path, prefix)
       sender ! members
     case InspectTypeAtPointReq(file, range: OffsetRange) =>
-      val p = pos(file, range)
-      scalaCompiler.askLoadedTyped(p.source)
-      sender ! scalaCompiler.askInspectTypeAt(p)
+      sender ! withExisting(file) {
+        val p = pos(file, range)
+        scalaCompiler.askLoadedTyped(p.source)
+        scalaCompiler.askInspectTypeAt(p).getOrElse(FalseResponse)
+      }
     case InspectTypeByNameReq(name: String) =>
-      sender ! scalaCompiler.askInspectTypeByName(name)
+      sender ! scalaCompiler.askInspectTypeByName(name).getOrElse(FalseResponse)
     case SymbolAtPointReq(file, point: Int) =>
-      val p = pos(file, point)
-      scalaCompiler.askLoadedTyped(p.source)
-      sender ! scalaCompiler.askSymbolInfoAt(p)
+      sender ! withExisting(file) {
+        val p = pos(file, point)
+        scalaCompiler.askLoadedTyped(p.source)
+        scalaCompiler.askSymbolInfoAt(p).getOrElse(FalseResponse)
+      }
     case SymbolByNameReq(typeFullName: String, memberName: Option[String], signatureString: Option[String]) =>
-      sender ! scalaCompiler.askSymbolByName(typeFullName, memberName, signatureString)
+      sender ! scalaCompiler.askSymbolByName(typeFullName, memberName, signatureString).getOrElse(FalseResponse)
     case DocUriAtPointReq(file, range: OffsetRange) =>
       val p = pos(file, range)
       scalaCompiler.askLoadedTyped(p.source)
@@ -220,17 +224,21 @@ class Analyzer(
     case DocUriForSymbolReq(typeFullName: String, memberName: Option[String], signatureString: Option[String]) =>
       sender() ! scalaCompiler.askDocSignatureForSymbol(typeFullName, memberName, signatureString)
     case InspectPackageByPathReq(path: String) =>
-      sender ! scalaCompiler.askPackageByPath(path)
+      sender ! scalaCompiler.askPackageByPath(path).getOrElse(FalseResponse)
     case TypeAtPointReq(file, range: OffsetRange) =>
-      val p = pos(file, range)
-      scalaCompiler.askLoadedTyped(p.source)
-      sender ! scalaCompiler.askTypeInfoAt(p)
+      sender ! withExisting(file) {
+        val p = pos(file, range)
+        scalaCompiler.askLoadedTyped(p.source)
+        scalaCompiler.askTypeInfoAt(p).getOrElse(FalseResponse)
+      }
     case TypeByNameReq(name: String) =>
-      sender ! scalaCompiler.askTypeInfoByName(name)
+      sender ! scalaCompiler.askTypeInfoByName(name).getOrElse(FalseResponse)
     case TypeByNameAtPointReq(name: String, file, range: OffsetRange) =>
-      val p = pos(file, range)
-      scalaCompiler.askLoadedTyped(p.source)
-      sender ! scalaCompiler.askTypeInfoByNameAt(name, p)
+      sender ! withExisting(file) {
+        val p = pos(file, range)
+        scalaCompiler.askLoadedTyped(p.source)
+        scalaCompiler.askTypeInfoByNameAt(name, p).getOrElse(FalseResponse)
+      }
     case SymbolDesignationsReq(f, start, end, Nil) =>
       sender ! SymbolDesignations(f.file, List.empty)
     case SymbolDesignationsReq(f, start, end, tpes) =>
@@ -241,12 +249,12 @@ class Analyzer(
         scalaCompiler.askLoadedTyped(pos.source)
         scalaCompiler.askSymbolDesignationsInRegion(pos, tpes)
       }
-
     case ImplicitInfoReq(file, range: OffsetRange) =>
-      val p = pos(file, range)
-      scalaCompiler.askLoadedTyped(p.source)
-      sender() ! scalaCompiler.askImplicitInfoInRegion(p)
-
+      sender ! withExisting(file) {
+        val p = pos(file, range)
+        scalaCompiler.askLoadedTyped(p.source)
+        scalaCompiler.askImplicitInfoInRegion(p)
+      }
     case ExpandSelectionReq(file, start: Int, stop: Int) =>
       sender ! handleExpandselection(file, start, stop)
     case FormatSourceReq(files: List[File]) =>

--- a/core/src/main/scala/org/ensime/core/JavaAnalyzer.scala
+++ b/core/src/main/scala/org/ensime/core/JavaAnalyzer.scala
@@ -68,14 +68,14 @@ class JavaAnalyzer(
       sender() ! javaCompiler.askDocSignatureAtPoint(file, range.from)
 
     case TypeAtPointReq(file, range) =>
-      sender() ! javaCompiler.askTypeAtPoint(file, range.from)
+      sender() ! javaCompiler.askTypeAtPoint(file, range.from).getOrElse(FalseResponse)
 
     case SymbolDesignationsReq(f, start, end, tpes) =>
       // NOT IMPLEMENTED YET
       sender ! SymbolDesignations(f.file, Nil)
 
     case SymbolAtPointReq(file, point) =>
-      sender() ! javaCompiler.askSymbolAtPoint(file, point)
+      sender() ! javaCompiler.askSymbolAtPoint(file, point).getOrElse(FalseResponse)
 
     case ImplicitInfoReq(file, range: OffsetRange) =>
       // Implicit type conversion information is not applicable for Java, so we

--- a/server/src/main/scala/org/ensime/server/RequestHandler.scala
+++ b/server/src/main/scala/org/ensime/server/RequestHandler.scala
@@ -46,15 +46,6 @@ class RequestHandler(
       server forward RpcResponseEnvelope(Some(envelope.callId), err)
       context stop self
 
-    // FIXME: find and eliminate all the Option responses
-    // legacy --- to deal with bad/Optional actor responses
-    case Some(response: RpcResponse) =>
-      server forward RpcResponseEnvelope(Some(envelope.callId), response)
-      context stop self
-    case None =>
-      server forward RpcResponseEnvelope(Some(envelope.callId), FalseResponse)
-      context stop self
-
     case response: RpcResponse =>
       server forward RpcResponseEnvelope(Some(envelope.callId), response)
       context stop self

--- a/server/src/main/scala/org/ensime/server/WebServerImpl.scala
+++ b/server/src/main/scala/org/ensime/server/WebServerImpl.scala
@@ -28,14 +28,7 @@ class WebServerImpl(
         case None => Future.successful(FalseResponse)
         case Some(sig: DocSigPair) => handleRpc(sig)
       }
-    case _ =>
-      (project ? Canonised(in)).map {
-        case r: EnsimeServerMessage => r
-        // FIXME: find and eliminate all the Option responses
-        // legacy --- to deal with bad/Optional actor responses
-        case Some(r: RpcResponse) => r
-        case None => FalseResponse
-      }
+    case _ => (project ? Canonised(in)).mapTo[EnsimeServerMessage]
   }
 
   def restHandler(in: RpcRequest): Future[EnsimeServerMessage] = handleRpc(in)


### PR DESCRIPTION
Heya! Trying to fix #1316
Request handler isn't listening to Options any more. FalseResponses returned from project actors instead. There is a non-RpcResponse family DocSigPair responses left. Wasn't sure if I should change it or not.