### PR TITLE
Javafqn to fullyqualifiedname

### DIFF
--- a/core/src/it/scala/org/ensime/core/JavaCompilerSpec.scala
+++ b/core/src/it/scala/org/ensime/core/JavaCompilerSpec.scala
@@ -5,10 +5,10 @@ package org.ensime.core
 import java.io.File
 
 import org.ensime.api._
-import org.ensime.core.javac.JavaFqn
 import org.ensime.fixture._
 import org.ensime.indexer.SearchServiceTestUtils._
 import org.ensime.util.EnsimeSpec
+import org.ensime.indexer._
 
 class JavaCompilerSpec extends EnsimeSpec
     with IsolatedJavaCompilerFixture {
@@ -65,9 +65,9 @@ class JavaCompilerSpec extends EnsimeSpec
       val test1 = SourceFileInfo(new File(config.rootDir, "testing/simple/src/main/java/org/example/Test1.java"))
       val test2 = SourceFileInfo(new File(config.rootDir, "testing/simple/src/main/java/org/example/Test2.java"))
 
-      cc.askLinkPos(JavaFqn("org.example", "Test2", None), test2) should matchPattern { case Some(OffsetSourcePosition(f, 22)) => }
-      cc.askLinkPos(JavaFqn("org.example", "Foo", None), test2) should matchPattern { case None => }
-      cc.askLinkPos(JavaFqn("org.example", "Test2.Bar", None), test2) should matchPattern { case Some(OffsetSourcePosition(f, 260)) => }
+      cc.askLinkPos(ClassName(PackageName(List("org", "example")), "Test2"), test2) should matchPattern { case Some(OffsetSourcePosition(f, 22)) => }
+      cc.askLinkPos(ClassName(PackageName(List("org", "example")), "Foo"), test2) should matchPattern { case None => }
+      cc.askLinkPos(ClassName(PackageName(List("org", "example")), "Test2.Bar"), test2) should matchPattern { case Some(OffsetSourcePosition(f, 260)) => }
       //    cc.askLinkPos(JavaFqn("org.example", "Test2", Some("compute()")), test2) should matchPattern { case Some(OffsetSourcePosition(f, 58)) => }
 
     }

--- a/core/src/main/scala/org/ensime/core/javac/Helpers.scala
+++ b/core/src/main/scala/org/ensime/core/javac/Helpers.scala
@@ -5,15 +5,19 @@ package org.ensime.core.javac
 import akka.event.slf4j.SLF4JLogging
 import com.sun.source.tree._
 import com.sun.source.util.TreePath
-import javax.lang.model.`type`.{ DeclaredType, PrimitiveType, TypeKind, TypeMirror }
+import javax.lang.model.`type`._
 import javax.lang.model.element._
+import javax.lang.model.element.ElementKind._
 import scala.collection.JavaConversions._
 
-import org.ensime.api.deprecating
 import org.ensime.core.{ DocFqn, DocSig }
 import org.ensime.indexer._
 
 trait Helpers extends UnsafeHelpers with SLF4JLogging {
+
+  private implicit class EnhachedElement(e: Element) {
+    def isOf(kinds: ElementKind*): Boolean = kinds.exists(_ == e.getKind)
+  }
 
   def typeMirror(c: Compilation, t: Tree): Option[TypeMirror] = {
     Option(c.trees.getTypeMirror(c.trees.getPath(c.compilationUnit, t)))
@@ -30,14 +34,49 @@ trait Helpers extends UnsafeHelpers with SLF4JLogging {
         .flatMap(t => Option(c.types.asElement(t))))
   }
 
+  def toSymbolName(fqn: FullyQualifiedName): String = fqn match {
+    case m: MethodName =>
+
+      val owner = m.owner.fqnString
+      val name = m.name
+
+      s"$owner.$name"
+
+    case x => x.fqnString
+  }
+
   def fqn(c: Compilation, el: Element): Option[FullyQualifiedName] = el match {
     case e: ExecutableElement =>
 
-      descriptor(c, e).map {
+      descriptor(c, e).map { descriptor =>
+
+        val name = e.getSimpleName.toString
+        val params = descriptor.params
+          .map(_.fqnString).mkString(",")
+
         MethodName(
           ClassName.fromFqn(e.getEnclosingElement.toString),
-          e.getSimpleName.toString, _
+          s"$name($params)", descriptor
         )
+      }
+
+    case e: VariableElement if e.isOf(PARAMETER, LOCAL_VARIABLE) =>
+
+      Some(ClassName(PackageName(Nil), e.toString))
+
+    case e: VariableElement if e.isOf(FIELD) =>
+
+      Some(FieldName(
+        ClassName.fromFqn(
+          e.getEnclosingElement.toString
+        ),
+        e.getSimpleName.toString
+      ))
+
+    case e: VariableElement if e.isOf(ENUM_CONSTANT) =>
+
+      fqn(c, e.asType()).map {
+        FieldName(_, e.getSimpleName.toString)
       }
 
     case e => fqn(c, e.asType())
@@ -69,24 +108,25 @@ trait Helpers extends UnsafeHelpers with SLF4JLogging {
     // hierarchy since an implementation may choose to have a single
     // object implement multiple TypeMirror subinterfaces." --
     // TypeMirror docs
-    tm match {
-      case tm: DeclaredType if tm.getKind == TypeKind.DECLARED => {
-        tm.asElement match {
-          case te: TypeElement => Some(ClassName.fromFqn(te.getQualifiedName.toString))
-          case _ => {
-            None
-          }
-        }
-      }
-      case tm: PrimitiveType if tm.getKind.isPrimitive => Some(ClassName(PackageName(Nil), tm.toString))
-      case _ => None
-    }
+    // tm match {
+    //   case tm: DeclaredType if tm.getKind == TypeKind.DECLARED => {
+    //     tm.asElement match {
+    //       case te: TypeElement => Some(ClassName.fromFqn(te.getQualifiedName.toString))
+    //       case _ => {
+    //         None
+    //       }
+    //     }
+    //   }
+    //   case tm: PrimitiveType if tm.getKind.isPrimitive => Some(ClassName(PackageName(Nil), tm.toString))
+    //   case _ => None
+    // }
+    Some(ClassName.fromFqn(tm.toString))
   }
 
   def toDocSign(fqn: FullyQualifiedName): DocSig = fqn match {
     case p: PackageName => DocSig(DocFqn(p.parent.fqnString, p.path.last), None)
     case c: ClassName => DocSig(DocFqn(c.pack.fqnString, c.name), None)
-    case m: MethodName => DocSig(DocFqn(m.owner.fqnString, m.name), Some(m.name))
+    case m: MethodName => DocSig(DocFqn(m.owner.pack.fqnString, m.owner.name), Some(m.name))
     case f: FieldName => DocSig(DocFqn(f.owner.fqnString, f.name), Some(f.name))
   }
 }

--- a/core/src/main/scala/org/ensime/core/javac/Helpers.scala
+++ b/core/src/main/scala/org/ensime/core/javac/Helpers.scala
@@ -15,7 +15,7 @@ import org.ensime.indexer._
 
 trait Helpers extends UnsafeHelpers with SLF4JLogging {
 
-  private implicit class EnhachedElement(e: Element) {
+  private implicit class EnhancedElement(e: Element) {
     def isOf(kinds: ElementKind*): Boolean = kinds.exists(_ == e.getKind)
   }
 
@@ -45,6 +45,11 @@ trait Helpers extends UnsafeHelpers with SLF4JLogging {
     case x => x.fqnString
   }
 
+  private def showParam(d: DescriptorType): String = d match {
+    case a: ArrayDescriptor => showParam(a.fqn)
+    case c: ClassName => c.fqnString
+  }
+
   def fqn(c: Compilation, el: Element): Option[FullyQualifiedName] = el match {
     case e: ExecutableElement =>
 
@@ -52,7 +57,7 @@ trait Helpers extends UnsafeHelpers with SLF4JLogging {
 
         val name = e.getSimpleName.toString
         val params = descriptor.params
-          .map(_.fqnString).mkString(",")
+          .map(showParam).mkString(",")
 
         MethodName(
           ClassName.fromFqn(e.getEnclosingElement.toString),

--- a/core/src/main/scala/org/ensime/core/javac/Helpers.scala
+++ b/core/src/main/scala/org/ensime/core/javac/Helpers.scala
@@ -69,12 +69,14 @@ trait Helpers extends UnsafeHelpers with SLF4JLogging {
       Some(FieldName(
         ClassName.fromFqn(
           e.getEnclosingElement.toString
-        ), e.getSimpleName.toString))
+        ), e.getSimpleName.toString
+      ))
 
     case e: VariableElement if e.isOf(ENUM_CONSTANT) =>
 
       fqn(c, e.asType()).map(
-        FieldName(_, e.getSimpleName.toString))
+        FieldName(_, e.getSimpleName.toString)
+      )
 
     case e => fqn(c, e.asType())
   }

--- a/core/src/main/scala/org/ensime/core/javac/Helpers.scala
+++ b/core/src/main/scala/org/ensime/core/javac/Helpers.scala
@@ -69,15 +69,12 @@ trait Helpers extends UnsafeHelpers with SLF4JLogging {
       Some(FieldName(
         ClassName.fromFqn(
           e.getEnclosingElement.toString
-        ),
-        e.getSimpleName.toString
-      ))
+        ), e.getSimpleName.toString))
 
     case e: VariableElement if e.isOf(ENUM_CONSTANT) =>
 
-      fqn(c, e.asType()).map {
-        FieldName(_, e.getSimpleName.toString)
-      }
+      fqn(c, e.asType()).map(
+        FieldName(_, e.getSimpleName.toString))
 
     case e => fqn(c, e.asType())
   }
@@ -85,7 +82,8 @@ trait Helpers extends UnsafeHelpers with SLF4JLogging {
   private def descriptor(c: Compilation, e: ExecutableElement): Option[Descriptor] = {
     import scala.collection.breakOut
     fqn(c, e.getReturnType).map { returnType =>
-      val params: List[DescriptorType] = e.getParameters.flatMap(p => fqn(c, p.asType()))(breakOut)
+      val params: List[DescriptorType] = e.getParameters
+        .flatMap(p => fqn(c, p.asType()))(breakOut)
       Descriptor(params, returnType)
     }
   }
@@ -103,27 +101,10 @@ trait Helpers extends UnsafeHelpers with SLF4JLogging {
   }
 
   def fqn(c: Compilation, tm: TypeMirror): Option[ClassName] = {
-    // "Using instanceof is not necessarily a reliable idiom for
-    // determining the effective class of an object in this modeling
-    // hierarchy since an implementation may choose to have a single
-    // object implement multiple TypeMirror subinterfaces." --
-    // TypeMirror docs
-    // tm match {
-    //   case tm: DeclaredType if tm.getKind == TypeKind.DECLARED => {
-    //     tm.asElement match {
-    //       case te: TypeElement => Some(ClassName.fromFqn(te.getQualifiedName.toString))
-    //       case _ => {
-    //         None
-    //       }
-    //     }
-    //   }
-    //   case tm: PrimitiveType if tm.getKind.isPrimitive => Some(ClassName(PackageName(Nil), tm.toString))
-    //   case _ => None
-    // }
     Some(ClassName.fromFqn(tm.toString))
   }
 
-  def toDocSign(fqn: FullyQualifiedName): DocSig = fqn match {
+  def toDocSig(fqn: FullyQualifiedName): DocSig = fqn match {
     case p: PackageName => DocSig(DocFqn(p.parent.fqnString, p.path.last), None)
     case c: ClassName => DocSig(DocFqn(c.pack.fqnString, c.name), None)
     case m: MethodName => DocSig(DocFqn(m.owner.pack.fqnString, m.owner.name), Some(m.name))

--- a/core/src/main/scala/org/ensime/core/javac/Helpers.scala
+++ b/core/src/main/scala/org/ensime/core/javac/Helpers.scala
@@ -3,29 +3,15 @@
 package org.ensime.core.javac
 
 import akka.event.slf4j.SLF4JLogging
-import com.sun.source.tree.{ IdentifierTree, Tree }
+import com.sun.source.tree._
 import com.sun.source.util.TreePath
 import javax.lang.model.`type`.{ DeclaredType, PrimitiveType, TypeKind, TypeMirror }
-import javax.lang.model.element.{ ElementKind, Element, TypeElement }
+import javax.lang.model.element._
+import scala.collection.JavaConversions._
+
 import org.ensime.api.deprecating
 import org.ensime.core.{ DocFqn, DocSig }
-
-@deprecating("prefer FullyQualifiedName")
-final case class JavaFqn(pack: Option[String], typename: Option[String], fieldOrMethod: Option[String]) {
-  def toDocSig = DocSig(DocFqn(pack.getOrElse(""), typename.getOrElse("")), fieldOrMethod)
-  def toFqnString = Array(pack, typename, fieldOrMethod).flatten.mkString(".")
-  def toQueryString = Array(pack, typename.map(_.replace(".", "$")), fieldOrMethod).flatten.mkString(".")
-}
-
-object JavaFqn {
-  def apply(pack: String, tpe: String, fieldOrMethod: Option[String]): JavaFqn = {
-    JavaFqn(
-      if (pack.isEmpty) None else Some(pack),
-      if (tpe.isEmpty) None else Some(tpe),
-      fieldOrMethod
-    )
-  }
-}
+import org.ensime.indexer._
 
 trait Helpers extends UnsafeHelpers with SLF4JLogging {
 
@@ -38,45 +24,46 @@ trait Helpers extends UnsafeHelpers with SLF4JLogging {
   }
 
   def element(c: Compilation, path: TreePath): Option[Element] = {
-    Option(c.trees.getElement(path)).orElse(unsafeGetElement(path.getLeaf)).orElse {
-      Option(c.trees.getTypeMirror(path)).flatMap { t => Option(c.types.asElement(t)) }
-    }
+    Option(c.trees.getElement(path))
+      .orElse(unsafeGetElement(path.getLeaf))
+      .orElse(Option(c.trees.getTypeMirror(path))
+        .flatMap(t => Option(c.types.asElement(t))))
   }
 
-  private def parseFqnAsClass(s: String): Option[JavaFqn] = {
-    val (front, back) = s.split("\\.").partition { s => s.forall(Character.isLowerCase) }
-    Some(JavaFqn(front.mkString("."), back.mkString("."), None))
-  }
+  def fqn(c: Compilation, el: Element): Option[FullyQualifiedName] = el match {
+    case e: ExecutableElement =>
 
-  def fqn(c: Compilation, el: Element): Option[JavaFqn] = {
-    el.getKind match {
-
-      case ElementKind.LOCAL_VARIABLE | ElementKind.PARAMETER =>
-        Some(JavaFqn(None, None, Some(el.getSimpleName.toString)))
-
-      case ElementKind.CONSTRUCTOR | ElementKind.ENUM_CONSTANT
-        | ElementKind.METHOD | ElementKind.FIELD =>
-
-        Option(el.getEnclosingElement).flatMap(fqn(c, _)).map(_.copy(fieldOrMethod = Some(el.toString)))
-
-      case k => parseFqnAsClass(el.toString)
-    }
-  }
-
-  def fqn(c: Compilation, p: TreePath): Option[JavaFqn] = {
-    element(c, p).flatMap(fqn(c, _)).orElse({
-      p.getLeaf match {
-        case t: IdentifierTree => Some(JavaFqn(None, None, Some(t.getName.toString)))
-        case t => None
+      descriptor(c, e).map {
+        MethodName(
+          ClassName.fromFqn(e.getEnclosingElement.toString),
+          e.getSimpleName.toString, _
+        )
       }
-    }).orElse(fqn(c, c.trees.getTypeMirror(p)))
+
+    case e => fqn(c, e.asType())
   }
 
-  def fqn(c: Compilation, t: Tree): Option[JavaFqn] = {
-    Option(c.trees.getPath(c.compilationUnit, t)).flatMap { p => fqn(c, p) }
+  private def descriptor(c: Compilation, e: ExecutableElement): Option[Descriptor] = {
+    import scala.collection.breakOut
+    fqn(c, e.getReturnType).map { returnType =>
+      val params: List[DescriptorType] = e.getParameters.flatMap(p => fqn(c, p.asType()))(breakOut)
+      Descriptor(params, returnType)
+    }
   }
 
-  def fqn(c: Compilation, tm: TypeMirror): Option[JavaFqn] = {
+  def path(c: Compilation, t: Tree): Option[TreePath] = {
+    Option(c.trees.getPath(c.compilationUnit, t))
+  }
+
+  def fqn(c: Compilation, t: Tree): Option[FullyQualifiedName] = {
+    path(c, t).flatMap(fqn(c, _))
+  }
+
+  def fqn(c: Compilation, p: TreePath): Option[FullyQualifiedName] = {
+    element(c, p).flatMap(fqn(c, _))
+  }
+
+  def fqn(c: Compilation, tm: TypeMirror): Option[ClassName] = {
     // "Using instanceof is not necessarily a reliable idiom for
     // determining the effective class of an object in this modeling
     // hierarchy since an implementation may choose to have a single
@@ -85,15 +72,21 @@ trait Helpers extends UnsafeHelpers with SLF4JLogging {
     tm match {
       case tm: DeclaredType if tm.getKind == TypeKind.DECLARED => {
         tm.asElement match {
-          case te: TypeElement => parseFqnAsClass(te.getQualifiedName.toString)
+          case te: TypeElement => Some(ClassName.fromFqn(te.getQualifiedName.toString))
           case _ => {
             None
           }
         }
       }
-      case tm: PrimitiveType if tm.getKind.isPrimitive => Some(JavaFqn(None, Some(tm.toString), None))
+      case tm: PrimitiveType if tm.getKind.isPrimitive => Some(ClassName(PackageName(Nil), tm.toString))
       case _ => None
     }
   }
 
+  def toDocSign(fqn: FullyQualifiedName): DocSig = fqn match {
+    case p: PackageName => DocSig(DocFqn(p.parent.fqnString, p.path.last), None)
+    case c: ClassName => DocSig(DocFqn(c.pack.fqnString, c.name), None)
+    case m: MethodName => DocSig(DocFqn(m.owner.fqnString, m.name), Some(m.name))
+    case f: FieldName => DocSig(DocFqn(f.owner.fqnString, f.name), Some(f.name))
+  }
 }

--- a/core/src/main/scala/org/ensime/core/javac/JavaCompiler.scala
+++ b/core/src/main/scala/org/ensime/core/javac/JavaCompiler.scala
@@ -21,6 +21,7 @@ import org.ensime.indexer.SearchService
 import org.ensime.util.ReportHandler
 import org.ensime.util.file._
 import org.ensime.vfs._
+import org.ensime.indexer.FullyQualifiedName
 
 class JavaCompiler(
   val config: EnsimeConfig,
@@ -86,7 +87,7 @@ class JavaCompiler(
     typecheckAll()
   }
 
-  def askLinkPos(fqn: JavaFqn, file: SourceFileInfo): Option[SourcePosition] = {
+  def askLinkPos(fqn: FullyQualifiedName, file: SourceFileInfo): Option[SourcePosition] = {
     val infos = typecheckForUnits(List(file))
     infos.headOption.flatMap { c => findInCompiledUnit(c, fqn) }
   }

--- a/core/src/main/scala/org/ensime/core/javac/JavaDocFinding.scala
+++ b/core/src/main/scala/org/ensime/core/javac/JavaDocFinding.scala
@@ -9,7 +9,7 @@ trait JavaDocFinding extends Helpers {
 
   def docSignature(c: Compilation, p: TreePath): Option[DocSigPair] = {
     fqn(c, p).map { fqn =>
-      val sig = fqn.toDocSig
+      val sig = toDocSign(fqn)
       DocSigPair(sig, sig)
     }
   }

--- a/core/src/main/scala/org/ensime/core/javac/JavaDocFinding.scala
+++ b/core/src/main/scala/org/ensime/core/javac/JavaDocFinding.scala
@@ -9,7 +9,7 @@ trait JavaDocFinding extends Helpers {
 
   def docSignature(c: Compilation, p: TreePath): Option[DocSigPair] = {
     fqn(c, p).map { fqn =>
-      val sig = toDocSign(fqn)
+      val sig = toDocSig(fqn)
       DocSigPair(sig, sig)
     }
   }

--- a/core/src/main/scala/org/ensime/core/javac/JavaSourceFinding.scala
+++ b/core/src/main/scala/org/ensime/core/javac/JavaSourceFinding.scala
@@ -10,16 +10,17 @@ import org.ensime.api._
 import org.ensime.model.LineSourcePositionHelper
 import org.ensime.vfs._
 import org.ensime.indexer.SearchService
+import org.ensime.indexer.FullyQualifiedName
 
 trait JavaSourceFinding extends Helpers with SLF4JLogging {
 
-  def askLinkPos(fqn: JavaFqn, file: SourceFileInfo): Option[SourcePosition]
+  def askLinkPos(fqn: FullyQualifiedName, file: SourceFileInfo): Option[SourcePosition]
   def search: SearchService
   def vfs: EnsimeVFS
   def config: EnsimeConfig
 
-  protected def findInCompiledUnit(c: Compilation, fqn: JavaFqn): Option[SourcePosition] = {
-    Option(c.elements.getTypeElement(fqn.toFqnString)).flatMap(elementPosition(c, _))
+  protected def findInCompiledUnit(c: Compilation, fqn: FullyQualifiedName): Option[SourcePosition] = {
+    Option(c.elements.getTypeElement(fqn.fqnString)).flatMap(elementPosition(c, _))
   }
 
   private def elementPosition(c: Compilation, el: Element): Option[SourcePosition] = {
@@ -40,7 +41,7 @@ trait JavaSourceFinding extends Helpers with SLF4JLogging {
 
   private def findInIndexer(c: Compilation, path: TreePath): Option[SourcePosition] = {
     val javaFqn = fqn(c, path)
-    val query = javaFqn.map(_.toFqnString).getOrElse("")
+    val query = javaFqn.map(_.fqnString).getOrElse("")
     val hit = search.findUnique(query)
     if (log.isTraceEnabled())
       log.trace(s"search: '$query' = $hit")

--- a/core/src/main/scala/org/ensime/core/javac/JavaSymbolAtPoint.scala
+++ b/core/src/main/scala/org/ensime/core/javac/JavaSymbolAtPoint.scala
@@ -27,7 +27,7 @@ trait JavaSymbolAtPoint { requires: JavaCompiler =>
             .map(typeMirrorToTypeInfo(identifierName, _))
         } yield {
           SymbolInfo(
-            fqn(c, path).map(_.toFqnString).getOrElse(identifierName),
+            fqn(c, path).map(_.fqnString).getOrElse(identifierName),
             identifierName,
             findDeclPos(c, path),
             typeInfo

--- a/core/src/main/scala/org/ensime/core/javac/JavaSymbolAtPoint.scala
+++ b/core/src/main/scala/org/ensime/core/javac/JavaSymbolAtPoint.scala
@@ -26,8 +26,11 @@ trait JavaSymbolAtPoint { requires: JavaCompiler =>
           typeInfo <- Option(c.trees.getTypeMirror(path))
             .map(typeMirrorToTypeInfo(identifierName, _))
         } yield {
+
           SymbolInfo(
-            fqn(c, path).map(_.fqnString).getOrElse(identifierName),
+            fqn(c, path)
+              .map(toSymbolName(_))
+              .getOrElse(identifierName),
             identifierName,
             findDeclPos(c, path),
             typeInfo

--- a/core/src/main/scala/org/ensime/core/javac/UnsafeHelpers.scala
+++ b/core/src/main/scala/org/ensime/core/javac/UnsafeHelpers.scala
@@ -35,7 +35,7 @@ trait UnsafeHelpers extends SLF4JLogging {
       case t: JCNewClass => Some(t.constructor)
       case t: JCMethodInvocation => unsafeGetElement(t.meth)
       case t: JCTypeApply => unsafeGetElement(t.clazz)
-      case t: JCTree => if (t.`type` != null) Some(t.`type`.tsym) else None
+      case t: JCTree => Option(t.`type`).map(_.tsym)
       case _ => None
     }
   }

--- a/core/src/main/scala/org/ensime/indexer/domain.scala
+++ b/core/src/main/scala/org/ensime/indexer/domain.scala
@@ -180,7 +180,6 @@ final case class GenericVar(name: String)
 
 sealed trait DescriptorType {
   def internalString: String
-  def fqnString: String
 }
 
 final case class ArrayDescriptor(fqn: DescriptorType) extends DescriptorType {
@@ -189,7 +188,6 @@ final case class ArrayDescriptor(fqn: DescriptorType) extends DescriptorType {
     case a: ArrayDescriptor => a.reifier
   }
   def internalString = "[" + fqn.internalString
-  def fqnString = fqn.fqnString
 }
 final case class Descriptor(params: List[DescriptorType], ret: DescriptorType) {
   def descriptorString =

--- a/core/src/main/scala/org/ensime/indexer/domain.scala
+++ b/core/src/main/scala/org/ensime/indexer/domain.scala
@@ -180,6 +180,7 @@ final case class GenericVar(name: String)
 
 sealed trait DescriptorType {
   def internalString: String
+  def fqnString: String
 }
 
 final case class ArrayDescriptor(fqn: DescriptorType) extends DescriptorType {
@@ -188,6 +189,7 @@ final case class ArrayDescriptor(fqn: DescriptorType) extends DescriptorType {
     case a: ArrayDescriptor => a.reifier
   }
   def internalString = "[" + fqn.internalString
+  def fqnString = fqn.fqnString
 }
 final case class Descriptor(params: List[DescriptorType], ret: DescriptorType) {
   def descriptorString =


### PR DESCRIPTION
This removes `JavaFqn` and solves #1469.
Some random thoughts:
`toDocSig` should be in `FullyQualifiedName` and all implementing classes, but I'm not sure about this cause its not clear to me how Scala Analyzer does the same thing so for now its in java helpers.
While on it, I've discovered `UnsafeHelpers` (yeah, better late than never) and that single method there solves the problem of `getElement` returning null in Java < 8. I think we should stick to a single pattern here especially that there is a simple reflection workaround to make this helper safe again.
Also, I have a really strong feeling that all name formatting in `AtPoint` mixins should utilise `FullyQualifiedName` which would simplify the code a quite a lot. Although I think this should go to a separate ticket.