### PR TITLE
Add Load/Unload Module

### DIFF
--- a/api/src/main/scala/org/ensime/api/incoming.scala
+++ b/api/src/main/scala/org/ensime/api/incoming.scala
@@ -51,6 +51,16 @@ final case class RemoveFileReq(file: File) extends RpcAnalyserRequest
 final case class TypecheckFileReq(fileInfo: SourceFileInfo) extends RpcAnalyserRequest
 
 /**
+ * Response with a `VoidResponse`.
+ */
+final case class UnloadModuleReq(module: String) extends RpcAnalyserRequest
+
+/**
+ * Response with a `VoidResponse`.
+ */
+final case class TypecheckModule(module: String) extends RpcAnalyserRequest
+
+/**
  * Responds with a `VoidResponse`.
  */
 case object UnloadAllReq extends RpcAnalyserRequest

--- a/core/src/it/scala/org/ensime/intg/BasicWorkflow.scala
+++ b/core/src/it/scala/org/ensime/intg/BasicWorkflow.scala
@@ -27,6 +27,16 @@ class BasicWorkflow extends EnsimeSpec
           val fooFilePath = fooFile.getAbsolutePath
           val barFile = sourceRoot / "org/example/Bar.scala"
 
+          // typeCheck module
+
+          project ! TypecheckModule("testingSimple")
+          expectMsg(VoidResponse)
+          asyncHelper.expectMsgType[NewScalaNotesEvent]
+          asyncHelper.expectMsgType[FullTypeCheckCompleteEvent.type]
+
+          project ! UnloadModuleReq("testingSimple")
+          expectMsg(VoidResponse)
+
           // trigger typeCheck
           project ! TypecheckFilesReq(List(Left(fooFile)))
           expectMsg(VoidResponse)
@@ -183,7 +193,7 @@ class BasicWorkflow extends EnsimeSpec
               BasicTypeInfo("Test1$", DeclaredAs.Object, "org.example.Test1$", List(), List(), None),
               BasicTypeInfo("Test2", DeclaredAs.Class, "org.example.Test2", List(), List(), None),
               BasicTypeInfo("Test2$", DeclaredAs.Object, "org.example.Test2$", List(), List(), None),
-              BasicTypeInfo("package$", DeclaredAs.Object, "org.example.package$", List(), List(), None),
+              //BasicTypeInfo("package$", DeclaredAs.Object, "org.example.package$", List(), List(), None),
               BasicTypeInfo("package$", DeclaredAs.Object, "org.example.package$", List(), List(), None))) =>
           }
 

--- a/core/src/it/scala/org/ensime/intg/BasicWorkflow.scala
+++ b/core/src/it/scala/org/ensime/intg/BasicWorkflow.scala
@@ -34,8 +34,14 @@ class BasicWorkflow extends EnsimeSpec
           asyncHelper.expectMsgType[NewScalaNotesEvent]
           asyncHelper.expectMsgType[FullTypeCheckCompleteEvent.type]
 
+          project ! TypeByNameReq("org.example.Bloo")
+          expectMsgType[BasicTypeInfo]
+
           project ! UnloadModuleReq("testingSimple")
           expectMsg(VoidResponse)
+
+          project ! TypeByNameReq("org.example.Bloo")
+          expectMsg(FalseResponse)
 
           // trigger typeCheck
           project ! TypecheckFilesReq(List(Left(fooFile)))

--- a/core/src/main/scala/org/ensime/config/package.scala
+++ b/core/src/main/scala/org/ensime/config/package.scala
@@ -7,11 +7,13 @@ import Predef.{ any2stringadd => _, _ => _ }
 import org.ensime.api._
 import org.ensime.util.file._
 
+import scala.collection.breakOut
+
 package object config {
 
   implicit class RichEnsimeConfig(val c: EnsimeConfig) extends AnyVal {
     def scalaSourceFiles: Set[File] =
-      c.modules.values.toSet.flatMap((m: EnsimeModule) => m.scalaSourceFiles)
+      c.modules.values.flatMap((m: EnsimeModule) => m.scalaSourceFiles)(breakOut)
   }
 
   implicit class RichEnsimeModule(val m: EnsimeModule) extends AnyVal {
@@ -19,7 +21,7 @@ package object config {
       val s = for {
         root <- m.sourceRoots
         file <- root.tree
-        if file.isFile && file.getName.endsWith(".scala")
+        if file.isFile && file.isScala
       } yield file
 
       s.toSet

--- a/core/src/main/scala/org/ensime/config/package.scala
+++ b/core/src/main/scala/org/ensime/config/package.scala
@@ -10,12 +10,19 @@ import org.ensime.util.file._
 package object config {
 
   implicit class RichEnsimeConfig(val c: EnsimeConfig) extends AnyVal {
-    def scalaSourceFiles: Set[File] = for {
-      module: EnsimeModule <- c.modules.values.toSet
-      root <- module.sourceRoots
-      file <- root.tree
-      if file.isFile && file.getName.endsWith(".scala")
-    } yield file
+    def scalaSourceFiles: Set[File] =
+      c.modules.values.toSet.flatMap((m: EnsimeModule) => m.scalaSourceFiles)
   }
 
+  implicit class RichEnsimeModule(val m: EnsimeModule) extends AnyVal {
+    def scalaSourceFiles: Set[File] = {
+      val s = for {
+        root <- m.sourceRoots
+        file <- root.tree
+        if file.isFile && file.getName.endsWith(".scala")
+      } yield file
+
+      s.toSet
+    }
+  }
 }

--- a/core/src/main/scala/org/ensime/core/Analyzer.scala
+++ b/core/src/main/scala/org/ensime/core/Analyzer.scala
@@ -16,6 +16,7 @@ import org.ensime.util.{ PresentationReporter, ReportHandler, FileUtils }
 import org.slf4j.LoggerFactory
 import org.ensime.util.file._
 
+import scala.collection.breakOut
 import scala.reflect.internal.util.{ OffsetPosition, RangePosition, SourceFile }
 import scala.tools.nsc.Settings
 import scala.tools.nsc.interactive.Global
@@ -179,7 +180,7 @@ class Analyzer(
       //consider the case of a project with no modules
       config.modules get (moduleName) foreach {
         case module =>
-          val files = module.scalaSourceFiles.map(SourceFileInfo(_, None, None)).toList
+          val files: List[SourceFileInfo] = module.scalaSourceFiles.map(SourceFileInfo(_, None, None))(breakOut)
           sender ! handleReloadFiles(files)
       }
     case UnloadModuleReq(moduleName) =>

--- a/core/src/test/scala/org/ensime/config/EnsimeConfigSpec.scala
+++ b/core/src/test/scala/org/ensime/config/EnsimeConfigSpec.scala
@@ -107,4 +107,5 @@ class EnsimeConfigSpec extends EnsimeSpec {
       }
     }
   }
+
 }


### PR DESCRIPTION
In #993 @fommil suggested taking the module name in with the request & loading the files from there. I couldn't find a straightforward way to get the ensime module name from a given source file, so ended I up adding code to the Analyzer (planning on factoring it out into the `config` package object though) that derives the module for a given file.

### Todo
- Better test coverage
- Factor out duplicate code in the Analyzer

Please let me know if you think this approach has legs.