### PR TITLE
[WIP] Penalizes noisy inner classes with a negative boost

### DIFF
--- a/core/src/it/scala/org/ensime/indexer/SearchServiceSpec.scala
+++ b/core/src/it/scala/org/ensime/indexer/SearchServiceSpec.scala
@@ -149,13 +149,18 @@ class SearchServiceSpec extends EnsimeSpec
     val hits = service.searchClasses("Baz", 10).map(_.fqn)
     hits should contain theSameElementsAs (Seq(
       "org.example2.Baz",
-      "org.example2.Baz$Wibble$baz",
-      "org.example2.Baz$Wibble$baz$",
+      "org.example2.Baz$Wibble$Baz",
+      "org.example2.Baz$Wibble$Baz$",
       "org.example2.Baz$Wibble$",
       "org.example2.Baz$",
       "org.example2.Baz$Wibble"
     ))
     hits.head shouldBe "org.example2.Baz"
+    hits(1) shouldBe oneOf(
+      "org.example2.Baz$Wibble",
+      "org.example2.Baz$",
+      "org.example2.Baz$Wibble$"
+    )
   }
 
   it should "return user created classes first" in withSearchService { implicit service =>

--- a/core/src/main/scala/org/ensime/indexer/SearchService.scala
+++ b/core/src/main/scala/org/ensime/indexer/SearchService.scala
@@ -128,6 +128,7 @@ class SearchService(
       val basesWithChecks: Set[(FileObject, Option[FileCheck])] = bases.map { base =>
         (base, checksLookup.get(base.getName().getURI()))
       }
+
       Future.sequence(basesWithChecks.map { case (file, check) => indexBase(file, check) }).map(_.flatten.sum)
     }
 

--- a/core/src/main/scala/org/ensime/indexer/lucene/SimpleLucene.scala
+++ b/core/src/main/scala/org/ensime/indexer/lucene/SimpleLucene.scala
@@ -92,8 +92,8 @@ class SimpleLucene(path: File, analyzers: Map[String, Analyzer]) extends SLF4JLo
       val result = searcher.doc(hit.doc)
       results += result
       if (log.isTraceEnabled) {
-        val explanation = searcher.explain(query, hit.doc)
-        log.trace("" + result + " scored " + explanation)
+      val explanation = searcher.explain(query, hit.doc)
+      log.trace("" + result + " scored " + explanation)
       }
     }
 

--- a/core/src/main/scala/org/ensime/indexer/lucene/package.scala
+++ b/core/src/main/scala/org/ensime/indexer/lucene/package.scala
@@ -36,5 +36,9 @@ package object lucene {
     def boostText(f: String, boost: Float) = {
       d.getField(f).asInstanceOf[TextField].setBoost(boost)
     }
+
+    def currentBoost(f: String) = {
+      d.getField(f).asInstanceOf[TextField].boost
+    }
   }
 }

--- a/testing/simple/src/main/scala/org/example2/Baz.scala
+++ b/testing/simple/src/main/scala/org/example2/Baz.scala
@@ -4,8 +4,8 @@ package org.example2
 
 class Baz {
   class Wibble {
-    class baz
-    object baz
+    class Baz
+    object Baz
   }
   object Wibble
 }


### PR DESCRIPTION
I need a deeper understanding of Lucene's internals to really know what's going on here, but the test case where I expect one of the less-noisy internal classes to appear second is non-deterministic.

Basically, only the initial entry `org.example2.Baz` has a unique score, all others have the same score. I'm unsure why this is, so any insights would be appreciated.