### PR TITLE
Always write the port file message

### DIFF
--- a/server/src/main/scala/org/ensime/server/PortUtil.scala
+++ b/server/src/main/scala/org/ensime/server/PortUtil.scala
@@ -19,11 +19,12 @@ object PortUtil extends SLF4JLogging {
   def writePort(cacheDir: File, port: Int, name: String): Unit = {
     val portFile = cacheDir / name
     if (!portFile.exists()) {
-      log.info("creating port file: " + portFile)
       portFile.createNewFile()
     }
 
     portFile.deleteOnExit() // doesn't work on Windows
     portFile.writeString(port.toString)
+    // Some clients grep the log waiting for this file to be written - so always write the log message.
+    log.info("creating port file: " + portFile)
   }
 }


### PR DESCRIPTION
This is a quick fix - Sublime relies on the log message to notice that the server is ready for connection.
This change ensures the message is always written.