### PR TITLE
Add support for by-name parameters in ArrowTypeInfoBuilder.

### DIFF
--- a/core/src/it/scala/org/ensime/core/TypeToScalaNameSpec.scala
+++ b/core/src/it/scala/org/ensime/core/TypeToScalaNameSpec.scala
@@ -29,6 +29,8 @@ class TypeToScalaNameSpec extends EnsimeSpec
       "    def hl@hlist@ist: Int :: String :: HNil = null",
       "    def re@refined@fined = 1.narrow",
       "    def ex@exciting@citing = 'f' ->> 23.narrow",
+      "    def by@byname@name(i: Int, s: => (Int, String)): String = s._2",
+      "    val s: String = by@bynamecall@name(15, (16, \"hello\"))",
       "}"
     ) { (p, label, cc) =>
         withClue(label) {
@@ -123,6 +125,30 @@ class TypeToScalaNameSpec extends EnsimeSpec
                   Class,
                   "scala.Int(23) with shapeless.labelled.KeyTag[scala.Char('f'), scala.Int(23)]",
                   Nil, Nil, None
+                )
+
+              case "byname" =>
+                BasicTypeInfo(
+                  "String",
+                  Class,
+                  "java.lang.String",
+                  Nil, Nil, None
+                )
+
+              case "bynamecall" =>
+                ArrowTypeInfo(
+                  "(Int, => (Int, String)) => String",
+                  "(scala.Int, => (scala.Int, java.lang.String)) => java.lang.String",
+                  BasicTypeInfo("String", Class, "java.lang.String", Nil, Nil, None),
+                  List(ParamSectionInfo(List(
+                    ("i", BasicTypeInfo("Int", Class, "scala.Int", Nil, Nil, None)),
+                    ("s", ArrowTypeInfo("=> (Int, String)", "=> (scala.Int, java.lang.String)",
+                      BasicTypeInfo("(Int, String)", Class, "(scala.Int, java.lang.String)",
+                        List(
+                          BasicTypeInfo("Int", Class, "scala.Int", Nil, Nil, None),
+                          BasicTypeInfo("String", Class, "java.lang.String", Nil, Nil, None)
+                        ), Nil, None), Nil))
+                  ), false))
                 )
             }
           }

--- a/core/src/main/scala/org/ensime/core/Helpers.scala
+++ b/core/src/main/scala/org/ensime/core/Helpers.scala
@@ -33,6 +33,7 @@ trait Helpers { self: Global =>
   def isArrowType(tpe: Type): Boolean = {
     tpe match {
       case args: ArgsTypeRef if args.typeSymbol.fullName.startsWith("scala.Function") => true
+      case TypeRef(_, definitions.ByNameParamClass, _) => true
       case _: MethodType => true
       case _: PolyType => true
       case _ =>

--- a/core/src/main/scala/org/ensime/core/TypeToScalaName.scala
+++ b/core/src/main/scala/org/ensime/core/TypeToScalaName.scala
@@ -14,6 +14,8 @@ final class ScalaName(val underlying: String) extends AnyVal {
 }
 
 trait TypeToScalaName { self: Global with Helpers =>
+  import definitions._
+
   def scalaName(tpe: Type, full: Boolean): ScalaName = tpe match {
     case _: MethodType | _: PolyType =>
       val tparams = tpe.paramss.map { sect =>
@@ -36,6 +38,10 @@ trait TypeToScalaName { self: Global with Helpers =>
         else tpe.typeSymbol.nameString
 
       new ScalaName(parts.init.mkString(" ")) + s" $name ${parts.last}"
+
+    case TypeRef(_, ByNameParamClass, args) =>
+      val parts = args.map(scalaName(_, full).underlying)
+      new ScalaName(s"=> ${parts.mkString}")
 
     case _ =>
       val name = tpe match {

--- a/core/src/main/scala/org/ensime/model/ModelBuilders.scala
+++ b/core/src/main/scala/org/ensime/model/ModelBuilders.scala
@@ -288,8 +288,13 @@ trait ModelBuilders {
             else tparams.init.zipWithIndex.map { case (tpe, idx) => ("_" + idx, TypeInfo(tpe)) }
           ArrowTypeInfo(shortName(tpe).underlying, fullName(tpe).underlying, result, ParamSectionInfo(params, isImplicit = false) :: Nil)
 
+        case TypeRef(_, definitions.ByNameParamClass, args) =>
+          val result = TypeInfo(args.head)
+          ArrowTypeInfo(shortName(tpe).underlying, fullName(tpe).underlying, result, Nil)
+
         case tpe: MethodType => apply(tpe, tpe.paramss.map(ParamSectionInfoBuilder.apply), tpe.finalResultType)
         case tpe: PolyType => apply(tpe, tpe.paramss.map(ParamSectionInfoBuilder.apply), tpe.finalResultType)
+
         case _ => nullInfo()
       }
     }


### PR DESCRIPTION
This resolves #1477.