### PR TITLE
Bugfix 692

### DIFF
--- a/s-express/src/main/scala/org/ensime/sexp/Sexp.scala
+++ b/s-express/src/main/scala/org/ensime/sexp/Sexp.scala
@@ -57,9 +57,8 @@ object SexpNumber {
 object SexpList {
   def apply(els: Sexp*): Sexp = apply(els.toList)
 
-  def apply(els: List[Sexp]): Sexp = els match {
-    case Nil => SexpNil
-    case head :: tail => SexpCons(head, apply(tail))
+  def apply(els: List[Sexp]): Sexp = els.foldRight(SexpNil: Sexp) {
+    case (head, tail) => SexpCons(head, tail)
   }
 
   def unapply(sexp: Sexp): Option[List[Sexp]] =

--- a/s-express/src/main/scala/org/ensime/sexp/formats/ProductFormats.scala
+++ b/s-express/src/main/scala/org/ensime/sexp/formats/ProductFormats.scala
@@ -69,7 +69,11 @@ trait LowPriorityProductFormats {
 
     def write(x: T): Sexp =
       if (keys.isEmpty) SexpNil
-      else SexpData(keys zip r.value.write(g.to(x)))
+      else {
+        val pairs = keys zip r.value.write(g.to(x))
+        if (skipNilValues) SexpData(pairs.filterNot(_._2 == SexpNil))
+        else SexpData(pairs)
+      }
 
     def read(value: Sexp): T = value match {
       case SexpNil => g.from(r.value.read(Nil))
@@ -87,6 +91,8 @@ trait LowPriorityProductFormats {
 
   // capable of overloading for legacy formats
   def toWireName(field: String): String = field
+  // capable of overriding to skip nil values in writing out case classes fields
+  def skipNilValues: Boolean = false
 }
 
 trait ProductFormats extends LowPriorityProductFormats {

--- a/s-express/src/test/scala/org/ensime/sexp/SexpSpec.scala
+++ b/s-express/src/test/scala/org/ensime/sexp/SexpSpec.scala
@@ -4,6 +4,8 @@ package org.ensime.sexp
 
 import org.ensime.util.EnsimeSpec
 
+import scala.util.{ Success, Try }
+
 class SexpSpec extends EnsimeSpec {
 
   val foostring = SexpString("foo")
@@ -38,6 +40,12 @@ class SexpSpec extends EnsimeSpec {
       case SexpList(_) => fail()
       case _ =>
     }
+  }
+
+  it should "support a list with 1000000 elements" in {
+    val data = List.fill(1000000)(SexpChar('a'))
+    val res = Try(SexpList(data))
+    res shouldBe a[Success[Sexp]]
   }
 
   "SexpData" should "create from varargs" in {

--- a/s-express/src/test/scala/org/ensime/sexp/formats/ProductFormatsSpec.scala
+++ b/s-express/src/test/scala/org/ensime/sexp/formats/ProductFormatsSpec.scala
@@ -92,7 +92,12 @@ class CustomisedProductFormatsSpec extends FormatSpec
     with BasicFormats with StandardFormats with ProductFormats
     with CamelCaseToDashes {
 
+  trait SkippingEnabled extends ProductFormats {
+    override val skipNilValues = true
+  }
+
   case class Foo(AThingyMaBob: Int, HTML: String)
+  case class Bar(num: Int, str: Option[String])
 
   "ProductFormats with overloaded toWireName" should "support custom field names" in {
     assertFormat(Foo(13, "foo"), SexpData(
@@ -100,4 +105,20 @@ class CustomisedProductFormatsSpec extends FormatSpec
       SexpSymbol(":h-t-m-l") -> SexpString("foo")
     ))
   }
+
+  "ProductFormats" should "not skip writing out nil values by default" in {
+    val wobble = Bar(13, None)
+    assertFormat(wobble, SexpData(
+      SexpSymbol(":num") -> SexpNumber(13),
+      SexpSymbol(":str") -> SexpNil
+    ))
+  }
+
+  "ProductFormats with overloaded skipNilValues" should "support writing out only non-nil values" in new SkippingEnabled {
+    val wobble = Bar(13, None)
+    assertFormat(wobble, SexpData(
+      SexpSymbol(":num") -> SexpNumber(13)
+    ))
+  }
 }
+


### PR DESCRIPTION
This PR fixes:
 - `SexpList` apply should have a tail recursive instead of recurse that could blow up the stack
 - option not to write out case class fields that are `nil`

These can be found in issue #692 
@iyadi @konradwudkowski