### PR TITLE
upgrade to recent akka / akka-http

### DIFF
--- a/project/EnsimeBuild.scala
+++ b/project/EnsimeBuild.scala
@@ -167,7 +167,7 @@ object EnsimeBuild extends Build {
       )
 
   val luceneVersion = "4.7.2"
-  val streamsVersion = "1.0"
+  val streamsVersion = Sensible.akkaVersion
   lazy val server = Project("server", file("server")).dependsOn(
     core, swanky, jerky,
     s_express % "test->test",
@@ -181,12 +181,12 @@ object EnsimeBuild extends Build {
       commonSettings ++ commonItSettings
     ).settings(
         libraryDependencies ++= Seq(
-          "com.typesafe.akka" %% "akka-stream-experimental" % streamsVersion,
-          "com.typesafe.akka" %% "akka-http-core-experimental" % streamsVersion,
+          "com.typesafe.akka" %% "akka-stream" % streamsVersion,
+          "com.typesafe.akka" %% "akka-http-core" % streamsVersion,
           "com.typesafe.akka" %% "akka-http-experimental" % streamsVersion,
           "com.typesafe.akka" %% "akka-http-spray-json-experimental" % streamsVersion,
           "com.typesafe.akka" %% "akka-http-xml-experimental" % streamsVersion,
-          "com.typesafe.akka" %% "akka-http-testkit-experimental" % streamsVersion % "test,it"
+          "com.typesafe.akka" %% "akka-http-testkit" % streamsVersion % "test,it"
         ) ++ Sensible.testLibs("it,test") ++ Sensible.shapeless(scalaVersion.value)
       )
 

--- a/project/SensibleSettings.scala
+++ b/project/SensibleSettings.scala
@@ -64,7 +64,8 @@ object Sensible {
       "org.scala-lang.modules" %% "scala-xml" % scalaModulesVersion,
       "org.scala-lang.modules" %% "scala-parser-combinators" % scalaModulesVersion,
       "org.scalamacros" %% "quasiquotes" % quasiquotesVersion,
-      "org.scalatest" %% "scalatest" % scalatestVersion
+      "org.scalatest" %% "scalatest" % scalatestVersion,
+      "com.typesafe" % "config" % configVersion
     ) ++ logback ++ guava ++ shapeless(scalaVersion.value)
   ) ++ inConfig(Test)(testSettings) ++ scalariformSettings
 
@@ -102,12 +103,12 @@ object Sensible {
   )
 
   val scalaModulesVersion = "1.0.4"
-  val akkaVersion = "2.3.14"
-  val streamsVersion = "1.0"
+  val akkaVersion = "2.4.4"
   val scalatestVersion = "2.2.6"
   val logbackVersion = "1.7.19"
   val quasiquotesVersion = "2.0.1"
   val guavaVersion = "19.0"
+  val configVersion = "1.3.0"
 
   val macroParadise = Seq(
     compilerPlugin("org.scalamacros" % "paradise" % "2.0.1" cross CrossVersion.full)

--- a/server/src/main/scala/org/ensime/server/Server.scala
+++ b/server/src/main/scala/org/ensime/server/Server.scala
@@ -20,6 +20,7 @@ import org.ensime.server.tcp.TCPServer
 import org.slf4j._
 import org.slf4j.bridge.SLF4JBridgeHandler
 
+import scala.concurrent.Await
 import scala.concurrent.duration._
 import scala.util.Properties._
 import scala.util._
@@ -145,10 +146,10 @@ object Server {
           log.info(s"Shutdown requested: ${request.reason}")
 
         log.info("Shutting down the ActorSystem")
-        Try(system.shutdown())
+        Try(system.terminate())
 
         log.info("Awaiting actor system termination")
-        Try(system.awaitTermination())
+        Try(Await.ready(system.whenTerminated, Duration.Inf))
 
         log.info("Shutdown complete")
         if (!propIsSet("ensime.server.test")) {

--- a/server/src/main/scala/org/ensime/server/WebServer.scala
+++ b/server/src/main/scala/org/ensime/server/WebServer.scala
@@ -72,11 +72,11 @@ trait WebServer {
     } ~ path("docs" / """[^/]+\.jar""".r / Rest) { (filename, entry) =>
       rejectEmptyResponse {
         complete {
+          val media = MediaTypes.forExtension(Files.getFileExtension(entry))
           for {
-            media <- MediaTypes.forExtension(Files.getFileExtension(entry))
             content <- docJarContent(filename, entry)
           } yield {
-            HttpResponse(entity = HttpEntity(ContentType(media, None), content))
+            HttpResponse(entity = HttpEntity(ContentType(media, () => HttpCharsets.`UTF-8`), content))
           }
         }
       }


### PR DESCRIPTION
Here's a first approximation to update to a recent akka/akka-http version 2.4.4 (preliminary to #1414). It comes with all caveats that Akka 2.4 comes with, probably most importantly that it needs a JDK > 6. Is that a problem?