### PR TITLE
RenameSourceFileChange support in refactoring

### DIFF
--- a/core/src/main/scala/org/ensime/util/DiffUtil.scala
+++ b/core/src/main/scala/org/ensime/util/DiffUtil.scala
@@ -5,7 +5,6 @@ package org.ensime.util
 import java.io.File
 import java.text.SimpleDateFormat
 import java.util.Date
-import java.util.TimeZone
 
 object DiffUtil {
 
@@ -23,8 +22,35 @@ object DiffUtil {
     if (file.exists)
       format.format(new Date(file.lastModified()))
     else {
-      format.setTimeZone(TimeZone.getTimeZone("UTC"))
-      format.format(new Date(0L))
+      epoch
     }
+  }
+
+  private val epoch: String = "1970-01-01 12:00:00 +0000"
+
+  def newFileDiff(text: Seq[String], file: File): String = {
+    val diff = StringBuilder.newBuilder
+    val originalInfo = s"${file.getAbsolutePath}\t$epoch"
+    val revisedInfo = s"${file.getAbsolutePath}\t${fileModificationTimeOrEpoch(file)}"
+
+    diff ++= s"--- $originalInfo\n"
+    diff ++= s"+++ $revisedInfo\n"
+    val additions = text.length
+    diff ++= s"@@ -0,0 +1,$additions @@\n"
+    diff ++= text.map(line => s"+$line").mkString("", "\n", "\n")
+    diff.toString
+  }
+
+  def deleteFileDiff(text: Seq[String], file: File): String = {
+    val diff = StringBuilder.newBuilder
+    val originalInfo = s"${file.getAbsolutePath}\t${fileModificationTimeOrEpoch(file)}"
+    val revisedInfo = s"${file.getAbsolutePath}\t$epoch"
+
+    diff ++= s"--- $originalInfo\n"
+    diff ++= s"+++ $revisedInfo\n"
+    val removals = text.length
+    diff ++= s"@@ -1,$removals +0,0 @@\n"
+    diff ++= text.map(line => s"-$line").mkString("", "\n", "\n")
+    diff.toString
   }
 }

--- a/core/src/main/scala/org/ensime/util/FileEditHelper.scala
+++ b/core/src/main/scala/org/ensime/util/FileEditHelper.scala
@@ -2,16 +2,26 @@
 // Licence: http://www.gnu.org/licenses/gpl-3.0.en.html
 package org.ensime.util
 
-import java.io.File
 import org.ensime.api._
+import org.ensime.util.file.File
+
+import scala.tools.refactoring.common.{ NewFileChange, RenameSourceFileChange }
 
 object FileEditHelper {
 
   import scala.tools.refactoring.common.{ Change, TextChange }
 
-  def fromChange(ch: Change): FileEdit = {
+  def fromChange(ch: Change): Seq[FileEdit] = {
     ch match {
-      case ch: TextChange => TextEdit(ch.file.file, ch.from, ch.to, ch.text)
+      case ch: TextChange => Seq(TextEdit(ch.file.file, ch.from, ch.to, ch.text))
+      case nf: NewFileChange => Seq(NewFile(File(nf.fullName), nf.text))
+      case rf: RenameSourceFileChange =>
+        val sourceFile = rf.sourceFile
+        val newFile = sourceFile.path.replace(sourceFile.name, rf.to)
+        Seq(
+          NewFile(File(newFile), ""),
+          DeleteFile(sourceFile.file, "")
+        )
       case _ => throw new UnsupportedOperationException(ch.toString)
     }
   }
@@ -26,4 +36,13 @@ object FileEditHelper {
     val newContents = applyEdits(ch, source)
     DiffUtil.compareContents(source.lines.toSeq, newContents.lines.toSeq, originalFile, revisedFile)
   }
+
+  def diffFromNewFile(newFile: NewFile, sourceChanges: List[TextEdit] = Nil, source: String = ""): String = {
+    val newContents = applyEdits(sourceChanges, source)
+    DiffUtil.newFileDiff(newContents.lines.toSeq, newFile.file)
+  }
+
+  def diffFromDeleteFile(deletedFile: DeleteFile, source: String): String =
+    DiffUtil.deleteFileDiff(source.lines.toSeq, deletedFile.file)
+
 }

--- a/testing/simple/src/main/scala/org/example/Foo.scala
+++ b/testing/simple/src/main/scala/org/example/Foo.scala
@@ -28,4 +28,5 @@ case object Blue
 
 class Qux {
   List(1, 2, 3).head + 2
+  val x = Bar.Bla
 }


### PR DESCRIPTION
This should make it possible to rename the source file together with the symbol if appropriate. Not yet properly tested.

Closes #1283 

