### PR TITLE
Trigger shutdown after indexing is complete

### DIFF
--- a/core/src/main/scala/org/ensime/core/Project.scala
+++ b/core/src/main/scala/org/ensime/core/Project.scala
@@ -17,7 +17,7 @@ import scala.util._
 import org.ensime.util.file._
 import org.ensime.util.FileUtils
 
-case object CloseOnIndexUpdate
+final case class ShutdownRequest(reason: String, isError: Boolean = false)
 
 /**
  * The Project actor simply forwards messages coming from the user to
@@ -74,7 +74,7 @@ class Project(
         log.debug(s"created $inserts and removed $deletes searchable rows")
         val exitAfterIndex = propOrFalse("ensime.exitAfterIndex")
         if (exitAfterIndex)
-          context.parent ! CloseOnIndexUpdate
+          context.parent ! ShutdownRequest("Index only run", isError = false)
       case Failure(problem) =>
         log.warning(problem.toString)
         throw problem

--- a/core/src/main/scala/org/ensime/core/Project.scala
+++ b/core/src/main/scala/org/ensime/core/Project.scala
@@ -72,8 +72,7 @@ class Project(
         // we could also just blindly send this on each connection.
         broadcaster ! Broadcaster.Persist(IndexerReadyEvent)
         log.debug(s"created $inserts and removed $deletes searchable rows")
-        val exitAfterIndex = propOrFalse("ensime.exitAfterIndex")
-        if (exitAfterIndex)
+        if (propOrFalse("ensime.exitAfterIndex"))
           context.parent ! ShutdownRequest("Index only run", isError = false)
       case Failure(problem) =>
         log.warning(problem.toString)

--- a/core/src/main/scala/org/ensime/core/Project.scala
+++ b/core/src/main/scala/org/ensime/core/Project.scala
@@ -72,8 +72,8 @@ class Project(
         // we could also just blindly send this on each connection.
         broadcaster ! Broadcaster.Persist(IndexerReadyEvent)
         log.debug(s"created $inserts and removed $deletes searchable rows")
-        val ensimeFlag = propOrNone("ensime.flag").getOrElse("")
-        if (ensimeFlag == "indexOnly")
+        val exitAfterIndex = propOrFalse("ensime.exitAfterIndex")
+        if (exitAfterIndex)
           context.parent ! CloseOnIndexUpdate
       case Failure(problem) =>
         log.warning(problem.toString)

--- a/server/src/main/scala/org/ensime/server/Server.scala
+++ b/server/src/main/scala/org/ensime/server/Server.scala
@@ -24,8 +24,6 @@ import scala.concurrent.duration._
 import scala.util.Properties._
 import scala.util._
 
-final case class ShutdownRequest(reason: String, isError: Boolean = false)
-
 class ServerActor(
     config: EnsimeConfig,
     protocol: Protocol,
@@ -96,8 +94,6 @@ class ServerActor(
   override def receive: Receive = {
     case req: ShutdownRequest =>
       triggerShutdown(req)
-    case CloseOnIndexUpdate =>
-      triggerShutdown(ShutdownRequest("Index only run", isError = false))
   }
 
   def triggerShutdown(request: ShutdownRequest): Unit = {

--- a/server/src/main/scala/org/ensime/server/Server.scala
+++ b/server/src/main/scala/org/ensime/server/Server.scala
@@ -96,6 +96,8 @@ class ServerActor(
   override def receive: Receive = {
     case req: ShutdownRequest =>
       triggerShutdown(req)
+    case CloseOnIndexUpdate =>
+      triggerShutdown(ShutdownRequest("Index only run", isError = false))
   }
 
   def triggerShutdown(request: ShutdownRequest): Unit = {

--- a/server/src/main/scala/org/ensime/server/tcp/TCPServer.scala
+++ b/server/src/main/scala/org/ensime/server/tcp/TCPServer.scala
@@ -7,8 +7,8 @@ import java.net.InetSocketAddress
 
 import akka.actor.{ Actor, ActorLogging, ActorRef }
 import akka.io.{ IO, Tcp }
-import org.ensime.core.Protocol
-import org.ensime.server.{ ShutdownRequest, PortUtil }
+import org.ensime.core.{ ShutdownRequest, Protocol }
+import org.ensime.server.PortUtil
 
 case object ClientConnectionClosed
 


### PR DESCRIPTION
Using system property `ensime.exitAfterIndex=true` will trigger a shutdown after the indexing is complete
- Send a new message type `CloseOnIndexUpdate` back to server to trigger the shutdown

Solves #1445 