### PR TITLE
Highlight class parameters as valFields.

### DIFF
--- a/core/src/it/scala/org/ensime/core/SemanticHighlightingSpec.scala
+++ b/core/src/it/scala/org/ensime/core/SemanticHighlightingSpec.scala
@@ -371,6 +371,33 @@ class SemanticHighlightingSpec extends EnsimeSpec
     ))
   }
 
+  it should "highlight class parameters as valFields" in withPresCompiler { (config, cc) =>
+    val sds = getSymbolDesignations(
+      config, cc, """
+            package com.example
+            class Test(a: Int, val b: String)(implicit c: Int, val d: String) {
+              def test(): Unit = {
+                val w = a
+                val x = b
+                val y = c
+                val z = d
+              }
+            }
+          """,
+      List(ValFieldSymbol)
+    )
+    sds should ===(List(
+      (ValFieldSymbol, "a"),
+      (ValFieldSymbol, "b"),
+      (ValFieldSymbol, "c"),
+      (ValFieldSymbol, "d"),
+      (ValFieldSymbol, "a"),
+      (ValFieldSymbol, "b"),
+      (ValFieldSymbol, "c"),
+      (ValFieldSymbol, "d")
+    ))
+  }
+
   it should "highlight vars" in withPresCompiler { (config, cc) =>
     val sds = getSymbolDesignations(
       config, cc, """

--- a/core/src/main/scala/org/ensime/core/SemanticHighlighting.scala
+++ b/core/src/main/scala/org/ensime/core/SemanticHighlighting.scala
@@ -75,6 +75,8 @@ class SemanticHighlighting(val global: RichPresentationCompiler) extends Compile
             } else {
               false
             }
+          } else if (sym.hasFlag(PARAMACCESSOR)) {
+            add(ValFieldSymbol)
           } else if (sym.isMethod) {
             if (sym.nameString == "apply" || sym.nameString == "update") { true }
             else if (sym.name.isOperatorName) {


### PR DESCRIPTION
Class parameters are treated as val fields by the compiler but are
flagged as PARAMACCESSOR rather than ACCESSOR. The semantic highlighter
would previously highlight the definition of class parameters as
valFields but then not highlight their usage as anything.