### PR TITLE
Allow port file reading to handle newline

### DIFF
--- a/server/src/main/scala/org/ensime/server/PortUtil.scala
+++ b/server/src/main/scala/org/ensime/server/PortUtil.scala
@@ -2,7 +2,6 @@
 // Licence: http://www.gnu.org/licenses/gpl-3.0.en.html
 package org.ensime.server
 
-import java.io.{ PrintWriter, IOException }
 import org.ensime.util.file._
 
 import akka.event.slf4j.SLF4JLogging
@@ -10,19 +9,21 @@ import akka.event.slf4j.SLF4JLogging
 object PortUtil extends SLF4JLogging {
 
   def port(cacheDir: File, name: String): Option[Int] = {
-    val portfile = cacheDir / name
-    if (portfile.exists()) Some(portfile.readString().toInt)
-    else None
+    val portFile = cacheDir / name
+    if (portFile.exists())
+      Some(portFile.readString().trim.toInt)
+    else
+      None
   }
 
   def writePort(cacheDir: File, port: Int, name: String): Unit = {
-    val portfile = cacheDir / name
-    if (!portfile.exists()) {
-      log.info("creating portfile " + portfile)
-      portfile.createNewFile()
+    val portFile = cacheDir / name
+    if (!portFile.exists()) {
+      log.info("creating port file: " + portFile)
+      portFile.createNewFile()
     }
 
-    portfile.deleteOnExit() // doesn't work on Windows
-    portfile.writeString(port.toString)
+    portFile.deleteOnExit() // doesn't work on Windows
+    portFile.writeString(port.toString)
   }
 }


### PR DESCRIPTION
No ticket, as I failed to get round to creating one.
Several people have seen port files with a trailing newline which blows up the server reader.
The only actual change here is a ```.trim``` on the read port file contents.

I've taken the liberty of removing an unused import and changing a capitalisation which was offending me.
