### PR TITLE
Add foreign key to FqnSymbols table and use cascade delete for file r…

### DIFF
--- a/core/src/main/scala/org/ensime/indexer/SearchService.scala
+++ b/core/src/main/scala/org/ensime/indexer/SearchService.scala
@@ -41,6 +41,8 @@ class SearchService(
   /**
    * Changelog:
    *
+   * 1.2 - added foreign key to FqnSymbols.file with cascade delete
+   *
    * 1.0 - reverted index due to negative impact to startup time. The
    *       workaround to large scale deletions is to just nuke the
    *       .ensime_cache.
@@ -49,7 +51,7 @@ class SearchService(
    *
    * 1.0 - initial schema
    */
-  private val version = "1.0"
+  private val version = "1.2"
 
   private val index = new IndexService(config.cacheDir / ("index-" + version))
   private val db = new DatabaseService(config.cacheDir / ("sql-" + version))


### PR DESCRIPTION
This should help with https://github.com/ensime/ensime-server/issues/1321

inSetBind will bind positional parameters rather than having deletes use literal strings
Cascade deletes mean fewer round trips to the database to achieve the same result

@fommil the foreign key implicitly adds the index that seemed to slow things down for you last time I tried to fix this. You should test it again. My tests suggest no measurable slow-down on inserts.

A bigger win would come from noticing that directories were deleted on a ```clean``` and then doing something like ```delete from fileChecks where filename like 'dir%'``` instead of a filewatcher deleting a file at a time.
The server knows, because I see it logging that ```a watched base was deleted```. But it is much more work to wire that through.