### PR TITLE
Remove deprecated completions

### DIFF
--- a/api/src/main/scala/org/ensime/api/outgoing.scala
+++ b/api/src/main/scala/org/ensime/api/outgoing.scala
@@ -286,8 +286,7 @@ final case class SymbolInfo(
     name: String,
     localName: String,
     declPos: Option[SourcePosition],
-    `type`: TypeInfo,
-    isCallable: Boolean
+    `type`: TypeInfo
 ) extends RpcResponse {
   def tpe = `type`
 }
@@ -306,18 +305,9 @@ final case class MethodBytecode(
   endLine: Int
 )
 
-@deprecating("not type safe")
-final case class CompletionSignature(
-  sections: List[List[(String, String)]],
-  result: String,
-  hasImplicit: Boolean
-)
-
 final case class CompletionInfo(
   typeInfo: Option[TypeInfo],
   name: String,
-  @deprecating("use `typeInfo`") typeSig: CompletionSignature,
-  @deprecating("not needed with `typeInfo`") isCallable: Boolean,
   relevance: Int,
   toInsert: Option[String]
 ) extends RpcResponse

--- a/api/src/test/scala/org/ensime/api/EnsimeTestData.scala
+++ b/api/src/test/scala/org/ensime/api/EnsimeTestData.scala
@@ -14,7 +14,7 @@ trait EnsimeTestData {
     }
   }
 
-  val typeInfo = new BasicTypeInfo("type1", DeclaredAs.Method, "FOO.type1", List(), List(), None)
+  val typeInfo = new BasicTypeInfo("type1", DeclaredAs.Method, "FOO.type1", Nil, Nil, None)
 
   val interfaceInfo = new InterfaceInfo(typeInfo, Some("DEF"))
   val typeInspectInfo = new TypeInspectInfo(typeInfo, List(interfaceInfo))
@@ -43,7 +43,7 @@ trait EnsimeTestData {
 
   val rangePos2 = new ERangePosition(batchSourceFile, 85, 80, 100)
 
-  val packageInfo = new PackageInfo("name", "fullName", List())
+  val packageInfo = new PackageInfo("name", "fullName", Nil)
 
   val refactorFailure = RefactorFailure(7, "message")
 

--- a/api/src/test/scala/org/ensime/api/EnsimeTestData.scala
+++ b/api/src/test/scala/org/ensime/api/EnsimeTestData.scala
@@ -30,7 +30,7 @@ trait EnsimeTestData {
     )
   )
 
-  val symbolInfo = new SymbolInfo("name", "localName", None, typeInfo, false)
+  val symbolInfo = new SymbolInfo("name", "localName", None, typeInfo)
 
   val implicitInfos = List(
     ImplicitConversionInfo(5, 6, symbolInfo),
@@ -107,9 +107,9 @@ trait EnsimeTestData {
 
   val entityInfo: TypeInfo = new ArrowTypeInfo("Arrow1", "example.Arrow1", typeInfo, List(paramSectionInfo))
 
-  val completionInfo = CompletionInfo(Some(typeInfo), "name", CompletionSignature(List(List(("abc", "def"), ("hij", "lmn"))), "ABC", false), false, 90, Some("BAZ"))
+  val completionInfo = CompletionInfo(Some(typeInfo), "name", 90, Some("BAZ"))
 
-  val completionInfo2 = CompletionInfo(None, "name2", CompletionSignature(List(List(("abc", "def"))), "ABC", false), true, 91, None)
+  val completionInfo2 = CompletionInfo(None, "name2", 91, None)
 
   val completionInfoList = List(completionInfo, completionInfo2)
 

--- a/core/src/it/scala/org/ensime/core/JavaCompilerSpec.scala
+++ b/core/src/it/scala/org/ensime/core/JavaCompilerSpec.scala
@@ -4,7 +4,7 @@ package org.ensime.core
 
 import java.io.File
 
-import org.ensime.api.{ LineSourcePosition, OffsetSourcePosition, SourceFileInfo }
+import org.ensime.api._
 import org.ensime.core.javac.JavaFqn
 import org.ensime.fixture._
 import org.ensime.indexer.SearchServiceTestUtils._
@@ -96,41 +96,39 @@ class JavaCompilerSpec extends EnsimeSpec
             info.name shouldBe "foo"
             info.localName shouldBe "foo"
             info.`type`.name shouldBe "int"
-            info.isCallable shouldBe false
+            info.`type` shouldBe a[BasicTypeInfo]
             info.declPos should matchPattern { case Some(OffsetSourcePosition(f, 174)) if f.getName == "Test1.java" => }
           case "1" =>
             info.name shouldBe "args"
             info.localName shouldBe "args"
             info.`type`.name shouldBe "java.lang.String[]"
-            info.isCallable shouldBe false
+            info.`type` shouldBe a[BasicTypeInfo]
             info.declPos should matchPattern { case Some(OffsetSourcePosition(f, 153)) if f.getName == "Test1.java" => }
           case "2" =>
             info.name shouldBe "org.example.Test1.Foo"
             info.localName shouldBe "Foo"
             info.`type`.name shouldBe "org.example.Test1.Foo"
-            info.isCallable shouldBe false
+            info.`type` shouldBe a[BasicTypeInfo]
             info.declPos should matchPattern { case Some(OffsetSourcePosition(f, 58)) if f.getName == "Test1.java" => }
           case "3" =>
             info.name shouldBe "java.io.PrintStream.println(java.lang.Object)"
             info.localName shouldBe "println"
             info.`type`.name shouldBe "(java.lang.Object)void"
-            info.isCallable shouldBe true
           case "4" =>
             info.name shouldBe "java.io.File"
             info.localName shouldBe "File"
             info.`type`.name shouldBe "java.io.File"
-            info.isCallable shouldBe false
+            info.`type` shouldBe a[BasicTypeInfo]
           case "5" =>
             info.name shouldBe "org.example.Test2"
             info.localName shouldBe "Test2"
             info.`type`.name shouldBe "org.example.Test2"
-            info.isCallable shouldBe false
+            info.`type` shouldBe a[BasicTypeInfo]
             info.declPos should matchPattern { case Some(OffsetSourcePosition(f, 22)) if f.getName == "Test2.java" => }
           case "6" =>
             info.name shouldBe "org.example.Test2.compute()"
             info.localName shouldBe "compute"
             info.`type`.name shouldBe "()int"
-            info.isCallable shouldBe true
             info.declPos should matchPattern {
               case Some(LineSourcePosition(f, 8)) if f.getName == "Test2.java" =>
               case Some(OffsetSourcePosition(f, 48)) if f.getName == "Test2.java" =>
@@ -140,31 +138,30 @@ class JavaCompilerSpec extends EnsimeSpec
             info.name shouldBe "org.example.Test1.compute(int,int)"
             info.localName shouldBe "compute"
             info.`type`.name shouldBe "(int,int)int"
-            info.isCallable shouldBe true
             info.declPos should matchPattern { case Some(OffsetSourcePosition(f, 481)) if f.getName == "Test1.java" => }
           case "8" =>
             info.name shouldBe "org.example.Test1.CONST"
             info.localName shouldBe "CONST"
             info.`type`.name shouldBe "int"
-            info.isCallable shouldBe false
+            info.`type` shouldBe a[BasicTypeInfo]
             info.declPos should matchPattern { case Some(OffsetSourcePosition(f, 98)) if f.getName == "Test1.java" => }
           case "9" =>
             info.name shouldBe "org.example.Test1.Day"
             info.localName shouldBe "Day"
             info.`type`.name shouldBe "org.example.Test1.Day"
-            info.isCallable shouldBe false
+            info.`type` shouldBe a[BasicTypeInfo]
             info.declPos should matchPattern { case Some(OffsetSourcePosition(f, 653)) if f.getName == "Test1.java" => }
           case "10" =>
             info.name shouldBe "org.example.Test1.Day.MON"
             info.localName shouldBe "MON"
             info.`type`.name shouldBe "org.example.Test1.Day"
-            info.isCallable shouldBe false
+            info.`type` shouldBe a[BasicTypeInfo]
             // Don't specify offset pos here as Java 6 seems to have a problem locating enums
             info.declPos should matchPattern { case Some(OffsetSourcePosition(f, i: Int)) if f.getName == "Test1.java" => }
           case "13" | "14" =>
             info.name shouldBe "k"
             info.`type`.name shouldBe "int"
-            info.isCallable shouldBe false
+            info.`type` shouldBe a[BasicTypeInfo]
         }
       }
   }

--- a/core/src/it/scala/org/ensime/core/RichPresentationCompilerSpec.scala
+++ b/core/src/it/scala/org/ensime/core/RichPresentationCompilerSpec.scala
@@ -343,7 +343,7 @@ class RichPresentationCompilerSpec extends EnsimeSpec
     "case class pi@@po extends bidon { }"
   ) { (p, cc) =>
       val info = cc.askInspectTypeAt(p)
-      val supers = info.map(_.supers).getOrElse(List())
+      val supers = info.map(_.supers).getOrElse(Nil)
       val supersNames = supers.map(_.tpe.name).toList
       supersNames.toSet should ===(Set("pipo", "bidon", "Object", "Product", "Serializable", "Any"))
     }

--- a/core/src/it/scala/org/ensime/core/RichPresentationCompilerSpec.scala
+++ b/core/src/it/scala/org/ensime/core/RichPresentationCompilerSpec.scala
@@ -268,7 +268,7 @@ class RichPresentationCompilerSpec extends EnsimeSpec
       val result = cc.completionsAt(p, 10, caseSens = false)
       forAtLeast(1, result.completions) { x =>
         x.name shouldBe "Vector"
-        x.isCallable shouldBe true
+        x.typeInfo.get shouldBe a[ArrowTypeInfo]
       }
     }
 

--- a/core/src/it/scala/org/ensime/intg/BasicWorkflow.scala
+++ b/core/src/it/scala/org/ensime/intg/BasicWorkflow.scala
@@ -166,11 +166,11 @@ class BasicWorkflow extends EnsimeSpec
           expectMsgPF() {
             case SymbolInfo("copy", "copy", Some(OffsetSourcePosition(`barFile`, 59)),
               ArrowTypeInfo("(String, Int) => Foo", "(java.lang.String, scala.Int) => org.example.Bar.Foo",
-                BasicTypeInfo("Foo", DeclaredAs.Class, "org.example.Bar.Foo", List(), List(), None),
+                BasicTypeInfo("Foo", DeclaredAs.Class, "org.example.Bar.Foo", Nil, Nil, None),
                 List(ParamSectionInfo(
                   List(
-                    ("bar", BasicTypeInfo("String", DeclaredAs.Class, "java.lang.String", List(), List(), None)),
-                    ("baz", BasicTypeInfo("Int", DeclaredAs.Class, "scala.Int", List(), List(), None))), false)))) =>
+                    ("bar", BasicTypeInfo("String", DeclaredAs.Class, "java.lang.String", Nil, Nil, None)),
+                    ("baz", BasicTypeInfo("Int", DeclaredAs.Class, "scala.Int", Nil, Nil, None))), false)))) =>
           }
 
           // C-c C-v p Inspect source of current package

--- a/core/src/it/scala/org/ensime/intg/BasicWorkflow.scala
+++ b/core/src/it/scala/org/ensime/intg/BasicWorkflow.scala
@@ -131,15 +131,14 @@ class BasicWorkflow extends EnsimeSpec
           // loaded by the pres compiler
           project ! SymbolAtPointReq(Left(fooFile), 276)
           expectMsgPF() {
-            case SymbolInfo("testMethod", "testMethod", Some(OffsetSourcePosition(`fooFile`, 114)), ArrowTypeInfo("(Int, String) => Int", "(scala.Int, java.lang.String) => scala.Int", BasicTypeInfo("Int", DeclaredAs.Class, "scala.Int", Nil, Nil, None), List(ParamSectionInfo(List(("i", BasicTypeInfo("Int", DeclaredAs.Class, "scala.Int", Nil, Nil, None)), (s, BasicTypeInfo("String", DeclaredAs.Class, "java.lang.String", Nil, Nil, None))), false))), true) =>
+            case SymbolInfo("testMethod", "testMethod", Some(OffsetSourcePosition(`fooFile`, 114)), ArrowTypeInfo("(Int, String) => Int", "(scala.Int, java.lang.String) => scala.Int", BasicTypeInfo("Int", DeclaredAs.Class, "scala.Int", Nil, Nil, None), List(ParamSectionInfo(List(("i", BasicTypeInfo("Int", DeclaredAs.Class, "scala.Int", Nil, Nil, None)), (s, BasicTypeInfo("String", DeclaredAs.Class, "java.lang.String", Nil, Nil, None))), false)))) =>
           }
 
           // M-.  external symbol
           project ! SymbolAtPointReq(Left(fooFile), 190)
           expectMsgPF() {
             case SymbolInfo("Map", "Map", Some(OffsetSourcePosition(_, _)),
-              BasicTypeInfo("Map", DeclaredAs.Object, "scala.collection.immutable.Map", Nil, Nil, None),
-              false) =>
+              BasicTypeInfo("Map", DeclaredAs.Object, "scala.collection.immutable.Map", Nil, Nil, None)) =>
           }
 
           project ! SymbolAtPointReq(Left(fooFile), 343)
@@ -149,8 +148,7 @@ class BasicWorkflow extends EnsimeSpec
                 List(
                   BasicTypeInfo("String", DeclaredAs.Class, "java.lang.String", Nil, Nil, None),
                   BasicTypeInfo("Int", DeclaredAs.Class, "scala.Int", Nil, Nil, None)),
-                Nil, None),
-              false) =>
+                Nil, None)) =>
           }
 
           project ! SymbolAtPointReq(Left(barFile), 150)
@@ -161,8 +159,7 @@ class BasicWorkflow extends EnsimeSpec
                 List(ParamSectionInfo(
                   List(
                     ("bar", BasicTypeInfo("String", DeclaredAs.Class, "java.lang.String", Nil, Nil, None)),
-                    ("baz", BasicTypeInfo("Int", DeclaredAs.Class, "scala.Int", Nil, Nil, None))), false))),
-              true) =>
+                    ("baz", BasicTypeInfo("Int", DeclaredAs.Class, "scala.Int", Nil, Nil, None))), false)))) =>
           }
 
           project ! SymbolAtPointReq(Left(barFile), 193)
@@ -173,8 +170,7 @@ class BasicWorkflow extends EnsimeSpec
                 List(ParamSectionInfo(
                   List(
                     ("bar", BasicTypeInfo("String", DeclaredAs.Class, "java.lang.String", List(), List(), None)),
-                    ("baz", BasicTypeInfo("Int", DeclaredAs.Class, "scala.Int", List(), List(), None))), false))),
-              true) =>
+                    ("baz", BasicTypeInfo("Int", DeclaredAs.Class, "scala.Int", List(), List(), None))), false)))) =>
           }
 
           // C-c C-v p Inspect source of current package

--- a/core/src/it/scala/org/ensime/intg/DebugTest.scala
+++ b/core/src/it/scala/org/ensime/intg/DebugTest.scala
@@ -74,13 +74,13 @@ class DebugTest extends EnsimeSpec
             project ! DebugBacktraceReq(threadId, 0, 3)
             expectMsgType[DebugBacktrace] should matchPattern {
               case DebugBacktrace(List(
-                DebugStackFrame(0, List(), 0, "breakpoints.Breakpoints", "mainTest",
+                DebugStackFrame(0, Nil, 0, "breakpoints.Breakpoints", "mainTest",
                   LineSourcePosition(`breakpointsFile`, 32), _),
                 DebugStackFrame(1, List(
                   DebugStackLocal(0, "args", "Array(length = 0)[<EMPTY>]", "java.lang.String[]")
                   ), 1, "breakpoints.Breakpoints$", "main",
                   LineSourcePosition(`breakpointsFile`, 42), _),
-                DebugStackFrame(2, List(), 1, "breakpoints.Breakpoints", "main",
+                DebugStackFrame(2, Nil, 1, "breakpoints.Breakpoints", "main",
                   LineSourcePosition(`breakpointsFile`, _), _)
                 ), `threadId`, "main") =>
             }

--- a/core/src/main/scala/org/ensime/core/Completion.scala
+++ b/core/src/main/scala/org/ensime/core/Completion.scala
@@ -322,7 +322,7 @@ object Keywords {
   )
 
   val keywordCompletions = keywords map { keyword =>
-    CompletionInfo(None, keyword, CompletionSignature(Nil, "", hasImplicit = false), false, 100, None)
+    CompletionInfo(None, keyword, 100, None)
   }
 }
 
@@ -338,7 +338,7 @@ trait Completion { self: RichPresentationCompiler =>
         memberSyms.flatMap { s =>
           val name = if (s.hasPackageFlag) { s.nameString } else { shortName(s).underlying }
           if (name.startsWith(prefix))
-            Some(CompletionInfo(None, name, CompletionSignature(Nil, "", false), isCallable = false, 50, None))
+            Some(CompletionInfo(None, name, 50, None))
           else
             None
         }.toList.sortBy(ci => (ci.relevance, ci.name))
@@ -375,8 +375,7 @@ object CompletionUtil {
         s.syms.map { s =>
           CompletionInfo(
             None,
-            s.localName, CompletionSignature(List.empty, s.name, false),
-            isCallable = false, 40, None
+            s.localName, 40, None
           )
         }
       case unknown =>

--- a/core/src/main/scala/org/ensime/core/javac/JavaCompiler.scala
+++ b/core/src/main/scala/org/ensime/core/javac/JavaCompiler.scala
@@ -13,7 +13,7 @@ import akka.event.slf4j.SLF4JLogging
 import com.sun.source.tree.{ Scope, IdentifierTree, MemberSelectTree }
 import com.sun.source.util.{ JavacTask, TreePath }
 import com.sun.tools.javac.util.Abort
-import javax.lang.model.`type`.{ TypeMirror, TypeKind }
+import javax.lang.model.`type`.{ TypeMirror }
 import javax.lang.model.element.ExecutableElement
 import javax.tools._
 import org.ensime.api._
@@ -105,8 +105,7 @@ class JavaCompiler(
             fqn(c, path).map(_.toFqnString).getOrElse(name),
             name,
             findDeclPos(c, path),
-            tpeMirror.map(typeMirrorToTypeInfo).getOrElse(nullTpe),
-            tpeMirror.map(_.getKind == TypeKind.EXECUTABLE).getOrElse(false)
+            tpeMirror.map(typeMirrorToTypeInfo).getOrElse(nullTpe)
           ))
         }
         path.getLeaf match {

--- a/core/src/main/scala/org/ensime/core/javac/JavaCompletion.scala
+++ b/core/src/main/scala/org/ensime/core/javac/JavaCompletion.scala
@@ -85,11 +85,11 @@ trait JavaCompletion { this: JavaCompiler =>
           scopeMemberCandidates(c, s, defaultPrefix, caseSens, constructing)
         }
       }) map { scopeCandidates =>
-        val typeSearchResult = typeSearch.flatMap(Await.result(_, Duration.Inf)).getOrElse(List())
+        val typeSearchResult = typeSearch.flatMap(Await.result(_, Duration.Inf)).getOrElse(Nil)
         scopeCandidates ++ typeSearchResult
       }
 
-    }).getOrElse(List())
+    }).getOrElse(Nil)
     CompletionInfoList(defaultPrefix, candidates.sortWith({ (c1, c2) =>
       c1.relevance > c2.relevance ||
         (c1.relevance == c2.relevance &&
@@ -127,7 +127,7 @@ trait JavaCompletion { this: JavaCompiler =>
     val pkg = selectedPackageName(select)
     val candidates = (Option(compilation.elements.getPackageElement(pkg)) map { p: PackageElement =>
       p.getEnclosedElements().flatMap { e => filterElement(compilation, e, prefix, caseSense, true, false) }
-    }).getOrElse(List())
+    }).getOrElse(Nil)
     candidates.toList
   }
 
@@ -143,9 +143,9 @@ trait JavaCompletion { this: JavaCompiler =>
         case e: ExecutableElement if !typesOnly => List(methodInfo(e, relevance + 5))
         case e: VariableElement if !typesOnly => List(fieldInfo(e, relevance + 10))
         case e: TypeElement => if (constructors) constructorInfos(c, e, relevance + 5) else List(typeInfo(e, relevance))
-        case _ => List()
+        case _ => Nil
       }
-    } else List()
+    } else Nil
   }
 
   private def scopeMemberCandidates(

--- a/core/src/main/scala/org/ensime/core/javac/JavaCompletion.scala
+++ b/core/src/main/scala/org/ensime/core/javac/JavaCompletion.scala
@@ -228,27 +228,20 @@ trait JavaCompletion { this: JavaCompiler =>
     CompletionInfo(
       Some(methodToTypeInfo(e)),
       e.getSimpleName.toString,
-      CompletionSignature(
-        List(e.getParameters().map { p => (p.getSimpleName.toString, p.asType.toString) }.toList),
-        e.getReturnType.toString,
-        false
-      ),
-      true, relevance, None
+      relevance, None
     )
 
   private def fieldInfo(e: VariableElement, relevance: Int): CompletionInfo = {
     val s = e.getSimpleName.toString
     CompletionInfo(
-      None,
-      s, CompletionSignature(List(), e.asType.toString, false), false, relevance, None
+      None, s, relevance, None
     )
   }
 
   private def typeInfo(e: TypeElement, relevance: Int): CompletionInfo = {
     val s = e.getSimpleName.toString
     CompletionInfo(
-      None,
-      s, CompletionSignature(List(), e.asType.toString, false), false, relevance, None
+      None, s, relevance, None
     )
   }
 

--- a/core/src/main/scala/org/ensime/model/ModelBuilders.scala
+++ b/core/src/main/scala/org/ensime/model/ModelBuilders.scala
@@ -19,18 +19,6 @@ trait ModelBuilders {
 
   import rootMirror.RootPackage
 
-  def completionSignatureForType(tpe: Type): CompletionSignature = {
-    if (isArrowType(tpe)) {
-      CompletionSignature(
-        tpe.paramss.map { sect =>
-          sect.map { p => (p.name.toString, fullName(p.tpe).underlying) }
-        },
-        fullName(tpe.finalResultType).underlying,
-        tpe.paramss.exists { sect => sect.exists(_.isImplicit) }
-      )
-    } else CompletionSignature(List.empty, fullName(tpe).underlying, false)
-  }
-
   def locateSymbolPos(sym: Symbol, needPos: PosNeeded): Option[SourcePosition] = {
     _locateSymbolPos(sym, needPos).orElse({
       sym.companionSymbol match {
@@ -243,8 +231,7 @@ trait ModelBuilders {
         name,
         localName,
         locateSymbolPos(sym, PosNeededYes),
-        TypeInfo(tpe, PosNeededAvail),
-        isArrowType(tpe)
+        TypeInfo(tpe, PosNeededAvail)
       )
     }
   }
@@ -257,8 +244,6 @@ trait ModelBuilders {
       CompletionInfo(
         Some(TypeInfo(tpe)),
         sym.nameString,
-        completionSignatureForType(tpe),
-        isArrowType(tpe.underlying),
         relevance,
         None
       )

--- a/core/src/test/scala/org/ensime/indexer/ClassfileIndexerSpec.scala
+++ b/core/src/test/scala/org/ensime/indexer/ClassfileIndexerSpec.scala
@@ -16,19 +16,19 @@ class ClassfileIndexerSpec extends EnsimeSpec with IsolatedEnsimeVFSFixture {
 
   "ClassfileIndexer" should "support Java 6 class files" in withVFS { implicit vfs =>
     val (clazz, refs) = indexClassfile(vfs.vres("jdk6/Test.class"))
-    clazz.name shouldBe ClassName(PackageName(List()), "Test")
+    clazz.name shouldBe ClassName(PackageName(Nil), "Test")
     clazz.generics shouldBe None
     clazz.superClass shouldBe Some(ClassName(PackageName(List("java", "lang")), "Object"))
-    clazz.interfaces shouldBe List()
+    clazz.interfaces shouldBe Nil
     clazz.access shouldBe Default
     clazz.deprecated shouldBe false
     clazz.fields shouldBe Queue()
     clazz.methods shouldBe Queue(
       RawMethod(
         name = MethodName(
-          ClassName(PackageName(List()), "Test"),
+          ClassName(PackageName(Nil), "Test"),
           "main",
-          Descriptor(List(ArrayDescriptor(ClassName(PackageName(List("java", "lang")), "String"))), ClassName(PackageName(List()), "void"))
+          Descriptor(List(ArrayDescriptor(ClassName(PackageName(List("java", "lang")), "String"))), ClassName(PackageName(Nil), "void"))
         ),
         access = Public,
         generics = None,
@@ -38,7 +38,7 @@ class ClassfileIndexerSpec extends EnsimeSpec with IsolatedEnsimeVFSFixture {
     clazz.source shouldBe RawSource(Some("Test.java"), Some(1))
 
     refs shouldBe Set(
-      ClassName(PackageName(List()), "void"),
+      ClassName(PackageName(Nil), "void"),
       ClassName(PackageName(List("java", "lang")), "Object"),
       FieldName(ClassName(PackageName(List("java", "lang")), "System"), "out"),
       ClassName(PackageName(List("java", "lang")), "Object"),

--- a/protocol-jerky/src/test/scala/org/ensime/jerk/JerkFormatsSpec.scala
+++ b/protocol-jerky/src/test/scala/org/ensime/jerk/JerkFormatsSpec.scala
@@ -476,22 +476,22 @@ class JerkFormatsSpec extends EnsimeSpec with SprayJsonTestSupport with EnsimeTe
 
     roundtrip(
       completionInfo: EnsimeServerMessage,
-      """{"typehint":"CompletionInfo","typeInfo":{"name":"type1","fullName":"FOO.type1","typehint":"BasicTypeInfo","typeArgs":[],"members":[],"declAs":{"typehint":"Method"}},"name":"name","typeSig":{"sections":[[["abc","def"],["hij","lmn"]]],"result":"ABC", "hasImplicit": false},"relevance":90,"isCallable":false,"toInsert":"BAZ"}"""
+      """{"name":"name","typeInfo":{"name":"type1","fullName":"FOO.type1","typehint":"BasicTypeInfo","typeArgs":[],"members":[],"declAs":{"typehint":"Method"}},"typehint":"CompletionInfo","relevance":90,"toInsert":"BAZ"}"""
     )
 
     roundtrip(
       completionInfo2: EnsimeServerMessage,
-      """{"typehint":"CompletionInfo","name":"name2","typeSig":{"sections":[[["abc","def"]]],"result":"ABC", "hasImplicit": false},"relevance":91,"isCallable":true}"""
+      """{"typehint":"CompletionInfo","name":"name2","relevance":91}"""
     )
 
     roundtrip(
       CompletionInfoList("fooBar", List(completionInfo)): EnsimeServerMessage,
-      """{"typehint":"CompletionInfoList","prefix":"fooBar","completions":[{"typeInfo":{"name":"type1","fullName":"FOO.type1","typehint":"BasicTypeInfo","typeArgs":[],"members":[],"declAs":{"typehint":"Method"}},"name":"name","typeSig":{"sections":[[["abc","def"],["hij","lmn"]]],"result":"ABC", "hasImplicit": false},"relevance":90,"isCallable":false,"toInsert":"BAZ"}]}"""
+      """{"typehint":"CompletionInfoList","prefix":"fooBar","completions":[{"typeInfo":{"name":"type1","fullName":"FOO.type1","typehint":"BasicTypeInfo","typeArgs":[],"members":[],"declAs":{"typehint":"Method"}},"name":"name","relevance":90,"toInsert":"BAZ"}]}"""
     )
 
     roundtrip(
-      new SymbolInfo("name", "localName", None, typeInfo, false): EnsimeServerMessage,
-      """{"typehint":"SymbolInfo","name":"name","localName":"localName","type":{"name":"type1","fullName":"FOO.type1","typehint":"BasicTypeInfo","typeArgs":[],"members":[],"declAs":{"typehint":"Method"}},"isCallable":false}"""
+      new SymbolInfo("name", "localName", None, typeInfo): EnsimeServerMessage,
+      """{"typehint":"SymbolInfo","name":"name","localName":"localName","type":{"name":"type1","fullName":"FOO.type1","typehint":"BasicTypeInfo","typeArgs":[],"members":[],"declAs":{"typehint":"Method"}}}"""
     )
 
     roundtrip(
@@ -575,12 +575,12 @@ class JerkFormatsSpec extends EnsimeSpec with SprayJsonTestSupport with EnsimeTe
 
     roundtrip(
       ImplicitInfos(List(ImplicitConversionInfo(5, 6, symbolInfo))): EnsimeServerMessage,
-      """{"typehint":"ImplicitInfos","infos":[{"typehint":"ImplicitConversionInfo","start":5,"end":6,"fun":{"name":"name","localName":"localName","type":{"name":"type1","fullName":"FOO.type1","typehint":"BasicTypeInfo","typeArgs":[],"members":[],"declAs":{"typehint":"Method"}},"isCallable":false}}]}"""
+      """{"typehint":"ImplicitInfos","infos":[{"typehint":"ImplicitConversionInfo","start":5,"end":6,"fun":{"name":"name","localName":"localName","type":{"name":"type1","fullName":"FOO.type1","typehint":"BasicTypeInfo","typeArgs":[],"members":[],"declAs":{"typehint":"Method"}}}}]}"""
     )
 
     roundtrip(
       ImplicitInfos(List(ImplicitParamInfo(5, 6, symbolInfo, List(symbolInfo, symbolInfo), true))): EnsimeServerMessage,
-      """{"typehint":"ImplicitInfos","infos":[{"params":[{"name":"name","localName":"localName","type":{"name":"type1","fullName":"FOO.type1","typehint":"BasicTypeInfo","typeArgs":[],"members":[],"declAs":{"typehint":"Method"}},"isCallable":false},{"name":"name","localName":"localName","type":{"name":"type1","fullName":"FOO.type1","typehint":"BasicTypeInfo","typeArgs":[],"members":[],"declAs":{"typehint":"Method"}},"isCallable":false}],"typehint":"ImplicitParamInfo","fun":{"name":"name","localName":"localName","type":{"name":"type1","fullName":"FOO.type1","typehint":"BasicTypeInfo","typeArgs":[],"members":[],"declAs":{"typehint":"Method"}},"isCallable":false},"funIsImplicit":true,"end":6,"start":5}]}"""
+      """{"typehint":"ImplicitInfos","infos":[{"params":[{"name":"name","localName":"localName","type":{"name":"type1","fullName":"FOO.type1","typehint":"BasicTypeInfo","typeArgs":[],"members":[],"declAs":{"typehint":"Method"}}},{"name":"name","localName":"localName","type":{"name":"type1","fullName":"FOO.type1","typehint":"BasicTypeInfo","typeArgs":[],"members":[],"declAs":{"typehint":"Method"}}}],"typehint":"ImplicitParamInfo","fun":{"name":"name","localName":"localName","type":{"name":"type1","fullName":"FOO.type1","typehint":"BasicTypeInfo","typeArgs":[],"members":[],"declAs":{"typehint":"Method"}}},"funIsImplicit":true,"end":6,"start":5}]}"""
     )
 
   }

--- a/protocol-swanky/src/main/scala/org/ensime/server/protocol/swank/SwankFormats.scala
+++ b/protocol-swanky/src/main/scala/org/ensime/server/protocol/swank/SwankFormats.scala
@@ -375,20 +375,6 @@ object SwankProtocolResponse {
     }
   }
 
-  implicit object CompletionSignatureFormat extends SexpFormat[CompletionSignature] {
-    private implicit val Tuple2Format: SexpFormat[(String, String)] = cachedImplicit
-    def write(cs: CompletionSignature): Sexp =
-      SexpList(cs.sections.toSexp, cs.result.toSexp, cs.hasImplicit.toSexp)
-    def read(sexp: Sexp): CompletionSignature = sexp match {
-      case SexpList(a :: b :: c :: Nil) => CompletionSignature(
-        a.convertTo[List[List[(String, String)]]],
-        b.convertTo[String],
-        c.convertTo[Boolean]
-      )
-      case _ => deserializationError(sexp)
-    }
-  }
-
   // watch out for recursive references here...
   implicit object TypeInfoFormat extends TraitFormatAlt[TypeInfo] {
     // a bit weird, but that's how we've been doing it

--- a/protocol-swanky/src/test/scala/org/ensime/server/protocol/swank/SwankFormatsSpec.scala
+++ b/protocol-swanky/src/test/scala/org/ensime/server/protocol/swank/SwankFormatsSpec.scala
@@ -323,7 +323,7 @@ class SwankFormatsSpec extends EnsimeSpec with EnsimeTestData {
     marshal(
       NewScalaNotesEvent(
         isFull = false,
-        List(new Note("foo.scala", "testMsg", NoteWarn, 50, 55, 77, 5))
+        List(Note("foo.scala", "testMsg", NoteWarn, 50, 55, 77, 5))
       ): EnsimeEvent,
       """(:scala-notes (:notes ((:file "foo.scala" :msg "testMsg" :severity warn :beg 50 :end 55 :line 77 :col 5))))"""
     )
@@ -491,26 +491,26 @@ class SwankFormatsSpec extends EnsimeSpec with EnsimeTestData {
 
     marshal(
       completionInfo: CompletionInfo,
-      """(:type-info (:arrow-type nil :name "type1" :decl-as method :full-name "FOO.type1") :name "name" :type-sig (((("abc" "def") ("hij" "lmn"))) "ABC" nil) :relevance 90 :to-insert "BAZ")"""
+      """(:type-info (:arrow-type nil :name "type1" :decl-as method :full-name "FOO.type1") :name "name" :relevance 90 :to-insert "BAZ")"""
     )
 
     marshal(
       completionInfo2: CompletionInfo,
-      """(:name "name2" :type-sig (((("abc" "def"))) "ABC" nil) :is-callable t :relevance 91)"""
+      """(:name "name2" :relevance 91)"""
     )
 
     marshal(
       CompletionInfoList("fooBar", List(completionInfo)): CompletionInfoList,
-      """(:prefix "fooBar" :completions ((:type-info (:arrow-type nil :name "type1" :decl-as method :full-name "FOO.type1") :name "name" :type-sig (((("abc" "def") ("hij" "lmn"))) "ABC" nil) :relevance 90 :to-insert "BAZ")))"""
+      """(:prefix "fooBar" :completions ((:type-info (:arrow-type nil :name "type1" :decl-as method :full-name "FOO.type1") :name "name" :relevance 90 :to-insert "BAZ")))"""
     )
 
     marshal(
-      new SymbolInfo("name", "localName", None, typeInfo, false): SymbolInfo,
+      SymbolInfo("name", "localName", None, typeInfo): SymbolInfo,
       """(:name "name" :local-name "localName" :type (:arrow-type nil :name "type1" :decl-as method :full-name "FOO.type1"))"""
     )
 
     marshal(
-      new NamedTypeMemberInfo("typeX", typeInfo, None, None, DeclaredAs.Method): EntityInfo,
+      NamedTypeMemberInfo("typeX", typeInfo, None, None, DeclaredAs.Method): EntityInfo,
       """(:name "typeX" :type (:arrow-type nil :name "type1" :decl-as method :full-name "FOO.type1") :decl-as method)"""
     )
 
@@ -535,7 +535,7 @@ class SwankFormatsSpec extends EnsimeSpec with EnsimeTestData {
     )
 
     marshal(
-      new TypeInspectInfo(typeInfo, List(interfaceInfo)): TypeInspectInfo,
+      TypeInspectInfo(typeInfo, List(interfaceInfo)): TypeInspectInfo,
       """(:type (:arrow-type nil :name "type1" :decl-as method :full-name "FOO.type1") :interfaces ((:type (:arrow-type nil :name "type1" :decl-as method :full-name "FOO.type1") :via-view "DEF")) :info-type typeInspect)"""
     )
 
@@ -552,12 +552,12 @@ class SwankFormatsSpec extends EnsimeSpec with EnsimeTestData {
 
   it should "marshal search related responses" in {
     marshal(
-      new SymbolSearchResults(List(methodSearchRes, typeSearchRes)): SymbolSearchResults,
+      SymbolSearchResults(List(methodSearchRes, typeSearchRes)): SymbolSearchResults,
       s"""((:type method :name "abc" :local-name "a" :decl-as method :pos (:type line :file "$abd" :line 10) :owner-name "ownerStr") (:type type :name "abc" :local-name "a" :decl-as trait :pos (:type line :file "$abd" :line 10)))"""
     )
 
     marshal(
-      new ImportSuggestions(List(List(methodSearchRes, typeSearchRes))): ImportSuggestions,
+      ImportSuggestions(List(List(methodSearchRes, typeSearchRes))): ImportSuggestions,
       s"""(((:type method :name "abc" :local-name "a" :decl-as method :pos (:type line :file "$abd" :line 10) :owner-name "ownerStr") (:type type :name "abc" :local-name "a" :decl-as trait :pos (:type line :file "$abd" :line 10))))"""
     )
 


### PR DESCRIPTION
close #1493 and uncovered #1494

also renamed all `List()` to `Nil`... it's fun reading the source code of `List` and seeing just how many object allocations that saves us :smile: