### PR TITLE
Parse scalariform intents

### DIFF
--- a/core/src/main/scala/org/ensime/config/ScalariformFormat.scala
+++ b/core/src/main/scala/org/ensime/config/ScalariformFormat.scala
@@ -21,7 +21,12 @@ trait ScalariformFormat {
         descriptor.preferenceType match {
           case BooleanPreference => sexp.convertTo[Boolean]
           case IntegerPreference(_, _) => sexp.convertTo[Int]
-          case IntentPreference => sexp.convertTo[String]
+          case IntentPreference => sexp.convertTo[String].toLowerCase match {
+            case "preserve" => Preserve
+            case "force" => Force
+            case "prevent" => Prevent
+            case intent => throw new DeserializationException(s"Unknown intent: $intent")
+          }
         }
       }
 
@@ -45,7 +50,7 @@ trait ScalariformFormat {
     ): Sexp = descriptor.preferenceType match {
       case BooleanPreference => value.asInstanceOf[Boolean].toSexp
       case IntegerPreference(_, _) => value.asInstanceOf[Int].toSexp
-      case IntentPreference => value.asInstanceOf[Intent].getClass.getSimpleName.toSexp
+      case IntentPreference => value.getClass.getSimpleName.replaceAll("\\$", "").toLowerCase.toSexp
     }
 
     def write(f: FormattingPreferences) = {

--- a/core/src/test/scala/org/ensime/config/ScalariformFormatSpec.scala
+++ b/core/src/test/scala/org/ensime/config/ScalariformFormatSpec.scala
@@ -15,11 +15,13 @@ class ScalariformFormatSpec extends EnsimeSpec {
 
   val prefs = FormattingPreferences().
     setPreference(DoubleIndentClassDeclaration, true).
-    setPreference(IndentSpaces, 13)
+    setPreference(IndentSpaces, 13).
+    setPreference(DanglingCloseParenthesis, Preserve)
 
   "ScalariformFormat" should "parse some example config" in {
     val text = """(:doubleIndentClassDeclaration t
-                     :indentSpaces 13)"""
+                     :indentSpaces 13
+                     :danglingCloseParenthesis "preserve")"""
     val recover = text.parseSexp.convertTo[FormattingPreferences]
     recover.preferencesMap shouldBe prefs.preferencesMap
   }
@@ -27,7 +29,9 @@ class ScalariformFormatSpec extends EnsimeSpec {
   it should "create valid output" in {
     prefs.toSexp should ===(SexpList(
       SexpSymbol(":doubleIndentClassDeclaration"), SexpSymbol("t"),
-      SexpSymbol(":indentSpaces"), SexpNumber(13)
+      SexpSymbol(":indentSpaces"), SexpNumber(13),
+      SexpSymbol(":danglingCloseParenthesis"), SexpString("preserve")
     ))
   }
+
 }


### PR DESCRIPTION
Scalariform intents currently aren't correctly parsed from s-expressions. This PR adds explicit parsing.

Also note that `descriptor.preferenceType` actually has a parsing function that takes a string and returns a preference value. To stay consistent, and since data is read from s-expressions (not strings), this PR copies the behaviour of the parsing function.