### PR TITLE
Use sbt-catalysts with a little cleanup of sbt build files.

### DIFF
--- a/project/EnsimeDeps.scala
+++ b/project/EnsimeDeps.scala
@@ -1,0 +1,68 @@
+package org
+package ensime
+package ensimeserver
+
+import sbt._
+import sbtcatalysts.CatalystsPlugin.autoImport._
+
+object Dependencies {
+
+  val akkaVersion = "2.3.14"
+  val guavaVersion = "19.0"
+  val logbackVersion = "1.7.16"
+  val luceneVersion = "4.7.2"
+  val quasiquotesVersion = "2.0.1"
+  val scalaModulesVersion = "1.0.4"
+  val scalatestVersion = "2.2.6"
+  val streamsVersion = "1.0"
+
+
+  // Versions for libraries and packages
+  // Package -> version
+  val versions = Map[String, String](
+    "akka"                        -> akkaVersion,
+    "scalatest"                   -> scalatestVersion,
+    "scalamock-scalatest-support" -> "3.2.2"
+  )
+
+  // library definitions and links to their versions
+  // Note that one version may apply to more than one library.
+  // Library name -> version key, org, library
+  val libraries = Map[String, (String, String, String)](
+    "akka-testkit"                -> ("akka"                        , "com.typesafe.akka" , "akka-testkit"),
+    "akka-slf4j"                  -> ("akka"                        , "com.typesafe.akka" , "akka-slf4j"),
+    "scalamock-scalatest-support" -> ("scalamock-scalatest-support" , "org.scalamock"     , "scalamock-scalatest-support")
+  )
+
+  // compiler plugins definitions and links to their versions
+  // Note that one version may apply to more than one plugin.
+  // Library name -> version key, org, librar, crossVersion
+  val scalacPlugins = Map[String, (String, String, String, CrossVersion)](
+  )
+
+  val macroParadise = Seq(
+    compilerPlugin("org.scalamacros" % "paradise" % "2.0.1" cross CrossVersion.full)
+  )
+
+  def shapeless(scalaVersion: String) = {
+    if (scalaVersion.startsWith("2.10.")) macroParadise
+    else Nil
+  } :+ "com.chuusai" %% "shapeless" % "2.3.0"
+
+  val logback = Seq(
+    "ch.qos.logback" % "logback-classic" % "1.1.5",
+    "org.slf4j" % "slf4j-api" % logbackVersion,
+    "org.slf4j" % "jul-to-slf4j" % logbackVersion,
+    "org.slf4j" % "jcl-over-slf4j" % logbackVersion
+  )
+
+  val guava = Seq(
+    "com.google.guava" % "guava" % guavaVersion,
+    "com.google.code.findbugs" % "jsr305" % "3.0.1" % "provided"
+  )
+
+  val commonsVfs2 = Seq(
+    "org.apache.commons" % "commons-vfs2" % "2.0" exclude ("commons-logging", "commons-logging")
+  )
+
+}

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,3 +1,8 @@
+resolvers += Resolver.url(
+  "typelevel-sbt-plugins",
+  url("http://dl.bintray.com/content/typelevel/sbt-plugins"))(
+  Resolver.ivyStylePatterns)
+
 // ensime-sbt is needed for the integration tests
 addSbtPlugin("org.ensime" % "ensime-sbt" % "0.4.0")
 
@@ -23,3 +28,5 @@ scalacOptions in Compile ++= Seq("-feature", "-deprecation")
 ivyLoggingLevel := UpdateLogging.Quiet
 
 addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.6.0")
+
+addSbtPlugin("org.typelevel" % "sbt-catalysts" % "0.1.9")


### PR DESCRIPTION
Closes: https://github.com/ensime/ensime-server/issues/1222

-added sbt-catalysts with uses in some placec
-removed some redundant settings
-created `EnsimeDeps` with a dependency map required by sbt-catalysts and moved all common dependency settings there from `EnsimeBuild` and `SensibleSettings`

Unfortunetely for a lot of repeated occurrences of dependencies we can't use sbt-catalysts helper functions because of lack of functionalities in sbt-catalysts:
https://github.com/InTheNow/sbt-catalysts/issues/28
https://github.com/InTheNow/sbt-catalysts/issues/29
https://github.com/InTheNow/sbt-catalysts/issues/30

@fommil please review it and if you will find some time tell me what you think about sbt-catalysts and these aformentioned functionalities

@InTheNow could you look at this too and tell me if maybe I missed something else in sbt-catalysts that we could use here? And please take a look at this issues that I proposed, if you want them and I will find some time I could try to do it.