### PR TITLE
Backpressure

### DIFF
--- a/core/src/it/scala-2.11/org/ensime/intg/ImplicitsWildcardImports.scala
+++ b/core/src/it/scala-2.11/org/ensime/intg/ImplicitsWildcardImports.scala
@@ -27,15 +27,12 @@ class ImplicitsWildcardImports extends EnsimeSpec
           val sourceRoot = scalaMain(config)
           val exampleFile = sourceRoot / "org/example/Example.scala"
 
-          log.info("Getting type the first time")
           project ! SymbolAtPointReq(Left(exampleFile), 116)
           expectMsgType[SymbolInfo].name should be("seconds")
 
-          log.info("Getting implicit info")
           project ! ImplicitInfoReq(Left(exampleFile), OffsetRange(0, 121))
           expectMsgType[ImplicitInfos]
 
-          log.info("Getting type the second time")
           project ! SymbolAtPointReq(Left(exampleFile), 116)
           expectMsgType[SymbolInfo].name should be("seconds")
         }

--- a/core/src/it/scala/org/ensime/intg/BasicWorkflow.scala
+++ b/core/src/it/scala/org/ensime/intg/BasicWorkflow.scala
@@ -115,8 +115,6 @@ class BasicWorkflow extends EnsimeSpec
           //-----------------------------------------------------------------------------------------------
           // uses of symbol at point
 
-          log.info("------------------------------------222-")
-
           project ! TypecheckFilesReq(List(Left(fooFile)))
           expectMsg(VoidResponse)
 
@@ -126,8 +124,6 @@ class BasicWorkflow extends EnsimeSpec
           expectMsgType[ERangePositions].positions should contain theSameElementsAs List(
             ERangePosition(`fooFilePath`, 114, 110, 172), ERangePosition(`fooFilePath`, 273, 269, 283)
           )
-
-          log.info("------------------------------------222-")
 
           // note that the line numbers appear to have been stripped from the
           // scala library classfiles, so offset/line comes out as zero unless

--- a/core/src/main/scala/org/ensime/core/Completion.scala
+++ b/core/src/main/scala/org/ensime/core/Completion.scala
@@ -125,7 +125,8 @@ trait CompletionControl {
 
       val contextOpt = x.get match {
         case Left(tree) =>
-          logger.debug("Completing at tree:" + tree.summaryString)
+          if (logger.isTraceEnabled())
+            logger.trace("Completing at tree:" + tree.summaryString)
           tree match {
             case Apply(fun, _) =>
               fun match {
@@ -237,8 +238,6 @@ trait CompletionControl {
       }
     } while (!x.isComplete)
 
-    logger.info("Found " + members.size + " members.")
-
     // Any interaction with the members (their types and symbols) must be done
     // on the compiler thread.
     askOption[Unit] {
@@ -246,7 +245,6 @@ trait CompletionControl {
         val s = m.sym.nameString
         matchesPrefix(s, context.prefix, matchEntire = false, caseSens = caseSens) && !s.contains("$")
       }
-      logger.info("Filtered down to " + filtered.size + ".")
       for (m <- filtered) {
         m match {
           case m @ ScopeMember(sym, tpe, accessible, viaView) =>

--- a/core/src/main/scala/org/ensime/core/DocResolver.scala
+++ b/core/src/main/scala/org/ensime/core/DocResolver.scala
@@ -124,7 +124,6 @@ class DocResolver(
   private def resolveLocalUri(sig: DocSigPair): Option[String] = {
     guessJar(sig) match {
       case Some((jar, sig)) =>
-        log.debug(s"Resolved to jar: $jar")
         Some(makeLocalUri(jar, sig))
       case _ =>
         log.debug(s"Failed to resolve doc jar for: $sig")

--- a/core/src/main/scala/org/ensime/core/javac/JavaCompletion.scala
+++ b/core/src/main/scala/org/ensime/core/javac/JavaCompletion.scala
@@ -34,18 +34,12 @@ trait JavaCompletion { this: JavaCompiler =>
 
     val preceding = s.slice(Math.max(0, offset - 100), offset)
 
-    log.debug("PRECEDING: " + preceding)
-
     val defaultPrefix = JavaIdentRegexp.findFirstMatchIn(preceding) match {
       case Some(m) => m.group(1)
       case _ => ""
     }
 
-    log.debug("PREFIX: " + defaultPrefix)
-
     val constructing = ConstructingRegexp.findFirstMatchIn(preceding).isDefined
-
-    log.debug("CONSTRUCTING: " + constructing)
 
     val indexAfterTarget = Math.max(0, offset - defaultPrefix.length - 1)
 

--- a/core/src/main/scala/org/ensime/core/javac/JavaSourceFinding.scala
+++ b/core/src/main/scala/org/ensime/core/javac/JavaSourceFinding.scala
@@ -42,7 +42,8 @@ trait JavaSourceFinding extends Helpers with SLF4JLogging {
     val javaFqn = fqn(c, path)
     val query = javaFqn.map(_.toFqnString).getOrElse("")
     val hit = search.findUnique(query)
-    log.debug(s"search: '$query' = $hit")
+    if (log.isTraceEnabled())
+      log.trace(s"search: '$query' = $hit")
     hit.flatMap(LineSourcePositionHelper.fromFqnSymbol(_)(config, vfs)).flatMap { sourcePos =>
       if (sourcePos.file.getName.endsWith(".java") && sourcePos.file.exists)
         javaFqn.flatMap(askLinkPos(_, SourceFileInfo(sourcePos.file, None, None))).orElse(Some(sourcePos))

--- a/core/src/main/scala/org/ensime/indexer/FileWatchers.scala
+++ b/core/src/main/scala/org/ensime/indexer/FileWatchers.scala
@@ -54,8 +54,8 @@ class ClassfileWatcher(
               (JarSelector, target.getParentFile, false)
             else
               (ClassfileSelector, target, true)
-          if (log.isDebugEnabled())
-            log.debug(s"creating a ApachePollingFileWatcher watcher for $dir")
+          if (log.isTraceEnabled())
+            log.trace(s"creating an ApachePollingFileWatcher watcher for $dir")
           new ApachePollingFileWatcher(dir, selector, rec, listeners).asInstanceOf[Watcher]
         }
       }
@@ -64,12 +64,12 @@ class ClassfileWatcher(
         val classJava7WatcherBuilder = new ClassJava7WatcherBuilder()
         config.targetClasspath.map { target =>
           if (target.isJar) {
-            if (log.isDebugEnabled())
-              log.debug(s"creating a Java 7 jar watcher for ${target}")
+            if (log.isTraceEnabled())
+              log.trace(s"creating a Java 7 jar watcher for ${target}")
             jarJava7WatcherBuilder.build(target, listeners)
           } else {
-            if (log.isDebugEnabled())
-              log.debug(s"creating a Java 7 class watcher for ${target}")
+            if (log.isTraceEnabled())
+              log.trace(s"creating a Java 7 class watcher for ${target}")
             classJava7WatcherBuilder.build(target, listeners)
           }
         }
@@ -104,8 +104,8 @@ class SourceWatcher(
           module <- config.modules.values
           root <- module.sourceRoots
         } yield {
-          if (log.isDebugEnabled())
-            log.debug(s"creating ApachPollingFileWatcher source watcher for $root")
+          if (log.isTraceEnabled())
+            log.trace(s"creating an ApachePollingFileWatcher source watcher for $root")
           new ApachePollingFileWatcher(root, SourceSelector, true, listeners)
         }
 
@@ -115,8 +115,8 @@ class SourceWatcher(
           module <- config.modules.values
           root <- module.sourceRoots
         } yield {
-          if (log.isDebugEnabled())
-            log.debug(s"creating a Java 7 source watcher for $root")
+          if (log.isTraceEnabled())
+            log.trace(s"creating a Java 7 source watcher for $root")
           sourceJava7WatcherBuilder.build(root, listeners)
         }
       }
@@ -151,28 +151,28 @@ private class ApachePollingFileWatcher(
 
     def fileChanged(event: FileChangeEvent): Unit = {
       if (watched(event)) {
-        if (log.isDebugEnabled())
-          log.debug(s"${event.getFile} was changed")
+        if (log.isTraceEnabled())
+          log.trace(s"${event.getFile} was changed")
         listeners foreach (_.fileChanged(event.getFile))
       }
     }
     def fileCreated(event: FileChangeEvent): Unit =
       if (watched(event)) {
-        if (log.isDebugEnabled())
-          log.debug(s"${event.getFile} was created")
+        if (log.isTraceEnabled())
+          log.trace(s"${event.getFile} was created")
         listeners foreach (_.fileAdded(event.getFile))
       }
     def fileDeleted(event: FileChangeEvent): Unit =
       if (base == event.getFile.getName.getURI) {
-        log.info(s"$base (a watched base) was deleted")
+        log.debug(s"$base (a watched base) was deleted")
         listeners foreach (_.baseRemoved(event.getFile))
         // this is a best efforts thing, subject to race conditions
         fm.stop() // the delete stack is a liability
         fm = create()
         init(restarted = true)
       } else if (watched(event)) {
-        if (log.isDebugEnabled())
-          log.debug(s"${event.getFile} was deleted")
+        if (log.isTraceEnabled())
+          log.trace(s"${event.getFile} was deleted")
         listeners foreach (_.fileRemoved(event.getFile))
       }
   })
@@ -350,8 +350,8 @@ class Java7WatchServiceBuilder extends SLF4JLogging {
     base: File,
     listeners: Seq[WatcherListener]
   )(implicit vfs: EnsimeVFS) = {
-    if (log.isDebugEnabled())
-      log.debug("watching {}", base)
+    if (log.isTraceEnabled())
+      log.trace("watching {}", base)
 
     trait EnsimeWatcher extends Watcher {
       val w = fileWatchService.spawnWatcher(watcherId, base, listeners.toSet)

--- a/core/src/main/scala/org/ensime/indexer/IndexService.scala
+++ b/core/src/main/scala/org/ensime/indexer/IndexService.scala
@@ -92,7 +92,7 @@ class IndexService(path: File) {
       case FqnSymbol(_, _, _, fqn, _, _, _, _, _) => ClassIndex(fqn, f).toDocument
     }
     if (boost) {
-      fqns foreach { _.boostText("fqn", 1.1f) }
+      fqns foreach { _.boostText("fqn", 1.3f) }
     }
 
     lucene.create(fqns, commit)

--- a/core/src/main/scala/org/ensime/indexer/SearchService.scala
+++ b/core/src/main/scala/org/ensime/indexer/SearchService.scala
@@ -86,7 +86,7 @@ class SearchService(
     // known files from the DB then and check against the disk, than
     // check each file against DatabaseService.outOfDate
     def findStaleFileChecks(checks: Seq[FileCheck]): List[FileCheck] = {
-      log.info("findStaleFileChecks")
+      log.debug("findStaleFileChecks")
       for {
         check <- checks
         name = check.file.getName.getURI
@@ -97,7 +97,7 @@ class SearchService(
     // delete the stale data before adding anything new
     // returns number of rows deleted
     def deleteReferences(checks: List[FileCheck]): Future[Int] = {
-      log.info(s"removing ${checks.size} stale files from the index")
+      log.debug(s"removing ${checks.size} stale files from the index")
       deleteInBatches(checks.map(_.file))
     }
 
@@ -132,7 +132,7 @@ class SearchService(
 
     // index all the given bases and return number of rows written
     def indexBases(bases: Set[FileObject], checks: Seq[FileCheck]): Future[Int] = {
-      log.info("Indexing bases...")
+      log.debug("Indexing bases...")
       val checksLookup: Map[String, FileCheck] = checks.map(check => (check.filename -> check)).toMap
       val basesWithChecks: Set[(FileObject, Option[FileCheck])] = bases.map { base =>
         (base, checksLookup.get(base.getName().getURI()))

--- a/core/src/main/scala/org/ensime/indexer/SearchService.scala
+++ b/core/src/main/scala/org/ensime/indexer/SearchService.scala
@@ -2,12 +2,13 @@
 // Licence: http://www.gnu.org/licenses/gpl-3.0.en.html
 package org.ensime.indexer
 
+import java.util.concurrent.Semaphore
+
 import scala.concurrent._
 import scala.concurrent.duration._
-import scala.util.{ Success, Failure }
+import scala.util.{ Failure, Properties, Success }
 
 import akka.actor._
-import akka.dispatch.MessageDispatcher
 import akka.event.slf4j.SLF4JLogging
 import org.apache.commons.vfs2._
 import org.ensime.api._
@@ -61,7 +62,12 @@ class SearchService(
   private val index = new IndexService(config.cacheDir / ("index-" + version))
   private val db = new DatabaseService(config.cacheDir / ("sql-" + version))
 
-  implicit val workerEC: MessageDispatcher = actorSystem.dispatchers.lookup("akka.search-service-dispatcher")
+  import ExecutionContext.Implicits.global
+
+  // each jar / directory must acquire a permit, released when the
+  // data is persisted. This is to keep the heap usage down and is a
+  // poor man's backpressure.
+  val semaphore = new Semaphore(Properties.propOrElse("ensime.index.parallel", "10").toInt, true)
 
   private def scan(f: FileObject) = f.findFiles(ClassfileSelector) match {
     case null => Nil
@@ -118,7 +124,9 @@ class SearchService(
       else {
         val boost = isUserFile(base.getName())
         val check = FileCheck(base)
-        extractSymbolsFromClassOrJar(base).flatMap(persist(check, _, commitIndex = false, boost = boost))
+        val indexed = extractSymbolsFromClassOrJar(base).flatMap(persist(check, _, commitIndex = false, boost = boost))
+        indexed.onComplete { _ => semaphore.release() }
+        indexed
       }
     }
 
@@ -163,26 +171,31 @@ class SearchService(
     iwork.flatMap { _ => dwork }
   }
 
-  def extractSymbolsFromClassOrJar(file: FileObject): Future[List[FqnSymbol]] = file match {
-    case classfile if classfile.getName.getExtension == "class" =>
-      // too noisy to log
-      val check = FileCheck(classfile)
-      Future {
-        blocking {
-          try extractSymbols(classfile, classfile)
-          finally classfile.close()
+  // this method leak semaphore on every call, which must be released
+  // when the List[FqnSymbol] has been processed (even if it is empty)
+  def extractSymbolsFromClassOrJar(file: FileObject): Future[List[FqnSymbol]] = {
+    def global: ExecutionContext = null // detach the global implicit
+    val ec = actorSystem.dispatchers.lookup("akka.search-service-dispatcher")
+
+    Future {
+      blocking {
+        semaphore.acquire()
+
+        file match {
+          case classfile if classfile.getName.getExtension == "class" =>
+            // too noisy to log
+            val check = FileCheck(classfile)
+            try extractSymbols(classfile, classfile)
+            finally classfile.close()
+          case jar =>
+            log.debug(s"indexing $jar")
+            val check = FileCheck(jar)
+            val vJar = vfs.vjar(jar)
+            try scan(vJar) flatMap (extractSymbols(jar, _))
+            finally vfs.nuke(vJar)
         }
       }
-    case jar =>
-      log.debug(s"indexing $jar")
-      val check = FileCheck(jar)
-      Future {
-        blocking {
-          val vJar = vfs.vjar(jar)
-          try scan(vJar) flatMap (extractSymbols(jar, _))
-          finally vfs.nuke(vJar)
-        }
-      }
+    }(ec)
   }
 
   private val blacklist = Set("sun/", "sunw/", "com/sun/")
@@ -308,7 +321,7 @@ class IndexingQueueActor(searchService: SearchService) extends Actor with ActorL
       if (remaining.nonEmpty)
         debounce()
 
-      import searchService.workerEC
+      import ExecutionContext.Implicits.global
 
       log.debug(s"Indexing ${batch.size} files")
 
@@ -321,12 +334,19 @@ class IndexingQueueActor(searchService: SearchService) extends Actor with ActorL
           log.error(s"failed to index batch of ${batch.size} files", t)
         case Success(indexed) =>
           searchService.delete(indexed.map(_._1)(collection.breakOut)).onComplete {
-            case Failure(t) => log.error(s"failed to remove stale entries in ${batch.size} files", t)
-            case Success(_) => indexed.collect {
-              case (file, syms) if syms.isEmpty =>
+            case Failure(t) =>
+              searchService.semaphore.release()
+              log.error(s"failed to remove stale entries in ${batch.size} files", t)
+            case Success(_) => indexed.foreach {
               case (file, syms) =>
                 val boost = searchService.isUserFile((file.getName))
-                searchService.persist(FileCheck(file), syms, commitIndex = true, boost = boost).onComplete {
+                val persisting = searchService.persist(FileCheck(file), syms, commitIndex = true, boost = boost)
+
+                persisting.onComplete {
+                  case _ => searchService.semaphore.release()
+                }
+
+                persisting.onComplete {
                   case Failure(t) => log.error(s"failed to persist entries in $file", t)
                   case Success(_) =>
                 }

--- a/core/src/main/scala/org/ensime/model/ModelBuilders.scala
+++ b/core/src/main/scala/org/ensime/model/ModelBuilders.scala
@@ -33,7 +33,6 @@ trait ModelBuilders {
 
   def locateSymbolPos(sym: Symbol, needPos: PosNeeded): Option[SourcePosition] = {
     _locateSymbolPos(sym, needPos).orElse({
-      logger.debug(s"search $sym: Try Companion")
       sym.companionSymbol match {
         case NoSymbol => None
         case s: Symbol => _locateSymbolPos(s, needPos)

--- a/project/SensibleSettings.scala
+++ b/project/SensibleSettings.scala
@@ -50,7 +50,7 @@ object Sensible {
     javaOptions := Seq("-Xss2m", "-XX:MaxPermSize=256m", "-Xms384m", "-Xmx384m"),
     javaOptions += "-Dfile.encoding=UTF8",
     javaOptions ++= Seq("-XX:+UseConcMarkSweepGC", "-XX:+CMSIncrementalMode"),
-    javaOptions in run ++= yourkitAgent,
+    javaOptions ++= yourkitAgent,
 
     maxErrors := 1,
     fork := true,
@@ -161,7 +161,7 @@ object Sensible {
   val yourkitAgent = Properties.envOrNone("YOURKIT_AGENT").map { name =>
     val agent = file(name)
     require(agent.exists(), s"Yourkit agent specified ($agent) does not exist")
-    Seq(s"-agentpath:${agent.getCanonicalPath}")
+    Seq(s"-agentpath:${agent.getCanonicalPath}=quiet")
   }.getOrElse(Nil)
 
   // WORKAROUND: https://github.com/scalatest/scalatest/issues/511


### PR DESCRIPTION
close #1341

This is a pretty evil hack, but the benefit to users is worth it.

We're introducing a semaphore during indexing to link backpressure between the (CPU and memory intensive) indexing and (very slow) persistence.

We can do it properly if we ever find a scala framework as good as `core.async` in clojure.
