### PR TITLE
Update scala-refactoring to 0.9.1-SNAPSHOT

### DIFF
--- a/project/EnsimeBuild.scala
+++ b/project/EnsimeBuild.scala
@@ -151,7 +151,7 @@ object EnsimeBuild extends Build {
         "org.scala-lang" % "scalap" % scalaVersion.value,
         "com.typesafe.akka" %% "akka-actor" % Sensible.akkaVersion,
         "com.typesafe.akka" %% "akka-slf4j" % Sensible.akkaVersion,
-        "org.scala-refactoring" %% "org.scala-refactoring.library" % "0.9.0-SNAPSHOT",
+        "org.scala-refactoring" %% "org.scala-refactoring.library" % "0.9.1-SNAPSHOT",
         "commons-lang" % "commons-lang" % "2.6",
         "com.googlecode.java-diff-utils" % "diffutils" % "1.3.0"
       ) ++ Sensible.testLibs("it,test") ++ Sensible.shapeless(scalaVersion.value)


### PR DESCRIPTION
The 0.9.0 release had to be skipped because its OSGi configuration was
broken (see https://github.com/scala-ide/scala-refactoring/pull/138).