### PR TITLE
Pretty type-at-point

### DIFF
--- a/core/src/it/scala/org/ensime/core/TypeToScalaNameSpec.scala
+++ b/core/src/it/scala/org/ensime/core/TypeToScalaNameSpec.scala
@@ -17,7 +17,7 @@ class TypeToScalaNameSpec extends EnsimeSpec
     runForPositionInCompiledSource(
       config, cc,
       "package com.example",
-      "import shapeless._, syntax.singleton._",
+      "import shapeless._, labelled._, syntax.singleton._",
       "class Thing {",
       "    val in@int@t: Int = 13",
       "    def met@method1@hod1(i: Int): String = i.toString",
@@ -27,6 +27,7 @@ class TypeToScalaNameSpec extends EnsimeSpec
       "    def tu@tuple2@ple2: (String, Int) = null",
       "    def hl@hlist@ist: Int :: String :: HNil = null",
       "    def re@refined@fined = 1.narrow",
+      "    def ex@exciting@citing = 'f' ->> 23.narrow",
       "}"
     ) { (p, label, cc) =>
         withClue(label) {
@@ -101,13 +102,22 @@ class TypeToScalaNameSpec extends EnsimeSpec
                 )
 
               case "refined" =>
-                // canary
                 BasicTypeInfo(
-                  "<refinement>",
+                  "Int(1)",
                   Class,
-                  "shapeless.syntax.SingletonOps.<refinement>",
+                  "scala.Int(1)",
                   Nil, Nil, None
                 )
+
+              case "exciting" =>
+                // potential canary, we might want to prettify KeyTag
+                BasicTypeInfo(
+                  "Int(23) with KeyTag[Char('f'), Int(23)]",
+                  Class,
+                  "scala.Int(23) with shapeless.labelled.KeyTag[scala.Char('f'), scala.Int(23)]",
+                  Nil, Nil, None
+                )
+
             }
           }
         }

--- a/core/src/it/scala/org/ensime/core/TypeToScalaNameSpec.scala
+++ b/core/src/it/scala/org/ensime/core/TypeToScalaNameSpec.scala
@@ -24,6 +24,7 @@ class TypeToScalaNameSpec extends EnsimeSpec
       "    val ar@arrow1@row1: Int => String = (i: Int) => met@call1@hod1(i)",
       "    def met@method2@hod2(i: Int, j: Long): String = i.toString",
       "    val arrow2: Int => Long => String = (i: Int, j: Long) => met@call2@hod2(i, j)",
+      "    val arrow0: () => Int = null ; ar@call0@row0()",
       "    def tu@tuple2@ple2: (String, Int) = null",
       "    def hl@hlist@ist: Int :: String :: HNil = null",
       "    def re@refined@fined = 1.narrow",
@@ -63,6 +64,15 @@ class TypeToScalaNameSpec extends EnsimeSpec
                   ),
                   Nil, None
                 )
+
+              case "call0" =>
+                ArrowTypeInfo(
+                  "() => Int",
+                  "() => scala.Int",
+                  BasicTypeInfo("Int", Class, "scala.Int", Nil, Nil, None),
+                  List(ParamSectionInfo(Nil, false))
+                )
+
               case "call2" =>
                 ArrowTypeInfo(
                   "(Int, Long) => String",
@@ -75,15 +85,16 @@ class TypeToScalaNameSpec extends EnsimeSpec
                 )
               case "tuple2" =>
                 BasicTypeInfo(
-                  "Tuple2[String, Int]",
+                  "(String, Int)",
                   Class,
-                  "scala.Tuple2[java.lang.String, scala.Int]",
+                  "(java.lang.String, scala.Int)",
                   List(
                     BasicTypeInfo("String", Class, "java.lang.String", Nil, Nil, None),
                     BasicTypeInfo("Int", Class, "scala.Int", Nil, Nil, None)
                   ),
                   Nil, None
                 )
+
               case "hlist" =>
                 // canary
                 BasicTypeInfo(
@@ -116,7 +127,6 @@ class TypeToScalaNameSpec extends EnsimeSpec
                   "scala.Int(23) with shapeless.labelled.KeyTag[scala.Char('f'), scala.Int(23)]",
                   Nil, Nil, None
                 )
-
             }
           }
         }

--- a/core/src/it/scala/org/ensime/core/TypeToScalaNameSpec.scala
+++ b/core/src/it/scala/org/ensime/core/TypeToScalaNameSpec.scala
@@ -96,14 +96,13 @@ class TypeToScalaNameSpec extends EnsimeSpec
                 )
 
               case "hlist" =>
-                // canary
                 BasicTypeInfo(
-                  "::[Int, ::[String, HNil]]",
+                  "Int :: String :: HNil",
                   Class,
-                  "shapeless.$colon$colon[scala.Int, shapeless.$colon$colon[java.lang.String, shapeless.HNil]]",
+                  "scala.Int shapeless.:: java.lang.String shapeless.:: shapeless.HNil",
                   List(
                     BasicTypeInfo("Int", Class, "scala.Int", Nil, Nil, None),
-                    BasicTypeInfo("::[String, HNil]", Class, "shapeless.$colon$colon[java.lang.String, shapeless.HNil]",
+                    BasicTypeInfo("String :: HNil", Class, "java.lang.String shapeless.:: shapeless.HNil",
                       List(
                         BasicTypeInfo("String", Class, "java.lang.String", Nil, Nil, None),
                         BasicTypeInfo("HNil", Trait, "shapeless.HNil", Nil, Nil, None)

--- a/core/src/it/scala/org/ensime/core/TypeToScalaNameSpec.scala
+++ b/core/src/it/scala/org/ensime/core/TypeToScalaNameSpec.scala
@@ -53,11 +53,10 @@ class TypeToScalaNameSpec extends EnsimeSpec
                   List(ParamSectionInfo(List(("i", BasicTypeInfo("Int", Class, "scala.Int", Nil, Nil, None))), false))
                 )
               case "arrow1" =>
-                // this is a canary, we'd prefer it to return an ArrowTypeInfo
                 BasicTypeInfo(
-                  "Function1[Int, String]",
+                  "(Int) => String",
                   Trait,
-                  "scala.Function1[scala.Int, java.lang.String]",
+                  "(scala.Int) => java.lang.String",
                   List(
                     BasicTypeInfo("Int", Class, "scala.Int", Nil, Nil, None),
                     BasicTypeInfo("String", Class, "java.lang.String", Nil, Nil, None)

--- a/core/src/it/scala/org/ensime/fixture/EnsimeConfigFixture.scala
+++ b/core/src/it/scala/org/ensime/fixture/EnsimeConfigFixture.scala
@@ -72,6 +72,10 @@ object EnsimeConfigFixture {
     subprojects = EnsimeTestProject.subprojects.filter(_.name == "testingTiming"),
     javaLibs = Nil
   )
+  lazy val ShapelessTestProject: EnsimeConfig = EnsimeTestProject.copy(
+    subprojects = EnsimeTestProject.subprojects.filter(_.name == "testingShapeless"),
+    javaLibs = Nil
+  )
   lazy val DebugTestProject: EnsimeConfig = EnsimeTestProject.copy(
     subprojects = EnsimeTestProject.subprojects.filter(_.name == "testingDebug")
   )

--- a/core/src/it/scala/org/ensime/intg/BasicWorkflow.scala
+++ b/core/src/it/scala/org/ensime/intg/BasicWorkflow.scala
@@ -148,7 +148,7 @@ class BasicWorkflow extends EnsimeSpec
           project ! SymbolAtPointReq(Left(fooFile), 343)
           expectMsgPF() {
             case SymbolInfo("fn", "fn", Some(OffsetSourcePosition(`fooFile`, 304)),
-              BasicTypeInfo("Function1[String, Int]", DeclaredAs.Trait, "scala.Function1[java.lang.String, scala.Int]",
+              BasicTypeInfo("(String) => Int", DeclaredAs.Trait, "(java.lang.String) => scala.Int",
                 List(
                   BasicTypeInfo("String", DeclaredAs.Class, "java.lang.String", Nil, Nil, None),
                   BasicTypeInfo("Int", DeclaredAs.Class, "scala.Int", Nil, Nil, None)),

--- a/core/src/main/scala/org/ensime/core/Helpers.scala
+++ b/core/src/main/scala/org/ensime/core/Helpers.scala
@@ -30,6 +30,7 @@ trait Helpers { self: Global =>
     members.toList.filter { _.isConstructor }
   }
 
+  // usually better to just do the pattern match instead of relying on this
   def isArrowType(tpe: Type): Boolean = {
     tpe match {
       case _: MethodType => true

--- a/core/src/main/scala/org/ensime/core/TypeToScalaName.scala
+++ b/core/src/main/scala/org/ensime/core/TypeToScalaName.scala
@@ -25,9 +25,11 @@ trait TypeToScalaName { self: Global with Helpers =>
       val parts = tpe.typeArgs.map(scalaName(_, full).underlying)
       new ScalaName(parts.init.mkString("(", ", ", ")")) + " => " + parts.last
 
-    case _ =>
-      //println(tpe.getClass + " -> " + tpe)
+    case args: ArgsTypeRef if args.typeSymbol.fullName.startsWith("scala.Tuple") =>
+      val parts = tpe.typeArgs.map(scalaName(_, full).underlying)
+      new ScalaName(parts.mkString("(", ", ", ")"))
 
+    case _ =>
       val name = tpe match {
         case c: ConstantType =>
           scalaName(c.underlying, full).underlying + "(" + c.value.escapedStringValue + ")"

--- a/core/src/main/scala/org/ensime/core/TypeToScalaName.scala
+++ b/core/src/main/scala/org/ensime/core/TypeToScalaName.scala
@@ -29,6 +29,14 @@ trait TypeToScalaName { self: Global with Helpers =>
       val parts = tpe.typeArgs.map(scalaName(_, full).underlying)
       new ScalaName(parts.mkString("(", ", ", ")"))
 
+    case args: ArgsTypeRef if args.typeSymbol.decodedName.endsWith(":") =>
+      val parts = tpe.typeArgs.map(scalaName(_, full).underlying)
+      val name =
+        if (full) tpe.typeSymbol.fullNameString
+        else tpe.typeSymbol.nameString
+
+      new ScalaName(parts.init.mkString(" ")) + s" $name ${parts.last}"
+
     case _ =>
       val name = tpe match {
         case c: ConstantType =>
@@ -36,7 +44,7 @@ trait TypeToScalaName { self: Global with Helpers =>
         case r: RefinedType =>
           r.parents.map(scalaName(_, full).underlying).mkString(" with ")
         case _ =>
-          if (full) tpe.typeSymbol.fullName
+          if (full) tpe.typeSymbol.fullNameString
           else tpe.typeSymbol.nameString
       }
       new ScalaName(name) + {

--- a/core/src/main/scala/org/ensime/core/TypeToScalaName.scala
+++ b/core/src/main/scala/org/ensime/core/TypeToScalaName.scala
@@ -29,7 +29,7 @@ trait TypeToScalaName { self: Global with Helpers =>
       val parts = tpe.typeArgs.map(scalaName(_, full).underlying)
       new ScalaName(parts.mkString("(", ", ", ")"))
 
-    case args: ArgsTypeRef if !args.typeSymbol.decodedName.last.isLetterOrDigit =>
+    case args: ArgsTypeRef if args.typeSymbol.decodedName.forall(!_.isLetterOrDigit) =>
       val parts = tpe.typeArgs.map(scalaName(_, full).underlying)
       val name =
         if (full) tpe.typeSymbol.fullNameString

--- a/core/src/main/scala/org/ensime/core/TypeToScalaName.scala
+++ b/core/src/main/scala/org/ensime/core/TypeToScalaName.scala
@@ -17,10 +17,7 @@ trait TypeToScalaName { self: Global with Helpers =>
   def scalaName(tpe: Type, full: Boolean): ScalaName = {
     if (isArrowType(tpe)) {
       val tparams = tpe.paramss.map { sect =>
-        sect.map { p => scalaName(p.tpe, full).underlying } match {
-          case one :: Nil => one
-          case many => many.mkString("(", ", ", ")")
-        }
+        sect.map { p => scalaName(p.tpe, full).underlying }.mkString("(", ", ", ")")
       }.mkString(" => ")
       new ScalaName(tparams) + " => " + scalaName(tpe.finalResultType, full).underlying
     } else {

--- a/core/src/main/scala/org/ensime/core/TypeToScalaName.scala
+++ b/core/src/main/scala/org/ensime/core/TypeToScalaName.scala
@@ -29,7 +29,7 @@ trait TypeToScalaName { self: Global with Helpers =>
       val parts = tpe.typeArgs.map(scalaName(_, full).underlying)
       new ScalaName(parts.mkString("(", ", ", ")"))
 
-    case args: ArgsTypeRef if args.typeSymbol.decodedName.endsWith(":") =>
+    case args: ArgsTypeRef if !args.typeSymbol.decodedName.last.isLetterOrDigit =>
       val parts = tpe.typeArgs.map(scalaName(_, full).underlying)
       val name =
         if (full) tpe.typeSymbol.fullNameString

--- a/core/src/main/scala/org/ensime/core/TypeToScalaName.scala
+++ b/core/src/main/scala/org/ensime/core/TypeToScalaName.scala
@@ -21,7 +21,15 @@ trait TypeToScalaName { self: Global with Helpers =>
       }.mkString(" => ")
       new ScalaName(tparams) + " => " + scalaName(tpe.finalResultType, full).underlying
     } else {
-      val name = if (full) tpe.typeSymbol.fullName else tpe.typeSymbol.nameString
+      val name = tpe match {
+        case c: ConstantType =>
+          scalaName(c.underlying, full).underlying + "(" + c.value.escapedStringValue + ")"
+        case r: RefinedType =>
+          r.parents.map(scalaName(_, full).underlying).mkString(" with ")
+        case _ =>
+          if (full) tpe.typeSymbol.fullName
+          else tpe.typeSymbol.nameString
+      }
       new ScalaName(name) + {
         if (tpe.typeArgs.nonEmpty)
           tpe.typeArgs.map(scalaName(_, full).underlying).mkString("[", ", ", "]")

--- a/core/src/main/scala/org/ensime/core/javac/JavaCompiler.scala
+++ b/core/src/main/scala/org/ensime/core/javac/JavaCompiler.scala
@@ -98,7 +98,7 @@ class JavaCompiler(
         def withName(name: String): Option[SymbolInfo] = {
 
           val tpeMirror = Option(c.trees.getTypeMirror(path))
-          val nullTpe = new BasicTypeInfo("NA", DeclaredAs.Nil, "NA", List.empty, List.empty, None)
+          val nullTpe = BasicTypeInfo("NA", DeclaredAs.Nil, "NA", List.empty, List.empty, None)
 
           Some(SymbolInfo(
             fqn(c, path).map(_.toFqnString).getOrElse(name),

--- a/core/src/main/scala/org/ensime/model/ModelBuilders.scala
+++ b/core/src/main/scala/org/ensime/model/ModelBuilders.scala
@@ -195,7 +195,7 @@ trait ModelBuilders {
         val typeSym = tpe.typeSymbol
         val symbolToLocate = if (typeSym.isModuleClass) typeSym.sourceModule else typeSym
         val symPos = locateSymbolPos(symbolToLocate, needPos)
-        new BasicTypeInfo(
+        BasicTypeInfo(
           shortName(tpe).underlying,
           declaredAs(typeSym),
           fullName(tpe).underlying,
@@ -213,9 +213,7 @@ trait ModelBuilders {
       }
     }
 
-    def nullInfo = {
-      new BasicTypeInfo("NA", DeclaredAs.Nil, "NA", List.empty, List.empty, None)
-    }
+    def nullInfo = BasicTypeInfo("NA", DeclaredAs.Nil, "NA", List.empty, List.empty, None)
   }
 
   object ParamSectionInfo {

--- a/project/EnsimeBuild.scala
+++ b/project/EnsimeBuild.scala
@@ -128,6 +128,7 @@ object EnsimeBuild extends Build {
     // test config needed to get the test jar
     testingSimpleJar % "test,it->test",
     testingTiming % "test,it",
+    testingShapeless % "test,it",
     testingDebug % "test,it",
     testingJava % "test,it"
   ).configs(It).settings(
@@ -207,6 +208,11 @@ object EnsimeBuild extends Build {
   )
 
   lazy val testingTiming = Project("testingTiming", file("testing/timing"))
+
+  // just to have access to shapeless
+  lazy val testingShapeless = Project("testingShapeless", file("testing/shapeless")).settings (
+    libraryDependencies ++= Sensible.shapeless(scalaVersion.value)
+  )
 
   lazy val testingDebug = Project("testingDebug", file("testing/debug")).settings(
     scalacOptions in Compile := Seq()


### PR DESCRIPTION
closes #1464 #635 making type-at-point a lot prettier for tuples, `scala.FunctionX`, refined types and classes designed to be used infix. The test cases show exactly what it does.

Might break the emacs tests since this could affect string assertions.
