### PR TITLE
Removed TODOs and FIXMEs. Adding new TODO/FIXME will fail CI.

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -7,6 +7,10 @@ build:
     - EMACS=/opt/emacs-24.5/bin/emacs
     - AKKA_TEST_TIMEFACTOR=10
   commands:
+    - if grep -rlE 'TODO|FIXME' . | grep -Ev 'target|.git|.drone.yml' > /dev/null; then
+        echo "Please remove TODO or FIXME. Create an issue at GitHub instead." ;
+        exit 1 ;
+      fi
     - git log | head -n 20
     - sbt ++$SCALA_VERSION gen-ensime ;
       sbt ++$SCALA_VERSION clean test:compile it:compile doc ;

--- a/.drone.yml
+++ b/.drone.yml
@@ -7,7 +7,7 @@ build:
     - EMACS=/opt/emacs-24.5/bin/emacs
     - AKKA_TEST_TIMEFACTOR=10
   commands:
-    - if git grep -E 'TODO|FIXME' . | grep -v '.drone.yml' > /dev/null; then
+    - if git grep -E 'TODO|FIXME' -- './*' ':!.drone.yml'; then
         echo "Please remove TODO or FIXME. Create an issue at GitHub instead." ;
         exit 1 ;
       fi

--- a/.drone.yml
+++ b/.drone.yml
@@ -7,7 +7,7 @@ build:
     - EMACS=/opt/emacs-24.5/bin/emacs
     - AKKA_TEST_TIMEFACTOR=10
   commands:
-    - if grep -rlE 'TODO|FIXME' . | grep -Ev 'target|.git|.drone.yml' > /dev/null; then
+    - if git grep -E 'TODO|FIXME' . | grep -v '.drone.yml' > /dev/null; then
         echo "Please remove TODO or FIXME. Create an issue at GitHub instead." ;
         exit 1 ;
       fi

--- a/core/src/it/scala/org/ensime/core/DocFindingSpec.scala
+++ b/core/src/it/scala/org/ensime/core/DocFindingSpec.scala
@@ -81,8 +81,6 @@ class DocFindingSpec extends EnsimeSpec
           case "13" => sig.java shouldBe DocSig(DocFqn("com.google.common.io", "Files"), Some("map(java.io.File, java.nio.channels.FileChannel.MapMode)"))
           case "14" => sig.java shouldBe DocSig(DocFqn("com.google.common.io", "Files"), Some("map(java.io.File, java.nio.channels.FileChannel.MapMode, long)"))
           case "15" => sig.java shouldBe DocSig(DocFqn("com.google.common.io", "Files"), Some("write(byte[], java.io.File)"))
-          // TODO(fix this hack) - just goes to the class itself if companion
-          // constructor is requested.
           case "16" => sig.java shouldBe DocSig(DocFqn("scala", "Some"), None)
           case "17" => sig.java shouldBe DocSig(DocFqn("java.lang", "String"), None)
           case "18" => sig.scala shouldBe DocSig(DocFqn("scala", "Int"), None)
@@ -94,10 +92,6 @@ class DocFindingSpec extends EnsimeSpec
           case "25" => sig.java shouldBe DocSig(DocFqn("java.util", "Map.Entry"), None)
           case "26" => sig.java shouldBe DocSig(DocFqn("java.util", "package"), None)
           case "27" => sig.java shouldBe DocSig(DocFqn("scala.collection", "package"), None)
-          // TODO: Would be nice to be able to inspect a particular constructor. The problem is that
-          // symbolAt returns the type itself when point is in 'File', and it's not totally clear
-          // that's wrong.
-          //            case "28" => sig.java shouldBe DocSig("java.io.File", Some("File(java.lang.String, java.lang.String)")
           case "28" => sig.scala shouldBe DocSig(DocFqn("scala", "package"), Some("Exception=Exception"))
 
           // Check @usecase handling.

--- a/core/src/it/scala/org/ensime/core/JavaCompilerSpec.scala
+++ b/core/src/it/scala/org/ensime/core/JavaCompilerSpec.scala
@@ -134,10 +134,6 @@ class JavaCompilerSpec extends EnsimeSpec
             info.localName shouldBe "compute"
             info.`type`.name shouldBe "()int"
             info.isCallable shouldBe true
-            // NOTE: we should find an OffsetSourcePosition here as the source enters
-            // the compiler's working set in case "5" above.
-            // TODO - However if the 'element' is not found, we'll fall through to indexer lookup.
-            // look into more exhaustive ways of finding the element.
             info.declPos should matchPattern {
               case Some(LineSourcePosition(f, 8)) if f.getName == "Test2.java" =>
               case Some(OffsetSourcePosition(f, 48)) if f.getName == "Test2.java" =>

--- a/core/src/it/scala/org/ensime/core/RichPresentationCompilerSpec.scala
+++ b/core/src/it/scala/org/ensime/core/RichPresentationCompilerSpec.scala
@@ -222,7 +222,6 @@ class RichPresentationCompilerSpec extends EnsimeSpec
     }
     verify("java.lang.String", Some("startsWith"), None, "startsWith", "startsWith", DeclaredAs.Nil)
     verify("java.lang.String", None, None, "String", "java.lang.String", DeclaredAs.Class)
-    // TODO: should not be getting 'nil for declaredAs.
     verify("scala.Option", Some("wait"), Some("(x$1: Long,x$2: Int): Unit"),
       "wait", "wait", DeclaredAs.Nil)
     verify("scala.Option", Some("wait"), Some("(x$1: Long): Unit"),

--- a/core/src/it/scala/org/ensime/core/SemanticHighlightingSpec.scala
+++ b/core/src/it/scala/org/ensime/core/SemanticHighlightingSpec.scala
@@ -76,7 +76,6 @@ class SemanticHighlightingSpec extends EnsimeSpec
           """,
       List(ConstructorSymbol)
     )
-    // TODO It would be better if the "new" was consistent.
     sds should ===(List(
       (ConstructorSymbol, "X1"),
       (ConstructorSymbol, "new X1(  )"),
@@ -221,7 +220,6 @@ class SemanticHighlightingSpec extends EnsimeSpec
       (ObjectSymbol, "A"),
       (ObjectSymbol, "B"),
       (ObjectSymbol, "D"),
-      // TODO two problems there: "c" should be a varField ; E should be highlighted.
       (ObjectSymbol, "c")
     ))
   }
@@ -237,7 +235,6 @@ class SemanticHighlightingSpec extends EnsimeSpec
           """,
       List(OperatorFieldSymbol)
     )
-    // TODO We should highlight the "+="
     sds should ===(List(
       (OperatorFieldSymbol, "+"),
       (OperatorFieldSymbol, "*")

--- a/core/src/it/scala/org/ensime/intg/BasicWorkflow.scala
+++ b/core/src/it/scala/org/ensime/intg/BasicWorkflow.scala
@@ -101,7 +101,6 @@ class BasicWorkflow extends EnsimeSpec
 
           log.info("------------------------------------222-")
 
-          // FIXME: doing a fresh typecheck is needed to pass the next few tests. Why?
           project ! TypecheckFilesReq(List(Left(fooFile)))
           expectMsg(VoidResponse)
 
@@ -196,8 +195,6 @@ class BasicWorkflow extends EnsimeSpec
           project ! ExpandSelectionReq(fooFile, 214, 217)
           val expandRange2 = expectMsgType[FileRange]
           expandRange2 shouldBe FileRange(fooFilePath, 210, 229)
-
-          // TODO get the before content of the file
 
           project ! RefactorReq(1234, RenameRefactorDesc("bar", fooFile, 215, 215), false)
           expectMsgPF() {

--- a/core/src/it/scala/org/ensime/intg/DebugTest.scala
+++ b/core/src/it/scala/org/ensime/intg/DebugTest.scala
@@ -29,9 +29,6 @@ class DebugTest extends EnsimeSpec
     javaLibs = Nil // no need to index the JRE
   )
 
-  // TODO This is broken because step in our case is stepping into
-  // the classloader for inner class rather than doing a user
-  // visible step.
   "Debug - stepping" should "handle basic stepping" ignore {
     withEnsimeConfig { implicit config =>
       withTestKit { implicit testkit =>

--- a/core/src/main/java/org/ensime/core/javac/TreeUtilities.java
+++ b/core/src/main/java/org/ensime/core/javac/TreeUtilities.java
@@ -619,7 +619,6 @@ public final class TreeUtilities {
                     if (remaped != null) {
                         sb.append(remaped);
                     } else {
-                        //TODO: illegal?
                         sb.append(text.charAt(c));
                     }
                 }

--- a/core/src/main/scala/org/ensime/config/ScalariformFormat.scala
+++ b/core/src/main/scala/org/ensime/config/ScalariformFormat.scala
@@ -9,8 +9,6 @@ import scalariform.formatter.preferences._
 trait ScalariformFormat {
   this: BasicFormats =>
 
-  // TODO sexp formatting should live in server.protocol
-
   implicit object FormattingPreferencesFormat extends SexpFormat[FormattingPreferences] {
 
     private def key(d: PreferenceDescriptor[_]) = SexpSymbol(":" + d.key)

--- a/core/src/main/scala/org/ensime/core/JavaAnalyzer.scala
+++ b/core/src/main/scala/org/ensime/core/JavaAnalyzer.scala
@@ -50,7 +50,6 @@ class JavaAnalyzer(
     // no way to stop the java compiler
   }
 
-  // TODO: create a sealed family of requests / responses just for Java usage
   override def receive = {
     case TypecheckFileReq(sfi) =>
       javaCompiler.askTypecheckFiles(sfi :: Nil)

--- a/core/src/main/scala/org/ensime/core/Project.scala
+++ b/core/src/main/scala/org/ensime/core/Project.scala
@@ -34,13 +34,10 @@ class Project(
   private var javac: ActorRef = _
   private var debugger: ActorRef = _
 
-  // TODO consolidate search/indexer
   private var indexer: ActorRef = _
   private var docs: ActorRef = _
 
-  // TODO: use state transitions to manage this state
   // vfs, resolver, search and watchers are considered "reliable" (hah!)
-  // TODO: Actor-ise as many of these vals as possible
   private implicit val vfs: EnsimeVFS = EnsimeVFS()
   private val resolver = new SourceResolver(config)
   private val searchService = new SearchService(config, resolver)

--- a/core/src/main/scala/org/ensime/core/SemanticHighlighting.scala
+++ b/core/src/main/scala/org/ensime/core/SemanticHighlighting.scala
@@ -145,14 +145,6 @@ class SemanticHighlighting(val global: RichPresentationCompiler) extends Compile
             case TypeTree() =>
               if (!qualifySymbol(sym)) {
                 if (t.tpe != null) {
-                  // TODO:
-                  // This case occurs when
-                  // pattern matching on
-                  // case classes.
-                  // As in:
-                  // case MyClass(a:Int,b:Int)
-                  //
-                  // Works, but this is *way* under-constrained.
                   val start = treeP.startOrCursor
                   val end = treeP.endOrCursor
                   addAt(start, end, ObjectSymbol)

--- a/core/src/main/scala/org/ensime/core/debug/DebugManager.scala
+++ b/core/src/main/scala/org/ensime/core/debug/DebugManager.scala
@@ -29,7 +29,6 @@ class DebugManager(
     config: EnsimeConfig
 ) extends Actor with ActorLogging {
 
-  // TODO this is built once on startup - probably makes sense for it to be done each time a debug vm is created
   private var sourceMap = new SourceMap(config)
 
   private var activeBreakpoints = Set[Breakpoint]()

--- a/core/src/main/scala/org/ensime/core/debug/MonitorOutput.scala
+++ b/core/src/main/scala/org/ensime/core/debug/MonitorOutput.scala
@@ -15,8 +15,6 @@ private class MonitorOutput(val inStream: InputStream, broadcaster: ActorRef) ex
 
   @volatile var finished = false
 
-  // TODO This should have a stop method
-
   override def run(): Unit = {
     val buf = new Array[Char](512)
 

--- a/core/src/main/scala/org/ensime/core/debug/VMEventManager.scala
+++ b/core/src/main/scala/org/ensime/core/debug/VMEventManager.scala
@@ -11,8 +11,6 @@ class VMEventManager(val eventQueue: EventQueue, debugManager: ActorRef) extends
 
   val log = LoggerFactory.getLogger("VMEventManager")
 
-  // TODO needs proper stop method with interrupt
-
   @volatile var finished = false
   override def run(): Unit = {
     while (!finished) {

--- a/core/src/main/scala/org/ensime/core/javac/JavaCompiler.scala
+++ b/core/src/main/scala/org/ensime/core/javac/JavaCompiler.scala
@@ -56,7 +56,6 @@ class JavaCompiler(
     val fileManager = sharedFileManager match {
       case Some(fm) => fm
       case _ =>
-        // TODO: take a charset for each invocation
         val fm = compiler.getStandardFileManager(listener, null, DefaultCharset)
         sharedFileManager = Some(fm)
         fm

--- a/core/src/main/scala/org/ensime/core/javac/JavaCompletion.scala
+++ b/core/src/main/scala/org/ensime/core/javac/JavaCompletion.scala
@@ -69,7 +69,6 @@ trait JavaCompletion extends Helpers with SLF4JLogging {
         }
       })
     } else if (isMemberAccess) {
-      // TODO how to avoid allocating a new string? buffer of immutable string slices?
       // Erase the trailing partial member (it breaks type resolution).
       val patched = s.substring(0, indexAfterTarget) + ".wait()" + s.substring(indexAfterTarget + defaultPrefix.length + 1);
       (pathToPoint(SourceFileInfo(info.file, Some(patched), None), indexAfterTarget + 1) flatMap {

--- a/core/src/main/scala/org/ensime/core/javac/UnsafeHelpers.scala
+++ b/core/src/main/scala/org/ensime/core/javac/UnsafeHelpers.scala
@@ -32,8 +32,6 @@ trait UnsafeHelpers extends SLF4JLogging {
       case t: JCVariableDecl => Some(t.sym)
       case t: JCIdent => Some(t.sym)
       case t: JCFieldAccess => Some(t.sym)
-      // TODO: Workaround for java 6
-      //      case t: JCMemberReference => Some(t.sym)
       case t: JCNewClass => Some(t.constructor)
       case t: JCMethodInvocation => unsafeGetElement(info, t.meth)
       case t: JCTypeApply => unsafeGetElement(info, t.clazz)

--- a/core/src/main/scala/org/ensime/indexer/ClassfileIndexer.scala
+++ b/core/src/main/scala/org/ensime/indexer/ClassfileIndexer.scala
@@ -108,7 +108,6 @@ trait ClassfileIndexer {
   }
 
   // factors out much of the verbose code that looks for references to members
-  // TODO: we need a classesInSignature (which needs the ability to parse signature)
   private trait ReferenceInClassHunter {
     this: ClassVisitor =>
 

--- a/core/src/main/scala/org/ensime/indexer/DatabaseService.scala
+++ b/core/src/main/scala/org/ensime/indexer/DatabaseService.scala
@@ -54,9 +54,6 @@ class DatabaseService(dir: File) extends SLF4JLogging {
     log.info("... created the search database")
   }
 
-  // TODO hierarchy
-  // TODO reverse lookup table
-
   // file with last modified time
   def knownFiles(): Future[Seq[FileCheck]] = db.run(fileChecks.result)
 

--- a/core/src/main/scala/org/ensime/indexer/SearchService.scala
+++ b/core/src/main/scala/org/ensime/indexer/SearchService.scala
@@ -190,7 +190,6 @@ class SearchService(
         val source = resolver.resolve(clazz.name.pack, clazz.source)
         val sourceUri = source.map(_.getName.getURI)
 
-        // TODO: other types of visibility when we get more sophisticated
         if (clazz.access != Public) Nil
         else FqnSymbol(None, name, path, clazz.name.fqnString, None, None, sourceUri, clazz.source.line) ::
           clazz.methods.toList.filter(_.access == Public).map { method =>
@@ -206,7 +205,6 @@ class SearchService(
     }
   }.filterNot(sym => ignore.exists(sym.fqn.contains))
 
-  // TODO: provide context (user's current module and main/test)
   /** free-form search for classes */
   def searchClasses(query: String, max: Int): List[FqnSymbol] = {
     val fqns = index.searchClasses(query, max)

--- a/core/src/main/scala/org/ensime/indexer/domain.scala
+++ b/core/src/main/scala/org/ensime/indexer/domain.scala
@@ -115,7 +115,6 @@ case class Descriptor(params: List[DescriptorType], ret: DescriptorType) {
     "(" + params.map(_.internalString).mkString("") + ")" + ret.internalString
 }
 
-// TODO: replace generics Strings with domain objects
 case class RawClassfile(
   name: ClassName,
   generics: Option[String],

--- a/core/src/main/scala/org/ensime/indexer/lucene/SimpleLucene.scala
+++ b/core/src/main/scala/org/ensime/indexer/lucene/SimpleLucene.scala
@@ -80,8 +80,6 @@ class SimpleLucene(path: File, analyzers: Map[String, Analyzer]) extends SLF4JLo
   def search(query: Query, limit: Int): List[Document] = {
     val searcher = new IndexSearcher(reader())
 
-    // TODO: use FieldCacheTermsFilter for fast restriction by module
-
     val collector = TopScoreDocCollector.create(limit, true)
     searcher.search(query, collector)
 

--- a/core/src/main/scala/org/ensime/model/Helpers.scala
+++ b/core/src/main/scala/org/ensime/model/Helpers.scala
@@ -199,8 +199,6 @@ trait Helpers { self: Global =>
         Some(typeSym.outerClass)
       } else None
     } catch {
-      // TODO accessing outerClass sometimes throws java.lang.Error
-      // Notably, when tpe = scala.Predef$Class
       case e: java.lang.Error => None
     }
   }

--- a/core/src/main/scala/org/ensime/model/ModelBuilders.scala
+++ b/core/src/main/scala/org/ensime/model/ModelBuilders.scala
@@ -134,7 +134,6 @@ trait ModelBuilders { self: RichPresentationCompiler =>
       }
     }
 
-    // TODO THIS SHOULD NOT EXIST
     val nullInfo = new PackageInfo("NA", "NA", List.empty)
 
     private def sortedMembers(items: Iterable[EntityInfo]) = {
@@ -177,8 +176,6 @@ trait ModelBuilders { self: RichPresentationCompiler =>
     // use needPos=PosNeededYes sparingly as it potentially causes lots of I/O
     def apply(typ: Type, needPos: PosNeeded = PosNeededNo, members: Iterable[EntityInfo] = List.empty): TypeInfo = {
       val tpe = typ match {
-        // TODO: Instead of throwing away this information, would be better to
-        // alert the user that the type is existentially quantified.
         case et: ExistentialType => et.underlying
         case t => t
       }

--- a/core/src/main/scala/org/ensime/util/FileEditHelper.scala
+++ b/core/src/main/scala/org/ensime/util/FileEditHelper.scala
@@ -26,8 +26,4 @@ object FileEditHelper {
     val newContents = applyEdits(ch, source)
     DiffUtil.compareContents(source.lines.toSeq, newContents.lines.toSeq, originalFile, revisedFile)
   }
-
-  //TODO: add diffFromNewFile and diffFromDeleteFile
-  //def diffFromNewFile(ch: NewFile, source: String): String = ???
-  //def diffFromDeleteFile(ch: DeleteFile, source: String): String = ??
 }

--- a/core/src/main/scala/org/ensime/util/FileUtil.scala
+++ b/core/src/main/scala/org/ensime/util/FileUtil.scala
@@ -82,7 +82,6 @@ object FileUtils {
   }
 
   def writeDiffChanges(changes: List[FileEdit])(implicit cs: Charset): Either[Exception, File] = {
-    //TODO: add support for NewFile and DeleteFile
     val editsByFile = changes.collect { case ed: TextEdit => ed }.groupBy(_.file)
     try {
       val diffContents =

--- a/core/src/test/scala/org/ensime/indexer/ClassfileIndexerSpec.scala
+++ b/core/src/test/scala/org/ensime/indexer/ClassfileIndexerSpec.scala
@@ -12,8 +12,6 @@ class ClassfileIndexerSpec extends EnsimeSpec with IsolatedEnsimeVFSFixture {
   val indexer = new ClassfileIndexer with SLF4JLogging {}
   import indexer._
 
-  // TODO: some assertions (currently we're just checking that no exceptions are raised!)
-
   "ClassfileIndexer" should "support Java 6 class files" in withVFS { implicit vfs =>
     indexClassfile(vfs.vres("jdk6/Test.class"))
   }

--- a/project/SensibleSettings.scala
+++ b/project/SensibleSettings.scala
@@ -1,15 +1,13 @@
 // Copyright 2016 Sam Halliday
 // Licence: http://www.apache.org/licenses/LICENSE-2.0
-import scala.util.{ Properties, Try }
-import sbt._
-import Keys._
 import com.typesafe.sbt.SbtScalariform._
+import sbt.Keys._
+import sbt._
+
 import scala.util.Properties
 
 /**
  * A bunch of sensible defaults that fommil typically uses.
- *
- * TODO: integrate / contribute to the typelevel sbt plugin.
  */
 object Sensible {
 
@@ -70,7 +68,6 @@ object Sensible {
     ) ++ logback ++ guava ++ shapeless(scalaVersion.value)
   ) ++ inConfig(Test)(testSettings) ++ scalariformSettings
 
-  // TODO: scalariformSettingsWithIt generalised
   def testSettings = Seq(
     parallelExecution := true,
 
@@ -130,7 +127,6 @@ object Sensible {
     "com.google.code.findbugs" % "jsr305" % "3.0.1" % "provided"
   )
 
-  // TODO: automate testLibs as part of the testSettings
   def testLibs(config: String = "test") = Seq(
     "org.scalatest" %% "scalatest" % scalatestVersion % config,
     "org.scalamock" %% "scalamock-scalatest-support" % "3.2.2" % config,

--- a/s-express/src/test/scala/org/ensime/sexp/SexpParserCheck.scala
+++ b/s-express/src/test/scala/org/ensime/sexp/SexpParserCheck.scala
@@ -40,9 +40,6 @@ trait ArbitrarySexp {
   lazy val genSexpKey: Gen[SexpSymbol] =
     alphaStr.filter(_.nonEmpty).map { s => SexpSymbol(":" + s) }
 
-  // TODO: String/Char should be selected from a wider range
-  // TODO: arbitrary[BigDecimal] but it freezes the tests
-  // TODO: cons in SexpCons car, but it dramatically slows things
   lazy val genSexpAtom: Gen[SexpAtom] = oneOf(
     alphaNumChar.map(SexpChar),
     alphaStr.map(SexpString),

--- a/server/src/test/scala/org/ensime/server/WebSocketBoilerplateSpec.scala
+++ b/server/src/test/scala/org/ensime/server/WebSocketBoilerplateSpec.scala
@@ -40,8 +40,6 @@ class WebSocketBoilerplateSpec extends EnsimeSpec with SharedTestKitFixture {
 
     // it would be good to check that errors / closing will stop the
     // actor but that's perhaps testing the framework.
-
-    // TODO: use Streams TestKit as much as possible here
   }
 
   case class Foo(a: String)


### PR DESCRIPTION
Removed all TODOs and FIXMEs from code. 

I was unsure about two things connected with failing builds that are have TODO/FIXME.

1) Is so simple approach fine? Or maybe should our search be case insensitive? If so, the filter will have to be a little bit smarter since for example `toDoc` phrase appears in code.

2) Where TODO/FIXME are allowed? I bet that `.drone.yml` but what else? Is there any `.git` or `target` directory? In my local directory I could find TODO there.