### PR TITLE
Adapt new behavior of add import refactoring in test suite

### DIFF
--- a/core/src/it/scala/org/ensime/core/RefactoringHandlerSpec.scala
+++ b/core/src/it/scala/org/ensime/core/RefactoringHandlerSpec.scala
@@ -243,7 +243,6 @@ class RefactoringHandlerSpec extends EnsimeSpec
         "package org.ensime.testing",
         "",
         "import java.lang.Integer",
-        "",
         "trait Temp {",
         "  valueOf(5)",
         "  vo(\"5\")",


### PR DESCRIPTION
scala-refactoring no longer prints new lines after in the add import
refactoring. See PR https://github.com/scala-ide/scala-refactoring/pull/139

----

We may rethink the decision to no longer print new lines in the add refactoring import but it is more likely that we stay with the decision to run the organize import refactoring afterwards to do the cleanups. Anyway, these are the problems one gets when depending on snapshots. Feel free to go back to the latest final version of scala-refactoring if you don't want to deal with these issues.