### PR TITLE
WIP reduce memory pressure during SearchService.refresh

### DIFF
--- a/core/src/main/scala/org/ensime/indexer/SearchService.scala
+++ b/core/src/main/scala/org/ensime/indexer/SearchService.scala
@@ -246,7 +246,7 @@ class SearchService(
     batchSize: Int = 1000
   ): Future[Int] = {
     val removing = files.grouped(batchSize).map(delete)
-    Future.sequence(removing).map(_.sum)(executor = ex)
+    Future.sequence(removing).map(_.sum)
   }
 
   // returns number of rows removed

--- a/core/src/main/scala/org/ensime/indexer/SearchService.scala
+++ b/core/src/main/scala/org/ensime/indexer/SearchService.scala
@@ -37,7 +37,7 @@ class SearchService(
     with SLF4JLogging {
 
   //Create a custom execution context that blocks the calling thread if no worker is available
-  private implicit val ex = BoundedExecutor.callerBlockingExecutor(4)
+  private val ex = BoundedExecutor.callerBlockingExecutor(4)
   private[indexer] def isUserFile(file: FileName): Boolean = {
     (config.allTargets map (vfs.vfile)) exists (file isAncestor _.getName)
   }
@@ -156,7 +156,7 @@ class SearchService(
   def refreshResolver(): Unit = resolver.update()
 
   def persist(check: FileCheck, symbols: List[FqnSymbol], commitIndex: Boolean, boost: Boolean): Future[Option[Int]] = {
-    val iwork = Future { blocking { index.persist(check, symbols, commitIndex, boost) } }(ex)
+    val iwork = Future { blocking { index.persist(check, symbols, commitIndex, boost) } }
     val dwork = db.persist(check, symbols)
     iwork.flatMap { _ => dwork }
   }
@@ -253,7 +253,7 @@ class SearchService(
   def delete(files: List[FileObject]): Future[Int] = {
     // this doesn't speed up Lucene deletes, but it means that we
     // don't wait for Lucene before starting the H2 deletions.
-    val iwork = Future { blocking { index.remove(files) } }(ex)
+    val iwork = Future { blocking { index.remove(files) } }
     val dwork = db.removeFiles(files)
     iwork.flatMap(_ => dwork)
   }

--- a/core/src/main/scala/org/ensime/util/ExecContexts.scala
+++ b/core/src/main/scala/org/ensime/util/ExecContexts.scala
@@ -2,7 +2,7 @@
 // Licence: http://www.gnu.org/licenses/gpl-3.0.en.html
 package org.ensime.util
 
-import java.util.concurrent._ 
+import java.util.concurrent._
 
 import scala.concurrent.ExecutionContext
 

--- a/core/src/main/scala/org/ensime/util/ExecContexts.scala
+++ b/core/src/main/scala/org/ensime/util/ExecContexts.scala
@@ -2,7 +2,7 @@
 // Licence: http://www.gnu.org/licenses/gpl-3.0.en.html
 package org.ensime.util
 
-import java.util.concurrent._
+import java.util.concurrent._ 
 
 import scala.concurrent.ExecutionContext
 
@@ -18,19 +18,8 @@ object BoundedExecutor {
   //unsafe 
   def callerBlockingExecutor(size: Int): ExecutionContext = {
     val q = new LinkedBlockingQueue[Runnable](1)
-    val handler = new RejectedExecutionHandler {
-      def rejectedExecution(r: Runnable, executor: ThreadPoolExecutor): Unit = {
-        q.synchronized {
-          while (!q.offer(r))
-            q.wait()
-        }
-      }
-    }
-
     val h = new ThreadPoolExecutor.CallerRunsPolicy()
-
-    val ex = new ThreadPoolExecutor(size, size, 30, TimeUnit.SECONDS, q, h) {
-    }
+    val ex = new ThreadPoolExecutor(size, size, 30, TimeUnit.SECONDS, q, h)
     ExecutionContext.fromExecutor(ex)
   }
 }

--- a/core/src/main/scala/org/ensime/util/ExecContexts.scala
+++ b/core/src/main/scala/org/ensime/util/ExecContexts.scala
@@ -1,0 +1,36 @@
+// Copyright: 2010 - 2016 https://github.com/ensime/ensime-server/graphs
+// Licence: http://www.gnu.org/licenses/gpl-3.0.en.html
+package org.ensime.util
+
+import java.util.concurrent._
+
+import scala.concurrent.ExecutionContext
+
+object BoundedExecutor {
+
+  /**
+   * This is a bounded execution context that will block the calling thread until
+   * a worker is available. The work queue is only sized to a single element because
+   * this causes a failure when attempting to add a work element, which in turn will
+   * fire the rejected execution handler, causing the calling thread to block.
+   */
+
+  //unsafe 
+  def callerBlockingExecutor(size: Int): ExecutionContext = {
+    val q = new LinkedBlockingQueue[Runnable](1)
+    val handler = new RejectedExecutionHandler {
+      def rejectedExecution(r: Runnable, executor: ThreadPoolExecutor): Unit = {
+        q.synchronized {
+          while (!q.offer(r))
+            q.wait()
+        }
+      }
+    }
+
+    val h = new ThreadPoolExecutor.CallerRunsPolicy()
+
+    val ex = new ThreadPoolExecutor(size, size, 30, TimeUnit.SECONDS, q, h) {
+    }
+    ExecutionContext.fromExecutor(ex)
+  }
+}


### PR DESCRIPTION
This is still under construction, but there are a couple of approaches I've considered for #1341

- Synchronize the refresh flow as much as possible. Certainly introduces "backpressure", but it also feels like we're loosing out on some parallelism here
- Use a bounded queue & `CallerRunsPolicy` once the queue is full. With a queue of size one, this means we'll begin using the calling thread for overflow work, which in turn slows down the caller, applying some back pressure
- Introduce a custom `RejectedExecutionHandler` policy that actually blocks the caller rather than delegate work to it. This seems like overkill for what we need.

I toyed around with the 3rd option, but ended up settling on the `CallerRunsPolicy` approach. I want to make sure this passes tests up here, and in the meantime I'll remove the old `val handler`. 