### PR TITLE
Update to scala-refactoring 0.10.0-SNAPSHOT

### DIFF
--- a/core/src/it/scala/org/ensime/core/RefactoringHandlerSpec.scala
+++ b/core/src/it/scala/org/ensime/core/RefactoringHandlerSpec.scala
@@ -243,6 +243,7 @@ class RefactoringHandlerSpec extends EnsimeSpec
         "package org.ensime.testing",
         "",
         "import java.lang.Integer",
+        "",
         "trait Temp {",
         "  valueOf(5)",
         "  vo(\"5\")",

--- a/project/EnsimeBuild.scala
+++ b/project/EnsimeBuild.scala
@@ -156,7 +156,7 @@ object EnsimeBuild extends Build {
         "org.scala-lang" % "scalap" % scalaVersion.value,
         "com.typesafe.akka" %% "akka-actor" % Sensible.akkaVersion,
         "com.typesafe.akka" %% "akka-slf4j" % Sensible.akkaVersion,
-        "org.scala-refactoring" %% "org.scala-refactoring.library" % "0.9.1-SNAPSHOT",
+        "org.scala-refactoring" %% "org.scala-refactoring.library" % "0.10.0-SNAPSHOT",
         "commons-lang" % "commons-lang" % "2.6",
         "com.googlecode.java-diff-utils" % "diffutils" % "1.3.0"
       ) ++ Sensible.testLibs("it,test") ++ Sensible.shapeless(scalaVersion.value)


### PR DESCRIPTION
Just a small behavior change: scala-refactoring now creates (as it did
in the 0.8 era) empty lines between import lists and class declarations.