### PR TITLE
Switch to sbt-coursier 1.0.0-M12

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -24,4 +24,4 @@ ivyLoggingLevel := UpdateLogging.Quiet
 
 addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.6.0")
 
-addSbtPlugin("io.get-coursier" % "sbt-coursier-java-6" % "1.0.0-M11")
+addSbtPlugin("io.get-coursier" % "sbt-coursier-java-6" % "1.0.0-M12")


### PR DESCRIPTION
~~DON'T MERGE, this uses things from sonatype staging, and requires Java >= 7 as is.~~

This doesn't fix https://github.com/alexarchambault/coursier/issues/244... should be for the next milestone.