### PR TITLE
Set akka.http.server.idle-timeout to infinite

### DIFF
--- a/core/src/main/resources/application.conf
+++ b/core/src/main/resources/application.conf
@@ -35,4 +35,10 @@ akka {
       task-queue-size = -1
     }
   }
+  
+  http {
+    server {
+      idle-timeout = infinite
+    }
+  }
 }


### PR DESCRIPTION
To prevent the connection from being closed even if the ensime client does not send any messages to it's server for some time.