### PR TITLE
Updates the Java8Chars regex and the integration tests to expect

### DIFF
--- a/core/src/it/scala/org/ensime/core/DocResolverSpec.scala
+++ b/core/src/it/scala/org/ensime/core/DocResolverSpec.scala
@@ -356,11 +356,11 @@ class DocResolverSpec extends EnsimeSpec
       ) shouldBe Some("http://docs.oracle.com/javase/8/docs/api/java/io/File.html#delete--")
 
       serv.resolve(
-        DocSig(DocFqn("java.lang", "Math"), Some("max(int, int)"))
+        DocSig(DocFqn("java.lang", "Math"), Some("max(int,int)"))
       ) shouldBe Some("http://docs.oracle.com/javase/8/docs/api/java/lang/Math.html#max-int-int-")
 
       serv.resolve(
-        DocSig(DocFqn("java.util", "Arrays"), Some("binarySearch(int[], int)"))
+        DocSig(DocFqn("java.util", "Arrays"), Some("binarySearch(int[],int)"))
       ) shouldBe Some("http://docs.oracle.com/javase/8/docs/api/java/util/Arrays.html#binarySearch-int:A-int-")
     }
   }

--- a/core/src/main/scala/org/ensime/core/DocResolver.scala
+++ b/core/src/main/scala/org/ensime/core/DocResolver.scala
@@ -136,7 +136,7 @@ class DocResolver(
   // url characters: parens, commas, brackets.
   // See https://bugs.eclipse.org/bugs/show_bug.cgi?id=432056
   // and https://bugs.openjdk.java.net/browse/JDK-8025633
-  private val Java8Chars = """(?:, |\(|\)|\[\])""".r
+  private val Java8Chars = """(?:,|\(|\)|\[\])""".r
   private def toJava8Anchor(anchor: String): String = {
     Java8Chars.replaceAllIn(anchor, { m =>
       anchor(m.start) match {


### PR DESCRIPTION
Resolves #1440.

Doc lookups for java 8 stdlib functions were failing to generate correct URLs. The problem resulted from the Java8Chars regex expecting commas followed by a space.  The DocResolver was receiving signatures of the form func(arg1,arg2) instead of func(arg1, arg2).  This change updates the regex
and the integration tests to expect function signatures without the space between arguments.