### PR TITLE
Log env info on multiple lines instead of one

### DIFF
--- a/core/src/main/scala/org/ensime/config/Environment.scala
+++ b/core/src/main/scala/org/ensime/config/Environment.scala
@@ -3,8 +3,6 @@
 package org.ensime
 package config
 
-import java.net.{ JarURLConnection, URL }
-
 object Environment {
   def info: Seq[String] = Seq(
     "Environment:",

--- a/core/src/main/scala/org/ensime/config/Environment.scala
+++ b/core/src/main/scala/org/ensime/config/Environment.scala
@@ -6,17 +6,17 @@ package config
 import java.net.{ JarURLConnection, URL }
 
 object Environment {
-  def info: String = s"""
-    |Environment:
-    |  OS : $osVersion
-    |  Java : $javaVersion
-    |  Scala version: $scalaVersion
-    |  Ensime : $ensimeVersion
-    |  Built with Scala version: ${BuildInfo.scalaVersion}
-    |  Built with sbt version: ${BuildInfo.sbtVersion}
-    |  Built from git sha: ${BuildInfo.gitSha}
-    |  Built on: ${BuildInfo.builtAtString}
-  """.trim.stripMargin
+  def info: Seq[String] = Seq(
+    "Environment:",
+    s"  OS : $osVersion",
+    s"  Java : $javaVersion",
+    s"  Scala version: $scalaVersion",
+    s"  Ensime : $ensimeVersion",
+    s"  Built with Scala version: ${BuildInfo.scalaVersion}",
+    s"  Built with sbt version: ${BuildInfo.sbtVersion}",
+    s"  Built from git sha: ${BuildInfo.gitSha}",
+    s"  Built on: ${BuildInfo.builtAtString}"
+  )
 
   private def osVersion: String =
     System.getProperty("os.name")

--- a/server/src/main/scala/org/ensime/server/Server.scala
+++ b/server/src/main/scala/org/ensime/server/Server.scala
@@ -81,7 +81,7 @@ class ServerActor(
         }
     }(context.system.dispatcher)
 
-    log.info(Environment.info)
+    Environment.info foreach log.info
   }
 
   override def preStart(): Unit = {


### PR DESCRIPTION
Fixes #1314

Test (hopefully) to follow, meanwhile here's the manual before-and-after test:

before:

    11:41:06.772 INFO  akka://ENSIME/user/ensime-main o.e.s.ServerActor - Environment:
      OS : Mac OS X
      Java : Java HotSpot(TM) 64-Bit Server VM 24.80-b11, Java(TM) SE Runtime Environment 1.7.0_80-b15
      Scala version: version 2.11.7
      Ensime : 0.9.10-SNAPSHOT
      Built with Scala version: 2.11.7
      Built with sbt version: 0.

after:

    12:17:54.984 INFO  akka://ENSIME/user/ensime-main o.e.s.ServerActor - Environment:
    12:17:54.985 INFO  akka://ENSIME/user/ensime-main o.e.s.ServerActor -   OS : Mac OS X
    12:17:54.985 INFO  akka://ENSIME/user/ensime-main o.e.s.ServerActor -   Java : Java HotSpot(TM) 64-Bit Server VM 24.80-b11, Java(TM) SE Runtime Environment 1.7.0_80-b15
    12:17:54.985 INFO  akka://ENSIME/user/ensime-main o.e.s.ServerActor -   Scala version: version 2.11.7
    12:17:54.986 INFO  akka://ENSIME/user/ensime-main o.e.s.ServerActor -   Ensime : 0.9.10-SNAPSHOT
    12:17:54.986 INFO  akka://ENSIME/user/ensime-main o.e.s.ServerActor -   Built with Scala version: 2.11.7
    12:17:54.986 INFO  akka://ENSIME/user/ensime-main o.e.s.ServerActor -   Built with sbt version: 0.13.11
    12:17:54.987 INFO  akka://ENSIME/user/ensime-main o.e.s.ServerActor -   Built from git sha: 929245ceb51e51c8022050c948c8ed076db18f91
    12:17:54.987 INFO  akka://ENSIME/user/ensime-main o.e.s.ServerActor -   Built on: 2016-03-12 12:15:55.335