### PR TITLE
akka http upgrade to 2.0.4

### DIFF
--- a/project/EnsimeBuild.scala
+++ b/project/EnsimeBuild.scala
@@ -167,7 +167,7 @@ object EnsimeBuild extends Build {
       )
 
   val luceneVersion = "4.7.2"
-  val streamsVersion = "1.0"
+  val streamsVersion = "2.0.4"
   lazy val server = Project("server", file("server")).dependsOn(
     core, swanky, jerky,
     s_express % "test->test",

--- a/project/SensibleSettings.scala
+++ b/project/SensibleSettings.scala
@@ -103,7 +103,6 @@ object Sensible {
 
   val scalaModulesVersion = "1.0.4"
   val akkaVersion = "2.3.14"
-  val streamsVersion = "1.0"
   val scalatestVersion = "2.2.6"
   val logbackVersion = "1.7.19"
   val quasiquotesVersion = "2.0.1"

--- a/server/src/main/scala/org/ensime/server/WebServer.scala
+++ b/server/src/main/scala/org/ensime/server/WebServer.scala
@@ -7,7 +7,7 @@ import java.io.File
 import akka.actor._
 import akka.http.scaladsl.marshallers.sprayjson.SprayJsonSupport
 import akka.http.scaladsl.marshallers.xml.ScalaXmlSupport
-import akka.http.scaladsl.model.{ HttpEntity, _ }
+import akka.http.scaladsl.model._
 import akka.http.scaladsl.server._
 import akka.stream._
 import akka.util.{ ByteString, Timeout }
@@ -73,10 +73,10 @@ trait WebServer {
       rejectEmptyResponse {
         complete {
           for {
-            media <- MediaTypes.forExtension(Files.getFileExtension(entry))
+            media <- MediaTypes.forExtensionOption(Files.getFileExtension(entry))
             content <- docJarContent(filename, entry)
           } yield {
-            HttpResponse(entity = HttpEntity(ContentType(media, None), content))
+            HttpResponse(entity = HttpEntity(ContentType(media, () => HttpCharsets.`UTF-8`), content))
           }
         }
       }

--- a/server/src/main/scala/org/ensime/server/WebSocketBoilerplate.scala
+++ b/server/src/main/scala/org/ensime/server/WebSocketBoilerplate.scala
@@ -77,13 +77,13 @@ object WebSocketBoilerplate {
   ): Flow[Incoming, Outgoing, Unit] = {
     val (target, pub) = Source.actorRef[Outgoing](
       0, OverflowStrategy.fail
-    ).toMat(Sink.publisher)(Keep.both).run()
-    val source = Source(pub)
+    ).toMat(Sink.asPublisher(false))(Keep.both).run()
+    val source = Source.fromPublisher(pub)
 
     val handler = actor(target)
     val sink = Sink.actorRef[Incoming](handler, PoisonPill)
 
-    Flow.wrap(sink, source)((_, _) => ())
+    Flow.fromSinkAndSourceMat(sink, source)((_, _) => ())
   }
 
   /**


### PR DESCRIPTION
Needed in #1414
Caveats:
1. Webserver.scala: in 2.0.4, ContentType.apply method has no version with optional HttpCharset, so I used HttpCharsets.UTF-8.
2. WebSocketBoilerplate.scala: in 2.0.4 Sink.asPublisher takes fanout: Boolean parameter, which decides if publisher supports multiple subscribers or not.  I've put false, not sure if that's correct.