### PR TITLE
Fix for #1281 - Documentation lookup for cats.data.Xor$$Right

### DIFF
--- a/core/src/it/scala/org/ensime/core/DocResolverSpec.scala
+++ b/core/src/it/scala/org/ensime/core/DocResolverSpec.scala
@@ -29,6 +29,16 @@ class DocResolverSpec extends EnsimeSpec
       )) shouldBe Some("docs/scala-library-" + c.scalaVersion + "-javadoc.jar/index.html#scala.Some@map[B](f:A=>B):Option[B]")
 
       serv.resolve(DocSigPair(
+        DocSig(DocFqn("scala", "Some"), None),
+        DocSig(DocFqn("scala", "Some"), None)
+      )) shouldBe Some("docs/scala-library-" + c.scalaVersion + "-javadoc.jar/index.html#scala.Some")
+
+      serv.resolve(DocSigPair(
+        DocSig(DocFqn("scala", "Some$"), None),
+        DocSig(DocFqn("scala", "Some"), None)
+      )) shouldBe Some("docs/scala-library-" + c.scalaVersion + "-javadoc.jar/index.html#scala.Some")
+
+      serv.resolve(DocSigPair(
         DocSig(DocFqn("com.google.common.io", "Files$"), Some("simplifyPath(x$1:String):String")),
         DocSig(DocFqn("com.google.common.io", "Files"), Some("simplifyPath(java.lang.String)"))
       )) shouldBe Some("docs/guava-18.0-javadoc.jar/com/google/common/io/Files.html#simplifyPath(java.lang.String)")


### PR DESCRIPTION
Fix for #1281

In some cases lookup of type return Object instead of Class, for example in
pattern matching:

`case Some(s) => ???`

type of `Some` is object, but there is no documentation for
`object Some`, only for `class Some`, so if we don't find documentation we
are looking for we try to find alternative documentation for class