### PR TITLE
prioritise the user's classes in search results

### DIFF
--- a/api/src/main/scala/org/ensime/api/config.scala
+++ b/api/src/main/scala/org/ensime/api/config.scala
@@ -52,6 +52,9 @@ case class EnsimeConfig(
     }.toSet
   } ++ javaLibs
 
+  val allTargets: Set[File] =
+    subprojects.flatMap(sm => sm.targets ::: sm.testTargets).toSet
+
   def allDocJars: Set[File] = modules.values.flatMap(_.docJars).toSet
 
   def scalaLibrary: Option[File] = allJars.find(_.getName.startsWith("scala-library"))

--- a/core/src/it/scala/org/ensime/indexer/SearchServiceSpec.scala
+++ b/core/src/it/scala/org/ensime/indexer/SearchServiceSpec.scala
@@ -158,6 +158,21 @@ class SearchServiceSpec extends EnsimeSpec
     hits.head shouldBe "org.example2.Baz"
   }
 
+  it should "return user created classes first" in withSearchService { implicit service =>
+    val hits = service.searchClasses("File", 10).map(_.fqn)
+    hits.head should startWith("org.boost.File")
+    hits should contain("java.io.File")
+
+    val hits2 = service.searchClasses("Function1", 25).map(_.fqn)
+    hits2.head should startWith("org.boost.Function1")
+    hits2 should contain("scala.Function1")
+  }
+
+  it should "return user methods first" in withSearchService { implicit service =>
+    val hits = service.searchClassesMethods("toString" :: Nil, 10).map(_.fqn)
+    all(hits) should startWith regex ("org.example|org.boost")
+  }
+
   "exact searches" should "find type aliases" in withSearchService { implicit service =>
     service.findUnique("org.scalatest.fixture.ConfigMapFixture$FixtureParam") shouldBe defined
   }

--- a/core/src/main/scala/org/ensime/indexer/DatabaseService.scala
+++ b/core/src/main/scala/org/ensime/indexer/DatabaseService.scala
@@ -2,7 +2,6 @@
 // Licence: http://www.gnu.org/licenses/gpl-3.0.en.html
 package org.ensime.indexer
 
-import java.io.File
 import java.sql.Timestamp
 
 import akka.event.slf4j.SLF4JLogging
@@ -12,6 +11,7 @@ import org.ensime.indexer.DatabaseService._
 
 import org.ensime.api._
 import org.ensime.vfs._
+import org.ensime.util.file._
 
 import scala.concurrent._
 import scala.concurrent.duration._

--- a/core/src/main/scala/org/ensime/indexer/IndexService.scala
+++ b/core/src/main/scala/org/ensime/indexer/IndexService.scala
@@ -84,13 +84,17 @@ class IndexService(path: File) {
 
   private val lucene = new SimpleLucene(path, analyzers)
 
-  def persist(check: FileCheck, symbols: List[FqnSymbol], commit: Boolean): Unit = {
+  def persist(check: FileCheck, symbols: List[FqnSymbol], commit: Boolean, boost: Boolean): Unit = {
     val f = Some(check)
     val fqns: List[Document] = symbols.map {
       case FqnSymbol(_, _, _, fqn, Some(_), _, _, _, _) => MethodIndex(fqn, f).toDocument
       case FqnSymbol(_, _, _, fqn, _, Some(_), _, _, _) => FieldIndex(fqn, f).toDocument
       case FqnSymbol(_, _, _, fqn, _, _, _, _, _) => ClassIndex(fqn, f).toDocument
     }
+    if (boost) {
+      fqns foreach { _.boostText("fqn", 1.1f) }
+    }
+
     lucene.create(fqns, commit)
   }
 

--- a/core/src/main/scala/org/ensime/indexer/lucene/package.scala
+++ b/core/src/main/scala/org/ensime/indexer/lucene/package.scala
@@ -32,5 +32,9 @@ package object lucene {
 
   implicit class RichDocument(d: Document) {
     def toEntity[T](implicit p: DocumentRecovery[T]) = p.toEntity(d)
+
+    def boostText(f: String, boost: Float) = {
+      d.getField(f).asInstanceOf[TextField].setBoost(boost)
+    }
   }
 }

--- a/testing/simple/src/main/scala/org/boost/Effs.scala
+++ b/testing/simple/src/main/scala/org/boost/Effs.scala
@@ -1,0 +1,5 @@
+package org.boost
+
+case class File()
+
+case class Function1()


### PR DESCRIPTION
This partially addresses #355, but only provides a partial ordering rather than the total ordering of symbols suggested in the ticket.

The implemented solution first boosts any symbols stored beneath the root director (but not in the cache) to ensure Lucene returns them at the top of it's query results (assuming a normal score-based result order). However, the final result set is actually extracted from the SQL Db, so I also had to implement an ordering for those results based on whether files should have been boosted. It's a little ugly, but does the trick.

The end result is that your own project files which match the search request are returned at the top of the results, followed by everything else.

I had some trouble writing integration tests for this because of how the it config paths are structured. If you'd like me to add an integration test I wouldn't mind a bit of guidance on the integration testing setup.