### PR TITLE
Fix debugger issues

### DIFF
--- a/core/src/it/scala/org/ensime/intg/DebugTest.scala
+++ b/core/src/it/scala/org/ensime/intg/DebugTest.scala
@@ -240,7 +240,7 @@ class DebugTest extends EnsimeSpec
                 summary should startWith("Instance of scala.collection.immutable.$colon$colon")
                 exactly(1, debugFields) should matchPattern {
                   case DebugClassField(_, head, "java.lang.Object", summary) if (
-                    (head == "head" || head == "scala$collection$immutable$$colon$colon$$hd") &&
+                    (head == "head" || head == "hd") &&
                     summary.startsWith("Instance of java.lang.Integer")
                   ) =>
                 }

--- a/core/src/it/scala/org/ensime/intg/DebugTest.scala
+++ b/core/src/it/scala/org/ensime/intg/DebugTest.scala
@@ -306,6 +306,33 @@ class DebugTest extends EnsimeSpec
     }
   }
 
+  they should "be retrievable for the BugFromGitter scenario" taggedAs Debugger in withEnsimeConfig { implicit config =>
+    withTestKit { implicit testkit =>
+      withProject { (project, asyncHelper) =>
+        implicit val p = (project, asyncHelper)
+        withDebugSession(
+          "variables.BugFromGitter",
+          "variables/BugFromGitter.scala",
+          31
+        ) { (threadId, variablesFile) =>
+            getVariableAsString(threadId, "actualTimes").text should be("10")
+
+            getVariableAsString(threadId, "name").text should be("\"Rory\"")
+
+            getVariableAsString(threadId, "times").text should be("5")
+
+            getVariableAsString(threadId, "arrayTest").text should be("Array(length = 4)[1,2,3,...]")
+
+            getVariableAsString(threadId, "listTest").text should
+              startWith("Instance of scala.collection.immutable.$colon$colon")
+
+            getVariableAsString(threadId, "person").text should
+              startWith("Instance of variables.Person")
+          }
+      }
+    }
+  }
+
   they should "set variable values" taggedAs Debugger in withEnsimeConfig { implicit config =>
     withTestKit { implicit testkit =>
       withProject { (project, asyncHelper) =>

--- a/core/src/main/scala/org/ensime/core/debug/DebugActor.scala
+++ b/core/src/main/scala/org/ensime/core/debug/DebugActor.scala
@@ -194,21 +194,25 @@ class DebugActor private (
       sender ! withThread(threadId.id, {
         case (s, t) =>
           if (name == "this") {
-            t.tryTopFrame.flatMap(_.tryThisObject).map {
-              case objectReference =>
-                DebugObjectReference(objectReference.cache().uniqueId)
+            t.tryTopFrame.flatMap(_.tryThisObject).map(_.cache()).map {
+              case objRef => DebugObjectReference(objRef.uniqueId)
             }.getOrElse(FalseResponse)
           } else {
-            t.findVariableByName(name).flatMap {
+            val result = t.findVariableByName(name).map(_.cache())
+            result.flatMap {
               case v: IndexedVariableInfoProfile =>
-                Some(DebugStackSlot(DebugThreadId(t.cache().uniqueId), v.frameIndex, v.offsetIndex))
-              case v if v.isField => v.toValueInfo match {
-                case o if o.isObject =>
-                  val oo = o.toObjectInfo
-                  Some(DebugObjectField(DebugObjectId(oo.cache().uniqueId), v.name))
-                case _ =>
+                Some(DebugStackSlot(DebugThreadId(t.uniqueId), v.frameIndex, v.offsetIndex))
+              case f: FieldVariableInfoProfile => f.parent match {
+                case Left(o) =>
+                  o.cache()
+                  Some(DebugObjectField(DebugObjectId(o.uniqueId), f.name))
+                case Right(r) =>
+                  log.error(s"Field $name is unable to be located because it is static!")
                   None
               }
+              case x =>
+                log.error(s"Unknown value: $x")
+                None
             }.getOrElse(FalseResponse)
           }
       })
@@ -230,14 +234,16 @@ class DebugActor private (
     // ========================================================================
     case DebugValueReq(location) =>
       sender ! withVM(s =>
-        lookupValue(s.cache, location)
+        lookupValue(s, s.cache, location)
+          .map(_.cache())
           .map(converter.convertValue)
           .getOrElse(FalseResponse))
 
     // ========================================================================
     case DebugToStringReq(threadId, location) =>
       sender ! withVM(s =>
-        lookupValue(s.cache, location)
+        lookupValue(s, s.cache, location)
+          .map(_.cache())
           .map(_.toPrettyString)
           .map(StringResponse(_))
           .getOrElse(FalseResponse))
@@ -331,8 +337,9 @@ class DebugActor private (
     threadId: Long,
     action: (ScalaVirtualMachine, ThreadInfoProfile) => T
   ): RpcResponse = withVM(s => {
-    val result = s.tryThread(threadId).flatMap(t =>
-      suspendAndExecute(t, action(s, t)))
+    val result = s.tryThread(threadId)
+      .map(_.cache())
+      .flatMap(t => suspendAndExecute(t, action(s, t)))
 
     // Report error information
     result.failed.foreach(log.warning(s"Unable to retrieve thread with id: $threadId - {}", _))
@@ -358,22 +365,27 @@ class DebugActor private (
   /**
    * Finds a value using the provided object cache and location information.
    *
+   * @param scalaVirtualMachine The virtual machine to use as a fallback in
+   *                            various cases when the cache is empty
    * @param objectCache The object cache used to retrieve the value or
    *                    another object associated with the value
    * @param location The Ensime location information for the value to retrieve
    * @return Some value profile if the value is found, otherwise None
    */
   private def lookupValue(
+    scalaVirtualMachine: ScalaVirtualMachine,
     objectCache: ObjectCache,
     location: DebugLocation
   ): Option[ValueInfoProfile] = location match {
     // Retrieves cached object
     case DebugObjectReference(objectId) =>
+      log.debug(s"Looking up object from reference $objectId")
       objectCache.load(objectId.id)
 
     // Uses cached object with id to find associated field
     // Caches retrieved field object
     case DebugObjectField(objectId, fieldName) =>
+      log.debug(s"Looking up object field from reference $objectId and field $fieldName")
       objectCache.load(objectId.id)
         .map(_.field(fieldName))
         .map(_.toValueInfo.cache())
@@ -381,20 +393,25 @@ class DebugActor private (
     // Uses cached object with id as array to find element
     // Caches retrieved element object
     case DebugArrayElement(objectId, index) =>
+      log.debug(s"Looking up array element from reference $objectId and index $index")
       objectCache.load(objectId.id).flatMap {
-        case a: ArrayInfoProfile => Some(a)
+        case a if a.isArray => Some(a.toArrayInfo)
         case _ => None
       }.map(_.value(index).cache())
 
     // Caches retrieved slot object
     case DebugStackSlot(threadId, frame, offset) =>
-      objectCache.load(threadId.id).flatMap {
-        case t: ThreadInfoProfile => Some(t)
+      log.debug(s"Looking up object from thread $threadId, frame $frame, and offset $offset")
+      val s = scalaVirtualMachine
+      objectCache.load(threadId.id).orElse(s.tryThread(threadId.id).toOption).flatMap {
+        case t if t.isThread => Some(t.toThreadInfo)
         case _ => None
       }.flatMap(_.findVariableByIndex(frame, offset)).map(_.toValueInfo.cache())
 
     // Unrecognized location request, so return nothing
-    case _ => None
+    case _ =>
+      log.error(s"Unknown location: $location")
+      None
   }
 
   /**
@@ -455,7 +472,7 @@ class DebugActor private (
     scalaVirtualMachine.createEventListener(EventType.ExceptionEventType).foreach(e => {
       val ee = e.asInstanceOf[ExceptionEvent]
       val t = scalaVirtualMachine.thread(ee.thread())
-      val ex = scalaVirtualMachine.`object`(t, ee.exception())
+      val ex = scalaVirtualMachine.`object`(ee.exception())
       val lsp = if (ee.catchLocation() != null) {
         val l: LocationInfoProfile = scalaVirtualMachine.location(ee.catchLocation())
         sourceMap.newLineSourcePosition(l)
@@ -479,10 +496,10 @@ class DebugActor private (
       SuspendPolicyProperty.AllThreads
     ).foreach(e => {
       // Cache the exception object
-      scalaVirtualMachine.`object`(e.thread(), e.exception()).cache()
+      scalaVirtualMachine.`object`(e.exception()).cache()
 
       val t = scalaVirtualMachine.thread(e.thread())
-      val ex = scalaVirtualMachine.`object`(t, e.exception())
+      val ex = scalaVirtualMachine.`object`(e.exception())
       val lsp = if (e.catchLocation() != null) {
         val l: LocationInfoProfile = scalaVirtualMachine.location(e.catchLocation())
         sourceMap.newLineSourcePosition(l)

--- a/core/src/main/scala/org/ensime/core/debug/StructureConverter.scala
+++ b/core/src/main/scala/org/ensime/core/debug/StructureConverter.scala
@@ -19,12 +19,12 @@ class StructureConverter(private val sourceMap: SourceMap) {
    * @return The equivalent Ensime message
    */
   def convertValue(valueInfo: ValueInfoProfile): DebugValue = {
-    valueInfo match {
+    valueInfo.cache() match {
       case v if v.isNull => newDebugNull()
       case v if v.isVoid => convertVoid(v)
       case v if v.isArray => convertArray(v.toArrayInfo)
       case v if v.isString => convertString(v.toStringInfo)
-      case v if v.isObject => convertObject(v.toObjectInfo)
+      case v if v.isObject => convertObject(v.toObjectInfo.cache())
       case v if v.isPrimitive => convertPrimitive(v.toPrimitiveInfo)
     }
   }
@@ -138,7 +138,7 @@ class StructureConverter(private val sourceMap: SourceMap) {
           //       fields (from object instance)
           f.tryToValueInfo.orElse(
             obj.tryField(f.name).flatMap(_.tryToValueInfo)
-          ).map(_.toPrettyString).getOrElse("???")
+          ).map(_.cache()).map(_.toPrettyString).getOrElse("???")
         ))).getOrElse(Nil).toList ++ fields
 
       tpe = tpe.flatMap(_.superclassOption)
@@ -154,7 +154,7 @@ class StructureConverter(private val sourceMap: SourceMap) {
    */
   def convertStackFrame(frame: FrameInfoProfile): DebugStackFrame = {
     val locals = ignoreErr(
-      frame.indexedLocalVariables.map(convertStackLocal).toList,
+      frame.indexedLocalVariables.map(_.cache()).map(convertStackLocal).toList,
       List.empty
     )
 
@@ -182,6 +182,7 @@ class StructureConverter(private val sourceMap: SourceMap) {
   private def convertStackLocal(
     variableInfo: VariableInfoProfile
   ): DebugStackLocal = {
+    variableInfo.cache()
     DebugStackLocal(
       variableInfo.offsetIndex,
       variableInfo.name,

--- a/core/src/main/scala/org/ensime/core/debug/VirtualMachineManager.scala
+++ b/core/src/main/scala/org/ensime/core/debug/VirtualMachineManager.scala
@@ -2,6 +2,7 @@ package org.ensime.core.debug
 
 import com.sun.jdi.VMDisconnectedException
 import org.scaladebugger.api.debuggers.{ AttachingDebugger, Debugger, LaunchingDebugger }
+import org.scaladebugger.api.profiles.scala210.Scala210DebugProfile
 import org.scaladebugger.api.virtualmachines.{ DummyScalaVirtualMachine, ScalaVirtualMachine }
 import org.slf4j.LoggerFactory
 
@@ -19,8 +20,14 @@ class VirtualMachineManager(
     private val globalStopFunc: (ScalaVirtualMachine) => Unit = _ => {}
 ) {
   private val log = LoggerFactory.getLogger(this.getClass)
-  private lazy val dummyScalaVirtualMachine: ScalaVirtualMachine =
-    DummyScalaVirtualMachine.newInstance()
+
+  /** Create a standard dummy vm using the Scala 2.10 profile */
+  private lazy val dummyScalaVirtualMachine: ScalaVirtualMachine = {
+    val d = DummyScalaVirtualMachine.newInstance()
+    d.use(Scala210DebugProfile.Name)
+    d
+  }
+
   @volatile private var debugger: Option[Debugger] = None
   @volatile private var vm: Option[ScalaVirtualMachine] = None
   @volatile private var mode: Option[VmMode] = None
@@ -59,7 +66,11 @@ class VirtualMachineManager(
           suspend = true
         ).withPending(dummyScalaVirtualMachine)
 
-        val s = d.start(timeout = 10.seconds, startProcessingEvents = false)
+        val s = d.start(
+          timeout = 10.seconds,
+          defaultProfile = Scala210DebugProfile.Name,
+          startProcessingEvents = false
+        )
 
         (d, s)
 
@@ -69,7 +80,11 @@ class VirtualMachineManager(
           hostname = hostname
         ).withPending(dummyScalaVirtualMachine)
 
-        val s = d.start(timeout = 10.seconds, startProcessingEvents = false)
+        val s = d.start(
+          timeout = 10.seconds,
+          defaultProfile = Scala210DebugProfile.Name,
+          startProcessingEvents = false
+        )
 
         (d, s)
     }

--- a/project/EnsimeBuild.scala
+++ b/project/EnsimeBuild.scala
@@ -27,9 +27,6 @@ object EnsimeBuild extends Build {
        "io.spray" %% "spray-json" % "1.3.2"
     ),
 
-    // NOTE: Temporary for testing, will not be included in final version
-    resolvers += Resolver.sonatypeRepo("snapshots"),
-
       // disabling shared memory gives a small performance boost to tests
     javaOptions ++= Seq("-XX:+PerfDisableSharedMem"),
 
@@ -159,7 +156,7 @@ object EnsimeBuild extends Build {
         },
         "commons-lang" % "commons-lang" % "2.6",
         "com.googlecode.java-diff-utils" % "diffutils" % "1.3.0",
-        "org.scala-debugger" %% "scala-debugger-api" % "1.1.0-SNAPSHOT"
+        "org.scala-debugger" %% "scala-debugger-api" % "1.1.0-M2"
       ) ++ Sensible.testLibs("it,test") ++ Sensible.shapeless(scalaVersion.value)
     ) enablePlugins BuildInfoPlugin settings (
         buildInfoPackage := organization.value,

--- a/project/EnsimeBuild.scala
+++ b/project/EnsimeBuild.scala
@@ -156,7 +156,7 @@ object EnsimeBuild extends Build {
         },
         "commons-lang" % "commons-lang" % "2.6",
         "com.googlecode.java-diff-utils" % "diffutils" % "1.3.0",
-        "org.scala-debugger" %% "scala-debugger-api" % "1.1.0-M1"
+        "org.scala-debugger" %% "scala-debugger-api" % "1.1.0-SNAPSHOT"
       ) ++ Sensible.testLibs("it,test") ++ Sensible.shapeless(scalaVersion.value)
     ) enablePlugins BuildInfoPlugin settings (
         buildInfoPackage := organization.value,

--- a/project/EnsimeBuild.scala
+++ b/project/EnsimeBuild.scala
@@ -27,7 +27,10 @@ object EnsimeBuild extends Build {
        "io.spray" %% "spray-json" % "1.3.2"
     ),
 
-    // disabling shared memory gives a small performance boost to tests
+    // NOTE: Temporary for testing, will not be included in final version
+    resolvers += Resolver.sonatypeRepo("snapshots"),
+
+      // disabling shared memory gives a small performance boost to tests
     javaOptions ++= Seq("-XX:+PerfDisableSharedMem"),
 
     javaOptions in Test ++= Seq(

--- a/testing/debug/src/main/scala/variables/BugFromGitter.scala
+++ b/testing/debug/src/main/scala/variables/BugFromGitter.scala
@@ -1,0 +1,34 @@
+package variables
+
+/**
+ * Bug from Gitter discussion with @dickwall and @rorygraves.
+ *
+ * Need to be able to inspect variables from the specified breakpoint.
+ */
+object BugFromGitter {
+  def main(args: Array[String]): Unit = {
+    val h = new BugFromGitter("Rory", 5)
+    h.sayHello()
+  }
+}
+
+case class Person(first: String, last: String, age: Int)
+
+class BugFromGitter(name: String, times: Int) {
+  def sayHello(): Unit = {
+    val actualTimes = times * 2
+
+    val arrayTest = Array(1, 2, 3, 4)
+    val listTest = List(1, 2, 3, 4)
+
+    val person = Person(name, "Smith", 25)
+
+    println(arrayTest)
+    println(listTest)
+    println(person)
+    println(actualTimes)
+
+    for (i <- 1 to actualTimes) // Put breakpoint on this line
+      println(s"Hello $name")
+  }
+}


### PR DESCRIPTION
Resolves #1505, resolves #1506, and resolves #1508.

Tentative PR based on fixes made from @dickwall's and my own discoveries. Only change remaining is to publish `1.1.0-M2` of the debugger API and switch this branch to use that version. The snapshot is the latest master code; so, if everything in the debugger api checks out, I can publish M2 shortly.

- Fixed field location retrieval to use parent (no static field support)

- Added missing caching calls

- Fixed array bug (pattern matching was not appropriate)

- Fixed potential thread bug (same pattern matching problem as array)

- Updated dummy vm to use Scala profile

- Updated start of new VMs to use Scala profile