### PR TITLE
Fixed not working git grep in .drone.yml

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -7,7 +7,7 @@ build:
     - EMACS=/opt/emacs-24.5/bin/emacs
     - AKKA_TEST_TIMEFACTOR=10
   commands:
-    - if git grep -E 'TODO|FIXME' -- './*' ':!.drone.yml'; then
+    - if $(git grep -qE "TODO|FIXME" -- `git ls-files | grep -v .drone.yml`) ; then
         echo "Please remove TODO or FIXME. Create an issue at GitHub instead." ;
         exit 1 ;
       fi

--- a/.drone.yml
+++ b/.drone.yml
@@ -15,7 +15,7 @@ build:
     - host `curl -s http://httpbin.org/ip | jq -r '.origin'` || true ;
     - sbt ++$SCALA_VERSION gen-ensime ;
       sbt ++$SCALA_VERSION clean test:compile it:compile doc ;
-      if [ $(git diff | wc -l) -ge 1 ] ; then
+      if $(! git diff --exit-code --quiet) ; then
         echo "Code formatting does not meet the project's standards:" ;
         git --no-pager diff ;
         exit 1 ;

--- a/core/src/main/scala/org/ensime/model/Helpers.scala
+++ b/core/src/main/scala/org/ensime/model/Helpers.scala
@@ -8,41 +8,41 @@ import org.ensime.api._
 
 trait Helpers { self: Global =>
 
-    import rootMirror.{ EmptyPackage, RootPackage }
+  import rootMirror.{ EmptyPackage, RootPackage }
 
-    def applySynonyms(sym: Symbol): List[Symbol] = {
-        val members = if (sym.isModule || sym.isModuleClass || sym.isPackageObject) {
-            sym.tpe.members
-        } else if (sym.isClass || sym.isPackageClass || sym.isPackageObjectClass) {
-            sym.companionModule.tpe.members
-        } else { List.empty }
-        members.toList.filter { _.name.toString == "apply" }
+  def applySynonyms(sym: Symbol): List[Symbol] = {
+    val members = if (sym.isModule || sym.isModuleClass || sym.isPackageObject) {
+      sym.tpe.members
+    } else if (sym.isClass || sym.isPackageClass || sym.isPackageObjectClass) {
+      sym.companionModule.tpe.members
+    } else { List.empty }
+    members.toList.filter { _.name.toString == "apply" }
+  }
+
+  def constructorSynonyms(sym: Symbol): List[Symbol] = {
+    val members = if (sym.isClass || sym.isPackageClass || sym.isPackageObjectClass) {
+      sym.tpe.members
+    } else if (sym.isModule || sym.isModuleClass || sym.isPackageObject) {
+      sym.companionClass.tpe.members
+    } else { List.empty }
+    members.toList.filter { _.isConstructor }
+  }
+
+  def isArrowType(tpe: Type): Boolean = {
+    tpe match {
+      case _: MethodType => true
+      case _: PolyType => true
+      case _ => false
     }
+  }
 
-    def constructorSynonyms(sym: Symbol): List[Symbol] = {
-        val members = if (sym.isClass || sym.isPackageClass || sym.isPackageObjectClass) {
-            sym.tpe.members
-        } else if (sym.isModule || sym.isModuleClass || sym.isPackageObject) {
-            sym.companionClass.tpe.members
-        } else { List.empty }
-            members.toList.filter { _.isConstructor }
+  def isNoParamArrowType(tpe: Type): Boolean = {
+    tpe match {
+      case t: MethodType => t.paramss.flatten.isEmpty
+      case t: PolyType => t.paramss.flatten.isEmpty
+      case t: Type => false
     }
-
-    def isArrowType(tpe: Type): Boolean = {
-        tpe match {
-            case _: MethodType => true
-            case _: PolyType => true
-            case _ => false
-        }
-    }
-
-      def isNoParamArrowType(tpe: Type): Boolean = {
-            tpe match {
-                  case t: MethodType => t.paramss.flatten.isEmpty
-                  case t: PolyType => t.paramss.flatten.isEmpty
-                  case t: Type => false
-            }
-      }
+  }
 
   def typeOrArrowTypeResult(tpe: Type): Type = {
     tpe match {

--- a/core/src/main/scala/org/ensime/model/Helpers.scala
+++ b/core/src/main/scala/org/ensime/model/Helpers.scala
@@ -10,6 +10,8 @@ trait Helpers { self: Global =>
 
   import rootMirror.{ EmptyPackage, RootPackage }
 
+  // TODO remove this todo
+
   def applySynonyms(sym: Symbol): List[Symbol] = {
     val members = if (sym.isModule || sym.isModuleClass || sym.isPackageObject) {
       sym.tpe.members

--- a/core/src/main/scala/org/ensime/model/Helpers.scala
+++ b/core/src/main/scala/org/ensime/model/Helpers.scala
@@ -8,43 +8,41 @@ import org.ensime.api._
 
 trait Helpers { self: Global =>
 
-  import rootMirror.{ EmptyPackage, RootPackage }
+    import rootMirror.{ EmptyPackage, RootPackage }
 
-  // TODO remove this todo
-
-  def applySynonyms(sym: Symbol): List[Symbol] = {
-    val members = if (sym.isModule || sym.isModuleClass || sym.isPackageObject) {
-      sym.tpe.members
-    } else if (sym.isClass || sym.isPackageClass || sym.isPackageObjectClass) {
-      sym.companionModule.tpe.members
-    } else { List.empty }
-    members.toList.filter { _.name.toString == "apply" }
-  }
-
-  def constructorSynonyms(sym: Symbol): List[Symbol] = {
-    val members = if (sym.isClass || sym.isPackageClass || sym.isPackageObjectClass) {
-      sym.tpe.members
-    } else if (sym.isModule || sym.isModuleClass || sym.isPackageObject) {
-      sym.companionClass.tpe.members
-    } else { List.empty }
-    members.toList.filter { _.isConstructor }
-  }
-
-  def isArrowType(tpe: Type): Boolean = {
-    tpe match {
-      case _: MethodType => true
-      case _: PolyType => true
-      case _ => false
+    def applySynonyms(sym: Symbol): List[Symbol] = {
+        val members = if (sym.isModule || sym.isModuleClass || sym.isPackageObject) {
+            sym.tpe.members
+        } else if (sym.isClass || sym.isPackageClass || sym.isPackageObjectClass) {
+            sym.companionModule.tpe.members
+        } else { List.empty }
+        members.toList.filter { _.name.toString == "apply" }
     }
-  }
 
-  def isNoParamArrowType(tpe: Type): Boolean = {
-    tpe match {
-      case t: MethodType => t.paramss.flatten.isEmpty
-      case t: PolyType => t.paramss.flatten.isEmpty
-      case t: Type => false
+    def constructorSynonyms(sym: Symbol): List[Symbol] = {
+        val members = if (sym.isClass || sym.isPackageClass || sym.isPackageObjectClass) {
+            sym.tpe.members
+        } else if (sym.isModule || sym.isModuleClass || sym.isPackageObject) {
+            sym.companionClass.tpe.members
+        } else { List.empty }
+            members.toList.filter { _.isConstructor }
     }
-  }
+
+    def isArrowType(tpe: Type): Boolean = {
+        tpe match {
+            case _: MethodType => true
+            case _: PolyType => true
+            case _ => false
+        }
+    }
+
+      def isNoParamArrowType(tpe: Type): Boolean = {
+            tpe match {
+                  case t: MethodType => t.paramss.flatten.isEmpty
+                  case t: PolyType => t.paramss.flatten.isEmpty
+                  case t: Type => false
+            }
+      }
 
   def typeOrArrowTypeResult(tpe: Type): Type = {
     tpe match {


### PR DESCRIPTION
Unfortunately, drone doesn't understand magic paths (`!` for `:(exclude)`) in `git grep`. That's why #1403 showed us that #1400 doesn't really work and needs a fix. That's why, we changed _.drone.yml_ to use the unix `grep` instead of path exclusion. 

Extra: Prettier `git diff` in `.drone_yml` (no more lines counting to find diffs).