### PR TITLE
SWANKY improvements

### DIFF
--- a/api/src/main/scala/org/ensime/api/outgoing.scala
+++ b/api/src/main/scala/org/ensime/api/outgoing.scala
@@ -331,6 +331,7 @@ object DebugThreadId {
    * @param s A Long encoded as a string
    * @return A ThreadId
    */
+  @deprecating("no code in the API")
   def apply(s: String): DebugThreadId = {
     new DebugThreadId(s.toLong)
   }
@@ -338,13 +339,13 @@ object DebugThreadId {
 
 final case class DebugObjectId(id: Long)
 
-@deprecating("no code in the API")
 object DebugObjectId {
   /**
    * Create a DebugObjectId from a String representation
    * @param s A Long encoded as a string
    * @return A DebugObjectId
    */
+  @deprecating("no code in the API")
   def apply(s: String): DebugObjectId = {
     new DebugObjectId(s.toLong)
   }

--- a/api/src/main/scala/org/ensime/api/outgoing.scala
+++ b/api/src/main/scala/org/ensime/api/outgoing.scala
@@ -111,10 +111,10 @@ final case class DebugBreakEvent(
 ) extends DebugEvent
 
 /** The debugged VM has started. */
-case object DebugVMStartEvent extends DebugEvent
+case object DebugVmStartEvent extends DebugEvent
 
 /** The debugger has disconnected from the debugged VM. */
-case object DebugVMDisconnectEvent extends DebugEvent
+case object DebugVmDisconnectEvent extends DebugEvent
 
 /** The debugged VM has thrown an exception and is now paused waiting for control. */
 final case class DebugExceptionEvent(
@@ -510,7 +510,7 @@ final case class EnsimeImplementation(
 final case class ConnectionInfo(
   pid: Option[Int] = None,
   implementation: EnsimeImplementation = EnsimeImplementation("ENSIME"),
-  version: String = "1.9.0"
+  version: String = "1.9.1"
 ) extends RpcResponse
 
 sealed trait ImplicitInfo

--- a/core/src/it/scala/org/ensime/fixture/ProjectFixture.scala
+++ b/core/src/it/scala/org/ensime/fixture/ProjectFixture.scala
@@ -43,7 +43,7 @@ object ProjectFixture extends Matchers {
       case e: DebugThreadStartEvent => true
       case e: DebugThreadDeathEvent => true
       case e: DebugVmError => true
-      case DebugVMDisconnectEvent => true
+      case DebugVmDisconnectEvent => true
       case ClearAllScalaNotesEvent => true
       case ClearAllJavaNotesEvent => true
     }

--- a/core/src/it/scala/org/ensime/intg/DebugTest.scala
+++ b/core/src/it/scala/org/ensime/intg/DebugTest.scala
@@ -523,7 +523,7 @@ trait DebugTestUtils {
 
       expectMsg(DebugVmSuccess())
 
-      asyncHelper.expectMsg(DebugVMStartEvent)
+      asyncHelper.expectMsg(DebugVmStartEvent)
 
       val gotOnStartup = asyncHelper.expectMsgType[EnsimeServerMessage]
       // weird! we sometimes see a duplicate break event instantly, not really expected

--- a/core/src/main/scala/org/ensime/core/debug/DebugActor.scala
+++ b/core/src/main/scala/org/ensime/core/debug/DebugActor.scala
@@ -47,7 +47,7 @@ class DebugActor private (
   private val converter: StructureConverter = new StructureConverter(sourceMap)
   private val vmm: VirtualMachineManager = new VirtualMachineManager(
     // Signal to the user that the JVM has disconnected
-    globalStopFunc = s => broadcaster ! DebugVMDisconnectEvent
+    globalStopFunc = s => broadcaster ! DebugVmDisconnectEvent
   )
 
   // Bind our event handlers (breakpoint, step, thread start, etc.) before the
@@ -427,7 +427,7 @@ class DebugActor private (
 
     // Send start event to client when received
     scalaVirtualMachine.onUnsafeVMStart().foreach(_ =>
-      broadcaster ! DebugVMStartEvent)
+      broadcaster ! DebugVmStartEvent)
 
     // Breakpoint Event - capture and broadcast breakpoint information
     scalaVirtualMachine.createEventListener(EventType.BreakpointEventType).foreach(e => {

--- a/protocol-jerky/src/test/scala/org/ensime/jerky/JerkyFormatsSpec.scala
+++ b/protocol-jerky/src/test/scala/org/ensime/jerky/JerkyFormatsSpec.scala
@@ -345,12 +345,12 @@ class JerkyFormatsSpec extends EnsimeSpec with SprayJsonTestSupport with EnsimeT
     )
 
     roundtrip(
-      DebugVMStartEvent: EnsimeServerMessage,
-      """{"typehint":"DebugVMStartEvent"}"""
+      DebugVmStartEvent: EnsimeServerMessage,
+      """{"typehint":"DebugVmStartEvent"}"""
     )
     roundtrip(
-      DebugVMDisconnectEvent: EnsimeServerMessage,
-      """{"typehint":"DebugVMDisconnectEvent"}"""
+      DebugVmDisconnectEvent: EnsimeServerMessage,
+      """{"typehint":"DebugVmDisconnectEvent"}"""
     )
     roundtrip(
       DebugExceptionEvent(33L, dtid, "threadNameStr", Some(sourcePos1.file), Some(sourcePos1.line)): EnsimeServerMessage,

--- a/protocol-swanky/src/main/scala/org/ensime/server/protocol/swank/SwankFormats.scala
+++ b/protocol-swanky/src/main/scala/org/ensime/server/protocol/swank/SwankFormats.scala
@@ -186,8 +186,8 @@ object SwankProtocolResponse {
   implicit val NoteInfoHint: TypeHint[NoteInfo.type] = TypeHint[NoteInfo.type](SexpSymbol("info"))
   implicit val DebugStepHint: TypeHint[DebugStepEvent] = TypeHint[DebugStepEvent](SexpSymbol("step"))
   implicit val DebugBreakHint: TypeHint[DebugBreakEvent] = TypeHint[DebugBreakEvent](SexpSymbol("breakpoint"))
-  implicit val DebugVMStartHint: TypeHint[DebugVMStartEvent.type] = TypeHint[DebugVMStartEvent.type](SexpSymbol("start"))
-  implicit val DebugVMDisconnectHint: TypeHint[DebugVMDisconnectEvent.type] = TypeHint[DebugVMDisconnectEvent.type](SexpSymbol("disconnect"))
+  implicit val DebugVMStartHint: TypeHint[DebugVmStartEvent.type] = TypeHint[DebugVmStartEvent.type](SexpSymbol("start"))
+  implicit val DebugVMDisconnectHint: TypeHint[DebugVmDisconnectEvent.type] = TypeHint[DebugVmDisconnectEvent.type](SexpSymbol("disconnect"))
   implicit val DebugExceptionHint: TypeHint[DebugExceptionEvent] = TypeHint[DebugExceptionEvent](SexpSymbol("exception"))
   implicit val DebugThreadStartHint: TypeHint[DebugThreadStartEvent] = TypeHint[DebugThreadStartEvent](SexpSymbol("threadStart"))
   implicit val DebugThreadDeathHint: TypeHint[DebugThreadDeathEvent] = TypeHint[DebugThreadDeathEvent](SexpSymbol("threadDeath"))
@@ -317,8 +317,8 @@ object SwankProtocolResponse {
     def write(ee: DebugEvent): Sexp = ee match {
       case dse: DebugStepEvent => wrap(dse)
       case dbe: DebugBreakEvent => wrap(dbe)
-      case DebugVMStartEvent => wrap(DebugVMStartEvent)
-      case DebugVMDisconnectEvent => wrap(DebugVMDisconnectEvent)
+      case DebugVmStartEvent => wrap(DebugVmStartEvent)
+      case DebugVmDisconnectEvent => wrap(DebugVmDisconnectEvent)
       case dee: DebugExceptionEvent => wrap(dee)
       case dts: DebugThreadStartEvent => wrap(dts)
       case dtd: DebugThreadDeathEvent => wrap(dtd)
@@ -327,8 +327,8 @@ object SwankProtocolResponse {
     def read(hint: SexpSymbol, value: Sexp): DebugEvent = hint match {
       case s if s == DebugStepHint.hint => value.convertTo[DebugStepEvent]
       case s if s == DebugBreakHint.hint => value.convertTo[DebugBreakEvent]
-      case s if s == DebugVMStartHint.hint => DebugVMStartEvent
-      case s if s == DebugVMDisconnectHint.hint => DebugVMDisconnectEvent
+      case s if s == DebugVMStartHint.hint => DebugVmStartEvent
+      case s if s == DebugVMDisconnectHint.hint => DebugVmDisconnectEvent
       case s if s == DebugExceptionHint.hint => value.convertTo[DebugExceptionEvent]
       case s if s == DebugThreadStartHint.hint => value.convertTo[DebugThreadStartEvent]
       case s if s == DebugThreadDeathHint.hint => value.convertTo[DebugThreadDeathEvent]

--- a/protocol-swanky/src/main/scala/org/ensime/swanky/SwankyFormats.scala
+++ b/protocol-swanky/src/main/scala/org/ensime/swanky/SwankyFormats.scala
@@ -15,6 +15,13 @@ private object SwankyConversions
     with OptionAltFormat
     with FamilyFormats {
 
+  def dashify(field: String): String =
+    ":" + field.replaceAll("([A-Z])", "-$1").toLowerCase.replaceAll("^-", "")
+
+  implicit override def productHint[T]: ProductHint[T] = new BasicProductHint[T] {
+    override def field[Key <: Symbol](key: Key): SexpSymbol = SexpSymbol(dashify(key.name))
+  }
+
   implicit object DebugThreadIdFormat extends SexpFormat[DebugThreadId] {
     override def read(s: Sexp): DebugThreadId = DebugThreadId(LongFormat.read(s))
     override def write(t: DebugThreadId): Sexp = LongFormat.write(t.id)

--- a/protocol-swanky/src/main/scala/org/ensime/swanky/SwankyFormats.scala
+++ b/protocol-swanky/src/main/scala/org/ensime/swanky/SwankyFormats.scala
@@ -18,6 +18,10 @@ private object SwankyConversions
   def dashify(field: String): String =
     ":" + field.replaceAll("([A-Z])", "-$1").toLowerCase.replaceAll("^-", "")
 
+  implicit override def coproductHint[T: Typeable]: CoproductHint[T] = new NestedCoproductHint[T] {
+    override def field(orig: String): SexpSymbol = SexpSymbol(dashify(orig))
+  }
+
   implicit override def productHint[T]: ProductHint[T] = new BasicProductHint[T] {
     override def field[Key <: Symbol](key: Key): SexpSymbol = SexpSymbol(dashify(key.name))
   }

--- a/protocol-swanky/src/main/scala/org/ensime/swanky/SwankyFormats.scala
+++ b/protocol-swanky/src/main/scala/org/ensime/swanky/SwankyFormats.scala
@@ -15,6 +15,16 @@ private object SwankyConversions
     with OptionAltFormat
     with FamilyFormats {
 
+  implicit object DebugThreadIdFormat extends SexpFormat[DebugThreadId] {
+    override def read(s: Sexp): DebugThreadId = DebugThreadId(LongFormat.read(s))
+    override def write(t: DebugThreadId): Sexp = LongFormat.write(t.id)
+  }
+
+  implicit object DebugObjectIdFormat extends SexpFormat[DebugObjectId] {
+    override def read(s: Sexp): DebugObjectId = DebugObjectId(LongFormat.read(s))
+    override def write(t: DebugObjectId): Sexp = LongFormat.write(t.id)
+  }
+
   implicit val RpcRequestEnvelopeFormat: SexpFormat[RpcRequestEnvelope] = cachedImplicit
   implicit val RpcResponseEnvelopeFormat: SexpFormat[RpcResponseEnvelope] = cachedImplicit
 

--- a/protocol-swanky/src/test/scala/org/ensime/server/protocol/swank/SwankFormatsSpec.scala
+++ b/protocol-swanky/src/test/scala/org/ensime/server/protocol/swank/SwankFormatsSpec.scala
@@ -351,11 +351,11 @@ class SwankFormatsSpec extends EnsimeSpec with EnsimeTestData {
     )
 
     marshal(
-      DebugVMStartEvent: EnsimeEvent,
+      DebugVmStartEvent: EnsimeEvent,
       """(:debug-event (:type start))"""
     )
     marshal(
-      DebugVMDisconnectEvent: EnsimeEvent,
+      DebugVmDisconnectEvent: EnsimeEvent,
       """(:debug-event (:type disconnect))"""
     )
     marshal(

--- a/protocol-swanky/src/test/scala/org/ensime/swanky/SwankyFormatsSpec.scala
+++ b/protocol-swanky/src/test/scala/org/ensime/swanky/SwankyFormatsSpec.scala
@@ -21,7 +21,7 @@ class SwankyFormatsSpec extends EnsimeSpec with EnsimeTestData {
 
   def roundtrip(value: RpcRequest, via: String): Unit = {
     val enveloped = RpcRequestEnvelope(value, -1)
-    assertFormat(enveloped, s"""(:req $via :callId -1)""".parseSexp)
+    assertFormat(enveloped, s"""(:req $via :call-id -1)""".parseSexp)
   }
 
   def roundtrip(value: EnsimeServerMessage, via: String): Unit = {
@@ -39,12 +39,12 @@ class SwankyFormatsSpec extends EnsimeSpec with EnsimeTestData {
   it should "roundtrip RpcSearchRequests" in {
     roundtrip(
       PublicSymbolSearchReq(List("foo", "bar"), 10): RpcRequest,
-      """(:PublicSymbolSearchReq (:keywords ("foo" "bar") :maxResults 10))"""
+      """(:PublicSymbolSearchReq (:keywords ("foo" "bar") :max-results 10))"""
     )
 
     roundtrip(
       ImportSuggestionsReq(Left(file1), 1, List("foo", "bar"), 10): RpcRequest,
-      s"""(:ImportSuggestionsReq (:file "$file1" :point 1 :names ("foo" "bar") :maxResults 10))"""
+      s"""(:ImportSuggestionsReq (:file "$file1" :point 1 :names ("foo" "bar") :max-results 10))"""
     )
   }
 
@@ -56,7 +56,7 @@ class SwankyFormatsSpec extends EnsimeSpec with EnsimeTestData {
 
     roundtrip(
       TypecheckFileReq(sourceFileInfo): RpcRequest,
-      s"""(:TypecheckFileReq (:fileInfo (:file "$file1" :contents "{/* code here */}" :contentsIn "$file2")))"""
+      s"""(:TypecheckFileReq (:file-info (:file "$file1" :contents "{/* code here */}" :contents-in "$file2")))"""
     )
 
     roundtrip(
@@ -86,7 +86,7 @@ class SwankyFormatsSpec extends EnsimeSpec with EnsimeTestData {
 
     roundtrip(
       FormatOneSourceReq(sourceFileInfo): RpcRequest,
-      s"""(:FormatOneSourceReq (:file (:file "$file1" :contents "{/* code here */}" :contentsIn "$file2")))"""
+      s"""(:FormatOneSourceReq (:file (:file "$file1" :contents "{/* code here */}" :contents-in "$file2")))"""
     )
 
     roundtrip(
@@ -96,17 +96,17 @@ class SwankyFormatsSpec extends EnsimeSpec with EnsimeTestData {
 
     roundtrip(
       DocUriAtPointReq(Right(SourceFileInfo(file1, None, Some(file2))), OffsetRange(1, 10)): RpcRequest,
-      s"""(:DocUriAtPointReq (:file (:file "$file1" :contentsIn "$file2") :point (:from 1 :to 10)))"""
+      s"""(:DocUriAtPointReq (:file (:file "$file1" :contents-in "$file2") :point (:from 1 :to 10)))"""
     )
 
     roundtrip(
       DocUriForSymbolReq("foo.bar", Some("Baz"), None): RpcRequest,
-      s"""(:DocUriForSymbolReq (:typeFullName "foo.bar" :memberName "Baz"))"""
+      s"""(:DocUriForSymbolReq (:type-full-name "foo.bar" :member-name "Baz"))"""
     )
 
     roundtrip(
       CompletionsReq(sourceFileInfo, 10, 100, true, false): RpcRequest,
-      s"""(:CompletionsReq (:fileInfo (:file "$file1" :contents "{/* code here */}" :contentsIn "$file2") :point 10 :maxResults 100 :caseSens t))"""
+      s"""(:CompletionsReq (:file-info (:file "$file1" :contents "{/* code here */}" :contents-in "$file2") :point 10 :max-results 100 :case-sens t))"""
     )
 
     roundtrip(
@@ -151,7 +151,7 @@ class SwankyFormatsSpec extends EnsimeSpec with EnsimeTestData {
 
     roundtrip(
       SymbolByNameReq("foo.Bar", Some("baz"), None): RpcRequest,
-      s"""(:SymbolByNameReq (:typeFullName "foo.Bar" :memberName "baz"))"""
+      s"""(:SymbolByNameReq (:type-full-name "foo.Bar" :member-name "baz"))"""
     )
 
     roundtrip(
@@ -161,7 +161,7 @@ class SwankyFormatsSpec extends EnsimeSpec with EnsimeTestData {
 
     roundtrip(
       RefactorReq(1, RenameRefactorDesc("bar", file1, 1, 100), false): RpcRequest,
-      s"""(:RefactorReq (:procId 1 :params (:RenameRefactorDesc (:newName "bar" :file "$file1" :start 1 :end 100))))"""
+      s"""(:RefactorReq (:proc-id 1 :params (:RenameRefactorDesc (:new-name "bar" :file "$file1" :start 1 :end 100))))"""
     )
 
     roundtrip(
@@ -169,7 +169,7 @@ class SwankyFormatsSpec extends EnsimeSpec with EnsimeTestData {
         Left(file1), 1, 100,
         List(ObjectSymbol, ValSymbol)
       ): RpcRequest,
-      s"""(:SymbolDesignationsReq (:file "$file1" :start 1 :end 100 :requestedTypes ((:ObjectSymbol nil) (:ValSymbol nil))))"""
+      s"""(:SymbolDesignationsReq (:file "$file1" :start 1 :end 100 :requested-types ((:ObjectSymbol nil) (:ValSymbol nil))))"""
     )
 
     roundtrip(
@@ -177,7 +177,7 @@ class SwankyFormatsSpec extends EnsimeSpec with EnsimeTestData {
         Right(SourceFileInfo(file1, None, None)), 1, 100,
         List(ObjectSymbol, ValSymbol)
       ): RpcRequest,
-      s"""(:SymbolDesignationsReq (:file (:file "$file1") :start 1 :end 100 :requestedTypes ((:ObjectSymbol nil) (:ValSymbol nil))))"""
+      s"""(:SymbolDesignationsReq (:file (:file "$file1") :start 1 :end 100 :requested-types ((:ObjectSymbol nil) (:ValSymbol nil))))"""
     )
 
     roundtrip(
@@ -192,12 +192,12 @@ class SwankyFormatsSpec extends EnsimeSpec with EnsimeTestData {
 
     roundtrip(
       StructureViewReq(sourceFileInfo): RpcRequest,
-      s"""(:StructureViewReq (:fileInfo (:file "$file1" :contents "{/* code here */}" :contentsIn "$file2")))"""
+      s"""(:StructureViewReq (:file-info (:file "$file1" :contents "{/* code here */}" :contents-in "$file2")))"""
     )
 
     roundtrip(
       AstAtPointReq(sourceFileInfo, OffsetRange(1, 100)): RpcRequest,
-      s"""(:AstAtPointReq (:file (:file "$file1" :contents "{/* code here */}" :contentsIn "$file2") :offset (:from 1 :to 100)))"""
+      s"""(:AstAtPointReq (:file (:file "$file1" :contents "{/* code here */}" :contents-in "$file2") :offset (:from 1 :to 100)))"""
     )
   }
 
@@ -244,47 +244,47 @@ class SwankyFormatsSpec extends EnsimeSpec with EnsimeTestData {
 
     roundtrip(
       DebugContinueReq(dtid): RpcRequest,
-      s"""(:DebugContinueReq (:threadId 13))"""
+      s"""(:DebugContinueReq (:thread-id 13))"""
     )
 
     roundtrip(
       DebugStepReq(dtid): RpcRequest,
-      s"""(:DebugStepReq (:threadId 13))"""
+      s"""(:DebugStepReq (:thread-id 13))"""
     )
 
     roundtrip(
       DebugNextReq(dtid): RpcRequest,
-      s"""(:DebugNextReq (:threadId 13))"""
+      s"""(:DebugNextReq (:thread-id 13))"""
     )
 
     roundtrip(
       DebugStepOutReq(dtid): RpcRequest,
-      s"""(:DebugStepOutReq (:threadId 13))"""
+      s"""(:DebugStepOutReq (:thread-id 13))"""
     )
 
     roundtrip(
       DebugLocateNameReq(dtid, "foo"): RpcRequest,
-      s"""(:DebugLocateNameReq (:threadId 13 :name "foo"))"""
+      s"""(:DebugLocateNameReq (:thread-id 13 :name "foo"))"""
     )
 
     roundtrip(
       DebugValueReq(debugLocationArray): RpcRequest,
-      s"""(:DebugValueReq (:loc (:DebugArrayElement (:objectId 13 :index 14))))"""
+      s"""(:DebugValueReq (:loc (:DebugArrayElement (:object-id 13 :index 14))))"""
     )
 
     roundtrip(
       DebugToStringReq(dtid, debugLocationArray): RpcRequest,
-      s"""(:DebugToStringReq (:threadId 13 :loc (:DebugArrayElement (:objectId 13 :index 14))))"""
+      s"""(:DebugToStringReq (:thread-id 13 :loc (:DebugArrayElement (:object-id 13 :index 14))))"""
     )
 
     roundtrip(
       DebugSetValueReq(debugLocationArray, "bar"): RpcRequest,
-      s"""(:DebugSetValueReq (:loc (:DebugArrayElement (:objectId 13 :index 14)) :newValue "bar"))"""
+      s"""(:DebugSetValueReq (:loc (:DebugArrayElement (:object-id 13 :index 14)) :new-value "bar"))"""
     )
 
     roundtrip(
       DebugBacktraceReq(dtid, 100, 200): RpcRequest,
-      s"""(:DebugBacktraceReq (:threadId 13 :index 100 :count 200))"""
+      s"""(:DebugBacktraceReq (:thread-id 13 :index 100 :count 200))"""
     )
 
   }
@@ -332,12 +332,12 @@ class SwankyFormatsSpec extends EnsimeSpec with EnsimeTestData {
 
     roundtrip(
       DebugStepEvent(DebugThreadId(207), "threadNameStr", sourcePos1.file, sourcePos1.line): EnsimeEvent,
-      s"""(:DebugStepEvent (:threadId 207 :threadName "threadNameStr" :file "$file1" :line 57))"""
+      s"""(:DebugStepEvent (:thread-id 207 :thread-name "threadNameStr" :file "$file1" :line 57))"""
     )
 
     roundtrip(
       DebugBreakEvent(DebugThreadId(209), "threadNameStr", sourcePos1.file, sourcePos1.line): EnsimeEvent,
-      s"""(:DebugBreakEvent (:threadId 209 :threadName "threadNameStr" :file "$file1" :line 57))"""
+      s"""(:DebugBreakEvent (:thread-id 209 :thread-name "threadNameStr" :file "$file1" :line 57))"""
     )
 
     roundtrip(
@@ -352,91 +352,91 @@ class SwankyFormatsSpec extends EnsimeSpec with EnsimeTestData {
 
     roundtrip(
       DebugExceptionEvent(33L, dtid, "threadNameStr", Some(sourcePos1.file), Some(sourcePos1.line)): EnsimeEvent,
-      s"""(:DebugExceptionEvent (:exception 33 :threadId 13 :threadName "threadNameStr" :file "$file1" :line 57))"""
+      s"""(:DebugExceptionEvent (:exception 33 :thread-id 13 :thread-name "threadNameStr" :file "$file1" :line 57))"""
     )
 
     roundtrip(
       DebugExceptionEvent(33L, dtid, "threadNameStr", None, None): EnsimeEvent,
-      """(:DebugExceptionEvent (:exception 33 :threadId 13 :threadName "threadNameStr"))"""
+      """(:DebugExceptionEvent (:exception 33 :thread-id 13 :thread-name "threadNameStr"))"""
     )
 
     roundtrip(
       DebugThreadStartEvent(dtid): EnsimeEvent,
-      """(:DebugThreadStartEvent (:threadId 13))"""
+      """(:DebugThreadStartEvent (:thread-id 13))"""
     )
 
     roundtrip(
       DebugThreadDeathEvent(dtid): EnsimeEvent,
-      """(:DebugThreadDeathEvent (:threadId 13))"""
+      """(:DebugThreadDeathEvent (:thread-id 13))"""
     )
   }
 
   it should "roundtrip DebugLocation" in {
     roundtrip(
       DebugObjectReference(57L): DebugLocation,
-      """(:DebugObjectReference (:objectId 57))"""
+      """(:DebugObjectReference (:object-id 57))"""
     )
 
     roundtrip(
       DebugArrayElement(DebugObjectId(58L), 2): DebugLocation,
-      """(:DebugArrayElement (:objectId 58 :index 2))"""
+      """(:DebugArrayElement (:object-id 58 :index 2))"""
     )
 
     roundtrip(
       DebugObjectField(DebugObjectId(58L), "fieldName"): DebugLocation,
-      """(:DebugObjectField (:objectId 58 :field "fieldName"))"""
+      """(:DebugObjectField (:object-id 58 :field "fieldName"))"""
     )
 
     roundtrip(
       DebugStackSlot(DebugThreadId(27), 12, 23): DebugLocation,
-      """(:DebugStackSlot (:threadId 27 :frame 12 :offset 23))"""
+      """(:DebugStackSlot (:thread-id 27 :frame 12 :offset 23))"""
     )
   }
 
   it should "roundtrip DebugValue" in {
     roundtrip(
       DebugPrimitiveValue("summaryStr", "typeNameStr"): DebugValue,
-      """(:DebugPrimitiveValue (:summary "summaryStr" :typeName "typeNameStr"))"""
+      """(:DebugPrimitiveValue (:summary "summaryStr" :type-name "typeNameStr"))"""
     )
 
     roundtrip(
       DebugStringInstance("summaryStr", List(debugClassField), "typeNameStr", DebugObjectId(5L)): DebugValue,
-      """(:DebugStringInstance (:summary "summaryStr" :fields ((:index 19 :name "nameStr" :typeName "typeNameStr" :summary "summaryStr")) :typeName "typeNameStr" :objectId 5))"""
+      """(:DebugStringInstance (:summary "summaryStr" :fields ((:index 19 :name "nameStr" :type-name "typeNameStr" :summary "summaryStr")) :type-name "typeNameStr" :object-id 5))"""
     )
 
     roundtrip(
       DebugObjectInstance("summaryStr", List(debugClassField), "typeNameStr", DebugObjectId(5L)): DebugValue,
-      """(:DebugObjectInstance (:summary "summaryStr" :fields ((:index 19 :name "nameStr" :typeName "typeNameStr" :summary "summaryStr")) :typeName "typeNameStr" :objectId 5))"""
+      """(:DebugObjectInstance (:summary "summaryStr" :fields ((:index 19 :name "nameStr" :type-name "typeNameStr" :summary "summaryStr")) :type-name "typeNameStr" :object-id 5))"""
     )
 
     roundtrip(
       DebugNullValue("typeNameStr"): DebugValue,
-      """(:DebugNullValue (:typeName "typeNameStr"))"""
+      """(:DebugNullValue (:type-name "typeNameStr"))"""
     )
 
     roundtrip(
       DebugArrayInstance(3, "typeName", "elementType", DebugObjectId(5L)): DebugValue,
-      """(:DebugArrayInstance (:length 3 :typeName "typeName" :elementTypeName "elementType" :objectId 5))"""
+      """(:DebugArrayInstance (:length 3 :type-name "typeName" :element-type-name "elementType" :object-id 5))"""
     )
 
     roundtrip(
       debugClassField: DebugClassField,
-      """(:DebugClassField (:index 19 :name "nameStr" :typeName "typeNameStr" :summary "summaryStr"))"""
+      """(:DebugClassField (:index 19 :name "nameStr" :type-name "typeNameStr" :summary "summaryStr"))"""
     )
 
     roundtrip(
       debugStackLocal1: DebugStackLocal,
-      """(:DebugStackLocal (:index 3 :name "name1" :summary "summary1" :typeName "type1"))"""
+      """(:DebugStackLocal (:index 3 :name "name1" :summary "summary1" :type-name "type1"))"""
     )
 
     roundtrip(
       debugStackFrame: DebugStackFrame,
-      s"""(:DebugStackFrame (:index 7 :locals ((:index 3 :name "name1" :summary "summary1" :typeName "type1") (:index 4 :name "name2" :summary "summary2" :typeName "type2")) :numArgs 4 :className "class1" :methodName "method1" :pcLocation (:file "$file1" :line 57) :thisObjectId 7))"""
+      s"""(:DebugStackFrame (:index 7 :locals ((:index 3 :name "name1" :summary "summary1" :type-name "type1") (:index 4 :name "name2" :summary "summary2" :type-name "type2")) :num-args 4 :class-name "class1" :method-name "method1" :pc-location (:file "$file1" :line 57) :this-object-id 7))"""
     )
 
     roundtrip(
       DebugBacktrace(List(debugStackFrame), dtid, "thread1"): DebugBacktrace,
-      s"""(:DebugBacktrace (:frames ((:index 7 :locals ((:index 3 :name "name1" :summary "summary1" :typeName "type1") (:index 4 :name "name2" :summary "summary2" :typeName "type2")) :numArgs 4 :className "class1" :methodName "method1" :pcLocation (:file "$file1" :line 57) :thisObjectId 7)) :threadId 13 :threadName "thread1"))"""
+      s"""(:DebugBacktrace (:frames ((:index 7 :locals ((:index 3 :name "name1" :summary "summary1" :type-name "type1") (:index 4 :name "name2" :summary "summary2" :type-name "type2")) :num-args 4 :class-name "class1" :method-name "method1" :pc-location (:file "$file1" :line 57) :this-object-id 7)) :thread-id 13 :thread-name "thread1"))"""
     )
 
     roundtrip(
@@ -476,7 +476,7 @@ class SwankyFormatsSpec extends EnsimeSpec with EnsimeTestData {
 
     roundtrip(
       DebugVmError(303, "xxxx"): DebugVmStatus,
-      """(:DebugVmError (:errorCode 303 :details "xxxx" :status "error"))"""
+      """(:DebugVmError (:error-code 303 :details "xxxx" :status "error"))"""
     )
   }
 
@@ -488,7 +488,7 @@ class SwankyFormatsSpec extends EnsimeSpec with EnsimeTestData {
 
     roundtrip(
       completionInfo: CompletionInfo,
-      """(:CompletionInfo (:typeInfo (:BasicTypeInfo (:name "type1" :declAs (:Method nil) :fullName "FOO.type1")) :name "name" :relevance 90 :toInsert "BAZ"))"""
+      """(:CompletionInfo (:type-info (:BasicTypeInfo (:name "type1" :decl-as (:Method nil) :full-name "FOO.type1")) :name "name" :relevance 90 :to-insert "BAZ"))"""
     )
 
     roundtrip(
@@ -498,47 +498,47 @@ class SwankyFormatsSpec extends EnsimeSpec with EnsimeTestData {
 
     roundtrip(
       CompletionInfoList("fooBar", List(completionInfo)): CompletionInfoList,
-      """(:CompletionInfoList (:prefix "fooBar" :completions ((:typeInfo (:BasicTypeInfo (:name "type1" :declAs (:Method nil) :fullName "FOO.type1")) :name "name" :relevance 90 :toInsert "BAZ"))))"""
+      """(:CompletionInfoList (:prefix "fooBar" :completions ((:type-info (:BasicTypeInfo (:name "type1" :decl-as (:Method nil) :full-name "FOO.type1")) :name "name" :relevance 90 :to-insert "BAZ"))))"""
     )
 
     roundtrip(
       SymbolInfo("name", "localName", None, typeInfo): SymbolInfo,
-      """(:SymbolInfo (:name "name" :localName "localName" :type (:BasicTypeInfo (:name "type1" :declAs (:Method nil) :fullName "FOO.type1"))))"""
+      """(:SymbolInfo (:name "name" :local-name "localName" :type (:BasicTypeInfo (:name "type1" :decl-as (:Method nil) :full-name "FOO.type1"))))"""
     )
 
     roundtrip(
       NamedTypeMemberInfo("typeX", typeInfo, None, None, DeclaredAs.Method): EntityInfo,
-      """(:NamedTypeMemberInfo (:name "typeX" :type (:BasicTypeInfo (:name "type1" :declAs (:Method nil) :fullName "FOO.type1")) :declAs (:Method nil)))"""
+      """(:NamedTypeMemberInfo (:name "typeX" :type (:BasicTypeInfo (:name "type1" :decl-as (:Method nil) :full-name "FOO.type1")) :decl-as (:Method nil)))"""
     )
 
     roundtrip(
       entityInfo: EntityInfo,
-      """(:ArrowTypeInfo (:name "Arrow1" :fullName "example.Arrow1" :resultType (:BasicTypeInfo (:name "type1" :declAs (:Method nil) :fullName "FOO.type1")) :paramSections ((:params ((:_1 "ABC" :_2 (:BasicTypeInfo (:name "type1" :declAs (:Method nil) :fullName "FOO.type1"))))))))"""
+      """(:ArrowTypeInfo (:name "Arrow1" :full-name "example.Arrow1" :result-type (:BasicTypeInfo (:name "type1" :decl-as (:Method nil) :full-name "FOO.type1")) :param-sections ((:params ((:_1 "ABC" :_2 (:BasicTypeInfo (:name "type1" :decl-as (:Method nil) :full-name "FOO.type1"))))))))"""
     )
 
     roundtrip(
       entityInfoTypeParams: EntityInfo,
-      s"""(:ArrowTypeInfo (:name "Arrow1" :fullName "example.Arrow1" :resultType (:BasicTypeInfo (:name "type1" :declAs (:Method nil) :fullName "FOO.type1")) :paramSections ((:params ((:_1 "ABC" :_2 (:BasicTypeInfo (:name "type1" :declAs (:Method nil) :fullName "FOO.type1")))))) :typeParams ((:BasicTypeInfo (:name "A" :declAs (:Nil nil) :fullName "example.Arrow1.A")) (:BasicTypeInfo (:name "B" :declAs (:Nil nil) :fullName "example.Arrow1.B")))))"""
+      s"""(:ArrowTypeInfo (:name "Arrow1" :full-name "example.Arrow1" :result-type (:BasicTypeInfo (:name "type1" :decl-as (:Method nil) :full-name "FOO.type1")) :param-sections ((:params ((:_1 "ABC" :_2 (:BasicTypeInfo (:name "type1" :decl-as (:Method nil) :full-name "FOO.type1")))))) :type-params ((:BasicTypeInfo (:name "A" :decl-as (:Nil nil) :full-name "example.Arrow1.A")) (:BasicTypeInfo (:name "B" :decl-as (:Nil nil) :full-name "example.Arrow1.B")))))"""
     )
 
     roundtrip(
       typeInfo: EntityInfo,
-      """(:BasicTypeInfo (:name "type1" :declAs (:Method nil) :fullName "FOO.type1"))"""
+      """(:BasicTypeInfo (:name "type1" :decl-as (:Method nil) :full-name "FOO.type1"))"""
     )
 
     roundtrip(
       packageInfo: EntityInfo,
-      """(:PackageInfo (:name "name" :fullName "fullName"))"""
+      """(:PackageInfo (:name "name" :full-name "fullName"))"""
     )
 
     roundtrip(
       interfaceInfo: InterfaceInfo,
-      """(:InterfaceInfo (:type (:BasicTypeInfo (:name "type1" :declAs (:Method nil) :fullName "FOO.type1")) :viaView "DEF"))"""
+      """(:InterfaceInfo (:type (:BasicTypeInfo (:name "type1" :decl-as (:Method nil) :full-name "FOO.type1")) :via-view "DEF"))"""
     )
 
     roundtrip(
       TypeInspectInfo(typeInfo, List(interfaceInfo)): TypeInspectInfo,
-      """(:TypeInspectInfo (:type (:BasicTypeInfo (:name "type1" :declAs (:Method nil) :fullName "FOO.type1")) :interfaces ((:type (:BasicTypeInfo (:name "type1" :declAs (:Method nil) :fullName "FOO.type1")) :viaView "DEF")) :infoType typeInspect))"""
+      """(:TypeInspectInfo (:type (:BasicTypeInfo (:name "type1" :decl-as (:Method nil) :full-name "FOO.type1")) :interfaces ((:type (:BasicTypeInfo (:name "type1" :decl-as (:Method nil) :full-name "FOO.type1")) :via-view "DEF")) :info-type typeInspect))"""
     )
 
     roundtrip(
@@ -555,22 +555,22 @@ class SwankyFormatsSpec extends EnsimeSpec with EnsimeTestData {
   it should "roundtrip search related responses" in {
     roundtrip(
       SymbolSearchResults(List(methodSearchRes, typeSearchRes)): SymbolSearchResults,
-      s"""(:SymbolSearchResults (:syms ((:MethodSearchResult (:name "abc" :localName "a" :declAs (:Method nil) :pos (:LineSourcePosition (:file "$abd" :line 10)) :ownerName "ownerStr")) (:TypeSearchResult (:name "abc" :localName "a" :declAs (:Trait nil) :pos (:LineSourcePosition (:file "$abd" :line 10)))))))"""
+      s"""(:SymbolSearchResults (:syms ((:MethodSearchResult (:name "abc" :local-name "a" :decl-as (:Method nil) :pos (:LineSourcePosition (:file "$abd" :line 10)) :owner-name "ownerStr")) (:TypeSearchResult (:name "abc" :local-name "a" :decl-as (:Trait nil) :pos (:LineSourcePosition (:file "$abd" :line 10)))))))"""
     )
 
     roundtrip(
       ImportSuggestions(List(List(methodSearchRes, typeSearchRes))): ImportSuggestions,
-      s"""(:ImportSuggestions (:symLists (((:MethodSearchResult (:name "abc" :localName "a" :declAs (:Method nil) :pos (:LineSourcePosition (:file "$abd" :line 10)) :ownerName "ownerStr")) (:TypeSearchResult (:name "abc" :localName "a" :declAs (:Trait nil) :pos (:LineSourcePosition (:file "$abd" :line 10))))))))"""
+      s"""(:ImportSuggestions (:sym-lists (((:MethodSearchResult (:name "abc" :local-name "a" :decl-as (:Method nil) :pos (:LineSourcePosition (:file "$abd" :line 10)) :owner-name "ownerStr")) (:TypeSearchResult (:name "abc" :local-name "a" :decl-as (:Trait nil) :pos (:LineSourcePosition (:file "$abd" :line 10))))))))"""
     )
 
     roundtrip(
       methodSearchRes: SymbolSearchResult,
-      s"""(:MethodSearchResult (:name "abc" :localName "a" :declAs (:Method nil) :pos (:LineSourcePosition (:file "$abd" :line 10)) :ownerName "ownerStr"))"""
+      s"""(:MethodSearchResult (:name "abc" :local-name "a" :decl-as (:Method nil) :pos (:LineSourcePosition (:file "$abd" :line 10)) :owner-name "ownerStr"))"""
     )
 
     roundtrip(
       typeSearchRes: SymbolSearchResult,
-      s"""(:TypeSearchResult (:name "abc" :localName "a" :declAs (:Trait nil) :pos (:LineSourcePosition (:file "$abd" :line 10))))"""
+      s"""(:TypeSearchResult (:name "abc" :local-name "a" :decl-as (:Trait nil) :pos (:LineSourcePosition (:file "$abd" :line 10))))"""
     )
   }
 
@@ -592,29 +592,29 @@ class SwankyFormatsSpec extends EnsimeSpec with EnsimeTestData {
         SymbolDesignation(11, 22, ClassSymbol)
       )
       ): SymbolDesignations,
-      s"""(:SymbolDesignations (:file "$symFile" :syms ((:start 7 :end 9 :symType (:VarFieldSymbol nil)) (:start 11 :end 22 :symType (:ClassSymbol nil)))))"""
+      s"""(:SymbolDesignations (:file "$symFile" :syms ((:start 7 :end 9 :sym-type (:VarFieldSymbol nil)) (:start 11 :end 22 :sym-type (:ClassSymbol nil)))))"""
     )
 
     roundtrip(
       ImplicitInfos(List(ImplicitConversionInfo(5, 6, symbolInfo))): ImplicitInfos,
-      """(:ImplicitInfos (:infos ((:ImplicitConversionInfo (:start 5 :end 6 :fun (:name "name" :localName "localName" :type (:BasicTypeInfo (:name "type1" :declAs (:Method nil) :fullName "FOO.type1"))))))))"""
+      """(:ImplicitInfos (:infos ((:ImplicitConversionInfo (:start 5 :end 6 :fun (:name "name" :local-name "localName" :type (:BasicTypeInfo (:name "type1" :decl-as (:Method nil) :full-name "FOO.type1"))))))))"""
     )
 
     roundtrip(
       ImplicitInfos(List(ImplicitParamInfo(5, 6, symbolInfo, List(symbolInfo, symbolInfo), true))): ImplicitInfos,
-      s"""(:ImplicitInfos (:infos ((:ImplicitParamInfo (:start 5 :end 6 :fun (:name "name" :localName "localName" :type (:BasicTypeInfo (:name "type1" :declAs (:Method nil) :fullName "FOO.type1"))) :params ((:name "name" :localName "localName" :type (:BasicTypeInfo (:name "type1" :declAs (:Method nil) :fullName "FOO.type1"))) (:name "name" :localName "localName" :type (:BasicTypeInfo (:name "type1" :declAs (:Method nil) :fullName "FOO.type1")))) :funIsImplicit t)))))"""
+      s"""(:ImplicitInfos (:infos ((:ImplicitParamInfo (:start 5 :end 6 :fun (:name "name" :local-name "localName" :type (:BasicTypeInfo (:name "type1" :decl-as (:Method nil) :full-name "FOO.type1"))) :params ((:name "name" :local-name "localName" :type (:BasicTypeInfo (:name "type1" :decl-as (:Method nil) :full-name "FOO.type1"))) (:name "name" :local-name "localName" :type (:BasicTypeInfo (:name "type1" :decl-as (:Method nil) :full-name "FOO.type1")))) :fun-is-implicit t)))))"""
     )
   }
 
   it should "roundtrip refactoring messages" in {
     roundtrip(
       RefactorFailure(7, "message"): RefactorFailure,
-      """(:RefactorFailure (:procedureId 7 :reason "message" :status failure))"""
+      """(:RefactorFailure (:procedure-id 7 :reason "message" :status failure))"""
     )
 
     roundtrip(
       refactorDiffEffect: RefactorDiffEffect,
-      s"""(:RefactorDiffEffect (:procedureId 9 :refactorType (:AddImport nil) :diff "$file2"))"""
+      s"""(:RefactorDiffEffect (:procedure-id 9 :refactor-type (:AddImport nil) :diff "$file2"))"""
     )
 
   }

--- a/protocol-swanky/src/test/scala/org/ensime/swanky/SwankyFormatsSpec.scala
+++ b/protocol-swanky/src/test/scala/org/ensime/swanky/SwankyFormatsSpec.scala
@@ -244,47 +244,47 @@ class SwankyFormatsSpec extends EnsimeSpec with EnsimeTestData {
 
     roundtrip(
       DebugContinueReq(dtid): RpcRequest,
-      s"""(:DebugContinueReq (:threadId (:id 13)))"""
+      s"""(:DebugContinueReq (:threadId 13))"""
     )
 
     roundtrip(
       DebugStepReq(dtid): RpcRequest,
-      s"""(:DebugStepReq (:threadId (:id 13)))"""
+      s"""(:DebugStepReq (:threadId 13))"""
     )
 
     roundtrip(
       DebugNextReq(dtid): RpcRequest,
-      s"""(:DebugNextReq (:threadId (:id 13)))"""
+      s"""(:DebugNextReq (:threadId 13))"""
     )
 
     roundtrip(
       DebugStepOutReq(dtid): RpcRequest,
-      s"""(:DebugStepOutReq (:threadId (:id 13)))"""
+      s"""(:DebugStepOutReq (:threadId 13))"""
     )
 
     roundtrip(
       DebugLocateNameReq(dtid, "foo"): RpcRequest,
-      s"""(:DebugLocateNameReq (:threadId (:id 13) :name "foo"))"""
+      s"""(:DebugLocateNameReq (:threadId 13 :name "foo"))"""
     )
 
     roundtrip(
       DebugValueReq(debugLocationArray): RpcRequest,
-      s"""(:DebugValueReq (:loc (:DebugArrayElement (:objectId (:id 13) :index 14))))"""
+      s"""(:DebugValueReq (:loc (:DebugArrayElement (:objectId 13 :index 14))))"""
     )
 
     roundtrip(
       DebugToStringReq(dtid, debugLocationArray): RpcRequest,
-      s"""(:DebugToStringReq (:threadId (:id 13) :loc (:DebugArrayElement (:objectId (:id 13) :index 14))))"""
+      s"""(:DebugToStringReq (:threadId 13 :loc (:DebugArrayElement (:objectId 13 :index 14))))"""
     )
 
     roundtrip(
       DebugSetValueReq(debugLocationArray, "bar"): RpcRequest,
-      s"""(:DebugSetValueReq (:loc (:DebugArrayElement (:objectId (:id 13) :index 14)) :newValue "bar"))"""
+      s"""(:DebugSetValueReq (:loc (:DebugArrayElement (:objectId 13 :index 14)) :newValue "bar"))"""
     )
 
     roundtrip(
       DebugBacktraceReq(dtid, 100, 200): RpcRequest,
-      s"""(:DebugBacktraceReq (:threadId (:id 13) :index 100 :count 200))"""
+      s"""(:DebugBacktraceReq (:threadId 13 :index 100 :count 200))"""
     )
 
   }
@@ -332,12 +332,12 @@ class SwankyFormatsSpec extends EnsimeSpec with EnsimeTestData {
 
     roundtrip(
       DebugStepEvent(DebugThreadId(207), "threadNameStr", sourcePos1.file, sourcePos1.line): EnsimeEvent,
-      s"""(:DebugStepEvent (:threadId (:id 207) :threadName "threadNameStr" :file "$file1" :line 57))"""
+      s"""(:DebugStepEvent (:threadId 207 :threadName "threadNameStr" :file "$file1" :line 57))"""
     )
 
     roundtrip(
       DebugBreakEvent(DebugThreadId(209), "threadNameStr", sourcePos1.file, sourcePos1.line): EnsimeEvent,
-      s"""(:DebugBreakEvent (:threadId (:id 209) :threadName "threadNameStr" :file "$file1" :line 57))"""
+      s"""(:DebugBreakEvent (:threadId 209 :threadName "threadNameStr" :file "$file1" :line 57))"""
     )
 
     roundtrip(
@@ -352,44 +352,44 @@ class SwankyFormatsSpec extends EnsimeSpec with EnsimeTestData {
 
     roundtrip(
       DebugExceptionEvent(33L, dtid, "threadNameStr", Some(sourcePos1.file), Some(sourcePos1.line)): EnsimeEvent,
-      s"""(:DebugExceptionEvent (:exception 33 :threadId (:id 13) :threadName "threadNameStr" :file "$file1" :line 57))"""
+      s"""(:DebugExceptionEvent (:exception 33 :threadId 13 :threadName "threadNameStr" :file "$file1" :line 57))"""
     )
 
     roundtrip(
       DebugExceptionEvent(33L, dtid, "threadNameStr", None, None): EnsimeEvent,
-      """(:DebugExceptionEvent (:exception 33 :threadId (:id 13) :threadName "threadNameStr"))"""
+      """(:DebugExceptionEvent (:exception 33 :threadId 13 :threadName "threadNameStr"))"""
     )
 
     roundtrip(
       DebugThreadStartEvent(dtid): EnsimeEvent,
-      """(:DebugThreadStartEvent (:threadId (:id 13)))"""
+      """(:DebugThreadStartEvent (:threadId 13))"""
     )
 
     roundtrip(
       DebugThreadDeathEvent(dtid): EnsimeEvent,
-      """(:DebugThreadDeathEvent (:threadId (:id 13)))"""
+      """(:DebugThreadDeathEvent (:threadId 13))"""
     )
   }
 
   it should "roundtrip DebugLocation" in {
     roundtrip(
       DebugObjectReference(57L): DebugLocation,
-      """(:DebugObjectReference (:objectId (:id 57)))"""
+      """(:DebugObjectReference (:objectId 57))"""
     )
 
     roundtrip(
       DebugArrayElement(DebugObjectId(58L), 2): DebugLocation,
-      """(:DebugArrayElement (:objectId (:id 58) :index 2))"""
+      """(:DebugArrayElement (:objectId 58 :index 2))"""
     )
 
     roundtrip(
       DebugObjectField(DebugObjectId(58L), "fieldName"): DebugLocation,
-      """(:DebugObjectField (:objectId (:id 58) :field "fieldName"))"""
+      """(:DebugObjectField (:objectId 58 :field "fieldName"))"""
     )
 
     roundtrip(
       DebugStackSlot(DebugThreadId(27), 12, 23): DebugLocation,
-      """(:DebugStackSlot (:threadId (:id 27) :frame 12 :offset 23))"""
+      """(:DebugStackSlot (:threadId 27 :frame 12 :offset 23))"""
     )
   }
 
@@ -401,12 +401,12 @@ class SwankyFormatsSpec extends EnsimeSpec with EnsimeTestData {
 
     roundtrip(
       DebugStringInstance("summaryStr", List(debugClassField), "typeNameStr", DebugObjectId(5L)): DebugValue,
-      """(:DebugStringInstance (:summary "summaryStr" :fields ((:index 19 :name "nameStr" :typeName "typeNameStr" :summary "summaryStr")) :typeName "typeNameStr" :objectId (:id 5)))"""
+      """(:DebugStringInstance (:summary "summaryStr" :fields ((:index 19 :name "nameStr" :typeName "typeNameStr" :summary "summaryStr")) :typeName "typeNameStr" :objectId 5))"""
     )
 
     roundtrip(
       DebugObjectInstance("summaryStr", List(debugClassField), "typeNameStr", DebugObjectId(5L)): DebugValue,
-      """(:DebugObjectInstance (:summary "summaryStr" :fields ((:index 19 :name "nameStr" :typeName "typeNameStr" :summary "summaryStr")) :typeName "typeNameStr" :objectId (:id 5)))"""
+      """(:DebugObjectInstance (:summary "summaryStr" :fields ((:index 19 :name "nameStr" :typeName "typeNameStr" :summary "summaryStr")) :typeName "typeNameStr" :objectId 5))"""
     )
 
     roundtrip(
@@ -416,7 +416,7 @@ class SwankyFormatsSpec extends EnsimeSpec with EnsimeTestData {
 
     roundtrip(
       DebugArrayInstance(3, "typeName", "elementType", DebugObjectId(5L)): DebugValue,
-      """(:DebugArrayInstance (:length 3 :typeName "typeName" :elementTypeName "elementType" :objectId (:id 5)))"""
+      """(:DebugArrayInstance (:length 3 :typeName "typeName" :elementTypeName "elementType" :objectId 5))"""
     )
 
     roundtrip(
@@ -431,12 +431,12 @@ class SwankyFormatsSpec extends EnsimeSpec with EnsimeTestData {
 
     roundtrip(
       debugStackFrame: DebugStackFrame,
-      s"""(:DebugStackFrame (:index 7 :locals ((:index 3 :name "name1" :summary "summary1" :typeName "type1") (:index 4 :name "name2" :summary "summary2" :typeName "type2")) :numArgs 4 :className "class1" :methodName "method1" :pcLocation (:file "$file1" :line 57) :thisObjectId (:id 7)))"""
+      s"""(:DebugStackFrame (:index 7 :locals ((:index 3 :name "name1" :summary "summary1" :typeName "type1") (:index 4 :name "name2" :summary "summary2" :typeName "type2")) :numArgs 4 :className "class1" :methodName "method1" :pcLocation (:file "$file1" :line 57) :thisObjectId 7))"""
     )
 
     roundtrip(
       DebugBacktrace(List(debugStackFrame), dtid, "thread1"): DebugBacktrace,
-      s"""(:DebugBacktrace (:frames ((:index 7 :locals ((:index 3 :name "name1" :summary "summary1" :typeName "type1") (:index 4 :name "name2" :summary "summary2" :typeName "type2")) :numArgs 4 :className "class1" :methodName "method1" :pcLocation (:file "$file1" :line 57) :thisObjectId (:id 7))) :threadId (:id 13) :threadName "thread1"))"""
+      s"""(:DebugBacktrace (:frames ((:index 7 :locals ((:index 3 :name "name1" :summary "summary1" :typeName "type1") (:index 4 :name "name2" :summary "summary2" :typeName "type2")) :numArgs 4 :className "class1" :methodName "method1" :pcLocation (:file "$file1" :line 57) :thisObjectId 7)) :threadId 13 :threadName "thread1"))"""
     )
 
     roundtrip(

--- a/protocol-swanky/src/test/scala/org/ensime/swanky/SwankyFormatsSpec.scala
+++ b/protocol-swanky/src/test/scala/org/ensime/swanky/SwankyFormatsSpec.scala
@@ -341,13 +341,13 @@ class SwankyFormatsSpec extends EnsimeSpec with EnsimeTestData {
     )
 
     roundtrip(
-      DebugVMStartEvent: EnsimeEvent,
-      """(:debug-v-m-start-event nil)"""
+      DebugVmStartEvent: EnsimeEvent,
+      """(:debug-vm-start-event nil)"""
     )
 
     roundtrip(
-      DebugVMDisconnectEvent: EnsimeEvent,
-      """(:debug-v-m-disconnect-event nil)"""
+      DebugVmDisconnectEvent: EnsimeEvent,
+      """(:debug-vm-disconnect-event nil)"""
     )
 
     roundtrip(

--- a/protocol-swanky/src/test/scala/org/ensime/swanky/SwankyFormatsSpec.scala
+++ b/protocol-swanky/src/test/scala/org/ensime/swanky/SwankyFormatsSpec.scala
@@ -32,7 +32,7 @@ class SwankyFormatsSpec extends EnsimeSpec with EnsimeTestData {
   "SWANK Formats" should "roundtrip startup messages" in {
     roundtrip(
       ConnectionInfoReq: RpcRequest,
-      "(:connection-info-req nil)"
+      ":connection-info-req"
     )
   }
 
@@ -71,12 +71,12 @@ class SwankyFormatsSpec extends EnsimeSpec with EnsimeTestData {
 
     roundtrip(
       UnloadAllReq: RpcRequest,
-      """(:unload-all-req nil)"""
+      """:unload-all-req"""
     )
 
     roundtrip(
       TypecheckAllReq: RpcRequest,
-      """(:typecheck-all-req nil)"""
+      """:typecheck-all-req"""
     )
 
     roundtrip(
@@ -169,7 +169,7 @@ class SwankyFormatsSpec extends EnsimeSpec with EnsimeTestData {
         Left(file1), 1, 100,
         List(ObjectSymbol, ValSymbol)
       ): RpcRequest,
-      s"""(:symbol-designations-req (:file "$file1" :start 1 :end 100 :requested-types ((:object-symbol nil) (:val-symbol nil))))"""
+      s"""(:symbol-designations-req (:file "$file1" :start 1 :end 100 :requested-types (:object-symbol :val-symbol)))"""
     )
 
     roundtrip(
@@ -177,7 +177,7 @@ class SwankyFormatsSpec extends EnsimeSpec with EnsimeTestData {
         Right(SourceFileInfo(file1, None, None)), 1, 100,
         List(ObjectSymbol, ValSymbol)
       ): RpcRequest,
-      s"""(:symbol-designations-req (:file (:file "$file1") :start 1 :end 100 :requested-types ((:object-symbol nil) (:val-symbol nil))))"""
+      s"""(:symbol-designations-req (:file (:file "$file1") :start 1 :end 100 :requested-types (:object-symbol :val-symbol)))"""
     )
 
     roundtrip(
@@ -204,7 +204,7 @@ class SwankyFormatsSpec extends EnsimeSpec with EnsimeTestData {
   it should "roundtrip RpcDebugRequests" in {
     roundtrip(
       DebugActiveVmReq: RpcRequest,
-      """(:debug-active-vm-req nil)"""
+      """:debug-active-vm-req"""
     )
 
     roundtrip(
@@ -214,7 +214,7 @@ class SwankyFormatsSpec extends EnsimeSpec with EnsimeTestData {
 
     roundtrip(
       DebugStopReq: RpcRequest,
-      """(:debug-stop-req nil)"""
+      """:debug-stop-req"""
     )
 
     roundtrip(
@@ -229,17 +229,17 @@ class SwankyFormatsSpec extends EnsimeSpec with EnsimeTestData {
 
     roundtrip(
       DebugClearAllBreaksReq: RpcRequest,
-      s"""(:debug-clear-all-breaks-req nil)"""
+      s""":debug-clear-all-breaks-req"""
     )
 
     roundtrip(
       DebugListBreakpointsReq: RpcRequest,
-      s"""(:debug-list-breakpoints-req nil)"""
+      s""":debug-list-breakpoints-req"""
     )
 
     roundtrip(
       DebugRunReq: RpcRequest,
-      s"""(:debug-run-req nil)"""
+      s""":debug-run-req"""
     )
 
     roundtrip(
@@ -297,17 +297,17 @@ class SwankyFormatsSpec extends EnsimeSpec with EnsimeTestData {
 
     roundtrip(
       AnalyzerReadyEvent: EnsimeEvent,
-      "(:analyzer-ready-event nil)"
+      ":analyzer-ready-event"
     )
 
     roundtrip(
       FullTypeCheckCompleteEvent: EnsimeEvent,
-      "(:full-type-check-complete-event nil)"
+      ":full-type-check-complete-event"
     )
 
     roundtrip(
       IndexerReadyEvent: EnsimeEvent,
-      "(:indexer-ready-event nil)"
+      ":indexer-ready-event"
     )
 
     roundtrip(
@@ -315,12 +315,12 @@ class SwankyFormatsSpec extends EnsimeSpec with EnsimeTestData {
         isFull = false,
         List(Note("foo.scala", "testMsg", NoteWarn, 50, 55, 77, 5))
       ): EnsimeEvent,
-      """(:new-scala-notes-event (:notes ((:file "foo.scala" :msg "testMsg" :severity (:note-warn nil) :beg 50 :end 55 :line 77 :col 5))))"""
+      """(:new-scala-notes-event (:notes ((:file "foo.scala" :msg "testMsg" :severity :note-warn :beg 50 :end 55 :line 77 :col 5))))"""
     )
 
     roundtrip(
       ClearAllScalaNotesEvent: EnsimeEvent,
-      "(:clear-all-scala-notes-event nil)"
+      ":clear-all-scala-notes-event"
     )
   }
 
@@ -342,12 +342,12 @@ class SwankyFormatsSpec extends EnsimeSpec with EnsimeTestData {
 
     roundtrip(
       DebugVmStartEvent: EnsimeEvent,
-      """(:debug-vm-start-event nil)"""
+      """:debug-vm-start-event"""
     )
 
     roundtrip(
       DebugVmDisconnectEvent: EnsimeEvent,
-      """(:debug-vm-disconnect-event nil)"""
+      """:debug-vm-disconnect-event"""
     )
 
     roundtrip(
@@ -451,7 +451,7 @@ class SwankyFormatsSpec extends EnsimeSpec with EnsimeTestData {
 
     roundtrip(
       sourcePos3: SourcePosition,
-      "(:empty-source-position nil)"
+      ":empty-source-position"
     )
 
     roundtrip(
@@ -483,12 +483,12 @@ class SwankyFormatsSpec extends EnsimeSpec with EnsimeTestData {
   it should "roundtrip various informational types" in {
     roundtrip(
       note1: Note,
-      """(:note (:file "file1" :msg "note1" :severity (:note-error nil) :beg 23 :end 33 :line 19 :col 8))"""
+      """(:note (:file "file1" :msg "note1" :severity :note-error :beg 23 :end 33 :line 19 :col 8))"""
     )
 
     roundtrip(
       completionInfo: CompletionInfo,
-      """(:completion-info (:type-info (:basic-type-info (:name "type1" :decl-as (:method nil) :full-name "FOO.type1")) :name "name" :relevance 90 :to-insert "BAZ"))"""
+      """(:completion-info (:type-info (:basic-type-info (:name "type1" :decl-as :method :full-name "FOO.type1")) :name "name" :relevance 90 :to-insert "BAZ"))"""
     )
 
     roundtrip(
@@ -498,32 +498,32 @@ class SwankyFormatsSpec extends EnsimeSpec with EnsimeTestData {
 
     roundtrip(
       CompletionInfoList("fooBar", List(completionInfo)): CompletionInfoList,
-      """(:completion-info-list (:prefix "fooBar" :completions ((:type-info (:basic-type-info (:name "type1" :decl-as (:method nil) :full-name "FOO.type1")) :name "name" :relevance 90 :to-insert "BAZ"))))"""
+      """(:completion-info-list (:prefix "fooBar" :completions ((:type-info (:basic-type-info (:name "type1" :decl-as :method :full-name "FOO.type1")) :name "name" :relevance 90 :to-insert "BAZ"))))"""
     )
 
     roundtrip(
       SymbolInfo("name", "localName", None, typeInfo): SymbolInfo,
-      """(:symbol-info (:name "name" :local-name "localName" :type (:basic-type-info (:name "type1" :decl-as (:method nil) :full-name "FOO.type1"))))"""
+      """(:symbol-info (:name "name" :local-name "localName" :type (:basic-type-info (:name "type1" :decl-as :method :full-name "FOO.type1"))))"""
     )
 
     roundtrip(
       NamedTypeMemberInfo("typeX", typeInfo, None, None, DeclaredAs.Method): EntityInfo,
-      """(:named-type-member-info (:name "typeX" :type (:basic-type-info (:name "type1" :decl-as (:method nil) :full-name "FOO.type1")) :decl-as (:method nil)))"""
+      """(:named-type-member-info (:name "typeX" :type (:basic-type-info (:name "type1" :decl-as :method :full-name "FOO.type1")) :decl-as :method))"""
     )
 
     roundtrip(
       entityInfo: EntityInfo,
-      """(:arrow-type-info (:name "Arrow1" :full-name "example.Arrow1" :result-type (:basic-type-info (:name "type1" :decl-as (:method nil) :full-name "FOO.type1")) :param-sections ((:params ((:_1 "ABC" :_2 (:basic-type-info (:name "type1" :decl-as (:method nil) :full-name "FOO.type1"))))))))"""
+      """(:arrow-type-info (:name "Arrow1" :full-name "example.Arrow1" :result-type (:basic-type-info (:name "type1" :decl-as :method :full-name "FOO.type1")) :param-sections ((:params ((:_1 "ABC" :_2 (:basic-type-info (:name "type1" :decl-as :method :full-name "FOO.type1"))))))))"""
     )
 
     roundtrip(
       entityInfoTypeParams: EntityInfo,
-      s"""(:arrow-type-info (:name "Arrow1" :full-name "example.Arrow1" :result-type (:basic-type-info (:name "type1" :decl-as (:method nil) :full-name "FOO.type1")) :param-sections ((:params ((:_1 "ABC" :_2 (:basic-type-info (:name "type1" :decl-as (:method nil) :full-name "FOO.type1")))))) :type-params ((:basic-type-info (:name "A" :decl-as (:nil nil) :full-name "example.Arrow1.A")) (:basic-type-info (:name "B" :decl-as (:nil nil) :full-name "example.Arrow1.B")))))"""
+      s"""(:arrow-type-info (:name "Arrow1" :full-name "example.Arrow1" :result-type (:basic-type-info (:name "type1" :decl-as :method :full-name "FOO.type1")) :param-sections ((:params ((:_1 "ABC" :_2 (:basic-type-info (:name "type1" :decl-as :method :full-name "FOO.type1")))))) :type-params ((:basic-type-info (:name "A" :decl-as :nil :full-name "example.Arrow1.A")) (:basic-type-info (:name "B" :decl-as :nil :full-name "example.Arrow1.B")))))"""
     )
 
     roundtrip(
       typeInfo: EntityInfo,
-      """(:basic-type-info (:name "type1" :decl-as (:method nil) :full-name "FOO.type1"))"""
+      """(:basic-type-info (:name "type1" :decl-as :method :full-name "FOO.type1"))"""
     )
 
     roundtrip(
@@ -533,12 +533,12 @@ class SwankyFormatsSpec extends EnsimeSpec with EnsimeTestData {
 
     roundtrip(
       interfaceInfo: InterfaceInfo,
-      """(:interface-info (:type (:basic-type-info (:name "type1" :decl-as (:method nil) :full-name "FOO.type1")) :via-view "DEF"))"""
+      """(:interface-info (:type (:basic-type-info (:name "type1" :decl-as :method :full-name "FOO.type1")) :via-view "DEF"))"""
     )
 
     roundtrip(
       TypeInspectInfo(typeInfo, List(interfaceInfo)): TypeInspectInfo,
-      """(:type-inspect-info (:type (:basic-type-info (:name "type1" :decl-as (:method nil) :full-name "FOO.type1")) :interfaces ((:type (:basic-type-info (:name "type1" :decl-as (:method nil) :full-name "FOO.type1")) :via-view "DEF")) :info-type typeInspect))"""
+      """(:type-inspect-info (:type (:basic-type-info (:name "type1" :decl-as :method :full-name "FOO.type1")) :interfaces ((:type (:basic-type-info (:name "type1" :decl-as :method :full-name "FOO.type1")) :via-view "DEF")) :info-type typeInspect))"""
     )
 
     roundtrip(
@@ -555,22 +555,22 @@ class SwankyFormatsSpec extends EnsimeSpec with EnsimeTestData {
   it should "roundtrip search related responses" in {
     roundtrip(
       SymbolSearchResults(List(methodSearchRes, typeSearchRes)): SymbolSearchResults,
-      s"""(:symbol-search-results (:syms ((:method-search-result (:name "abc" :local-name "a" :decl-as (:method nil) :pos (:line-source-position (:file "$abd" :line 10)) :owner-name "ownerStr")) (:type-search-result (:name "abc" :local-name "a" :decl-as (:trait nil) :pos (:line-source-position (:file "$abd" :line 10)))))))"""
+      s"""(:symbol-search-results (:syms ((:method-search-result (:name "abc" :local-name "a" :decl-as :method :pos (:line-source-position (:file "$abd" :line 10)) :owner-name "ownerStr")) (:type-search-result (:name "abc" :local-name "a" :decl-as :trait :pos (:line-source-position (:file "$abd" :line 10)))))))"""
     )
 
     roundtrip(
       ImportSuggestions(List(List(methodSearchRes, typeSearchRes))): ImportSuggestions,
-      s"""(:import-suggestions (:sym-lists (((:method-search-result (:name "abc" :local-name "a" :decl-as (:method nil) :pos (:line-source-position (:file "$abd" :line 10)) :owner-name "ownerStr")) (:type-search-result (:name "abc" :local-name "a" :decl-as (:trait nil) :pos (:line-source-position (:file "$abd" :line 10))))))))"""
+      s"""(:import-suggestions (:sym-lists (((:method-search-result (:name "abc" :local-name "a" :decl-as :method :pos (:line-source-position (:file "$abd" :line 10)) :owner-name "ownerStr")) (:type-search-result (:name "abc" :local-name "a" :decl-as :trait :pos (:line-source-position (:file "$abd" :line 10))))))))"""
     )
 
     roundtrip(
       methodSearchRes: SymbolSearchResult,
-      s"""(:method-search-result (:name "abc" :local-name "a" :decl-as (:method nil) :pos (:line-source-position (:file "$abd" :line 10)) :owner-name "ownerStr"))"""
+      s"""(:method-search-result (:name "abc" :local-name "a" :decl-as :method :pos (:line-source-position (:file "$abd" :line 10)) :owner-name "ownerStr"))"""
     )
 
     roundtrip(
       typeSearchRes: SymbolSearchResult,
-      s"""(:type-search-result (:name "abc" :local-name "a" :decl-as (:trait nil) :pos (:line-source-position (:file "$abd" :line 10))))"""
+      s"""(:type-search-result (:name "abc" :local-name "a" :decl-as :trait :pos (:line-source-position (:file "$abd" :line 10))))"""
     )
   }
 
@@ -592,17 +592,17 @@ class SwankyFormatsSpec extends EnsimeSpec with EnsimeTestData {
         SymbolDesignation(11, 22, ClassSymbol)
       )
       ): SymbolDesignations,
-      s"""(:symbol-designations (:file "$symFile" :syms ((:start 7 :end 9 :sym-type (:var-field-symbol nil)) (:start 11 :end 22 :sym-type (:class-symbol nil)))))"""
+      s"""(:symbol-designations (:file "$symFile" :syms ((:start 7 :end 9 :sym-type :var-field-symbol) (:start 11 :end 22 :sym-type :class-symbol))))"""
     )
 
     roundtrip(
       ImplicitInfos(List(ImplicitConversionInfo(5, 6, symbolInfo))): ImplicitInfos,
-      """(:implicit-infos (:infos ((:implicit-conversion-info (:start 5 :end 6 :fun (:name "name" :local-name "localName" :type (:basic-type-info (:name "type1" :decl-as (:method nil) :full-name "FOO.type1"))))))))"""
+      """(:implicit-infos (:infos ((:implicit-conversion-info (:start 5 :end 6 :fun (:name "name" :local-name "localName" :type (:basic-type-info (:name "type1" :decl-as :method :full-name "FOO.type1"))))))))"""
     )
 
     roundtrip(
       ImplicitInfos(List(ImplicitParamInfo(5, 6, symbolInfo, List(symbolInfo, symbolInfo), true))): ImplicitInfos,
-      s"""(:implicit-infos (:infos ((:implicit-param-info (:start 5 :end 6 :fun (:name "name" :local-name "localName" :type (:basic-type-info (:name "type1" :decl-as (:method nil) :full-name "FOO.type1"))) :params ((:name "name" :local-name "localName" :type (:basic-type-info (:name "type1" :decl-as (:method nil) :full-name "FOO.type1"))) (:name "name" :local-name "localName" :type (:basic-type-info (:name "type1" :decl-as (:method nil) :full-name "FOO.type1")))) :fun-is-implicit t)))))"""
+      s"""(:implicit-infos (:infos ((:implicit-param-info (:start 5 :end 6 :fun (:name "name" :local-name "localName" :type (:basic-type-info (:name "type1" :decl-as :method :full-name "FOO.type1"))) :params ((:name "name" :local-name "localName" :type (:basic-type-info (:name "type1" :decl-as :method :full-name "FOO.type1"))) (:name "name" :local-name "localName" :type (:basic-type-info (:name "type1" :decl-as :method :full-name "FOO.type1")))) :fun-is-implicit t)))))"""
     )
   }
 
@@ -614,7 +614,7 @@ class SwankyFormatsSpec extends EnsimeSpec with EnsimeTestData {
 
     roundtrip(
       refactorDiffEffect: RefactorDiffEffect,
-      s"""(:refactor-diff-effect (:procedure-id 9 :refactor-type (:add-import nil) :diff "$file2"))"""
+      s"""(:refactor-diff-effect (:procedure-id 9 :refactor-type :add-import :diff "$file2"))"""
     )
 
   }
@@ -622,12 +622,12 @@ class SwankyFormatsSpec extends EnsimeSpec with EnsimeTestData {
   it should "roundtrip legacy raw response types" in {
     roundtrip(
       FalseResponse,
-      "(:false-response nil)"
+      ":false-response"
     )
 
     roundtrip(
       TrueResponse,
-      "(:true-response nil)"
+      ":true-response"
     )
 
     roundtrip(
@@ -637,7 +637,7 @@ class SwankyFormatsSpec extends EnsimeSpec with EnsimeTestData {
 
     roundtrip(
       VoidResponse,
-      """(:void-response nil)"""
+      """:void-response"""
     )
 
   }

--- a/protocol-swanky/src/test/scala/org/ensime/swanky/SwankyFormatsSpec.scala
+++ b/protocol-swanky/src/test/scala/org/ensime/swanky/SwankyFormatsSpec.scala
@@ -32,136 +32,136 @@ class SwankyFormatsSpec extends EnsimeSpec with EnsimeTestData {
   "SWANK Formats" should "roundtrip startup messages" in {
     roundtrip(
       ConnectionInfoReq: RpcRequest,
-      "(:ConnectionInfoReq nil)"
+      "(:connection-info-req nil)"
     )
   }
 
   it should "roundtrip RpcSearchRequests" in {
     roundtrip(
       PublicSymbolSearchReq(List("foo", "bar"), 10): RpcRequest,
-      """(:PublicSymbolSearchReq (:keywords ("foo" "bar") :max-results 10))"""
+      """(:public-symbol-search-req (:keywords ("foo" "bar") :max-results 10))"""
     )
 
     roundtrip(
       ImportSuggestionsReq(Left(file1), 1, List("foo", "bar"), 10): RpcRequest,
-      s"""(:ImportSuggestionsReq (:file "$file1" :point 1 :names ("foo" "bar") :max-results 10))"""
+      s"""(:import-suggestions-req (:file "$file1" :point 1 :names ("foo" "bar") :max-results 10))"""
     )
   }
 
   it should "roundtrip RpcAnalyserRequests" in {
     roundtrip(
       RemoveFileReq(file1): RpcRequest,
-      s"""(:RemoveFileReq (:file "$file1"))"""
+      s"""(:remove-file-req (:file "$file1"))"""
     )
 
     roundtrip(
       TypecheckFileReq(sourceFileInfo): RpcRequest,
-      s"""(:TypecheckFileReq (:file-info (:file "$file1" :contents "{/* code here */}" :contents-in "$file2")))"""
+      s"""(:typecheck-file-req (:file-info (:file "$file1" :contents "{/* code here */}" :contents-in "$file2")))"""
     )
 
     roundtrip(
       TypecheckFilesReq(List(Left(file1), Left(file2))): RpcRequest,
-      s"""(:TypecheckFilesReq (:files ("$file1" "$file2")))"""
+      s"""(:typecheck-files-req (:files ("$file1" "$file2")))"""
     )
 
     roundtrip(
       TypecheckFilesReq(List(Right(SourceFileInfo(file1)), Right(SourceFileInfo(file2, Some("xxx"), None)))): RpcRequest,
-      s"""(:TypecheckFilesReq (:files ((:file "$file1") (:file "$file2" :contents "xxx"))))"""
+      s"""(:typecheck-files-req (:files ((:file "$file1") (:file "$file2" :contents "xxx"))))"""
     )
 
     roundtrip(
       UnloadAllReq: RpcRequest,
-      """(:UnloadAllReq nil)"""
+      """(:unload-all-req nil)"""
     )
 
     roundtrip(
       TypecheckAllReq: RpcRequest,
-      """(:TypecheckAllReq nil)"""
+      """(:typecheck-all-req nil)"""
     )
 
     roundtrip(
       FormatSourceReq(List(file1, file2)): RpcRequest,
-      s"""(:FormatSourceReq (:files ("$file1" "$file2")))"""
+      s"""(:format-source-req (:files ("$file1" "$file2")))"""
     )
 
     roundtrip(
       FormatOneSourceReq(sourceFileInfo): RpcRequest,
-      s"""(:FormatOneSourceReq (:file (:file "$file1" :contents "{/* code here */}" :contents-in "$file2")))"""
+      s"""(:format-one-source-req (:file (:file "$file1" :contents "{/* code here */}" :contents-in "$file2")))"""
     )
 
     roundtrip(
       DocUriAtPointReq(Left(file1), OffsetRange(1, 10)): RpcRequest,
-      s"""(:DocUriAtPointReq (:file "$file1" :point (:from 1 :to 10)))"""
+      s"""(:doc-uri-at-point-req (:file "$file1" :point (:from 1 :to 10)))"""
     )
 
     roundtrip(
       DocUriAtPointReq(Right(SourceFileInfo(file1, None, Some(file2))), OffsetRange(1, 10)): RpcRequest,
-      s"""(:DocUriAtPointReq (:file (:file "$file1" :contents-in "$file2") :point (:from 1 :to 10)))"""
+      s"""(:doc-uri-at-point-req (:file (:file "$file1" :contents-in "$file2") :point (:from 1 :to 10)))"""
     )
 
     roundtrip(
       DocUriForSymbolReq("foo.bar", Some("Baz"), None): RpcRequest,
-      s"""(:DocUriForSymbolReq (:type-full-name "foo.bar" :member-name "Baz"))"""
+      s"""(:doc-uri-for-symbol-req (:type-full-name "foo.bar" :member-name "Baz"))"""
     )
 
     roundtrip(
       CompletionsReq(sourceFileInfo, 10, 100, true, false): RpcRequest,
-      s"""(:CompletionsReq (:file-info (:file "$file1" :contents "{/* code here */}" :contents-in "$file2") :point 10 :max-results 100 :case-sens t))"""
+      s"""(:completions-req (:file-info (:file "$file1" :contents "{/* code here */}" :contents-in "$file2") :point 10 :max-results 100 :case-sens t))"""
     )
 
     roundtrip(
       PackageMemberCompletionReq("foo", "bar"): RpcRequest,
-      """(:PackageMemberCompletionReq (:path "foo" :prefix "bar"))"""
+      """(:package-member-completion-req (:path "foo" :prefix "bar"))"""
     )
 
     roundtrip(
       UsesOfSymbolAtPointReq(Left(file1), 100): RpcRequest,
-      s"""(:UsesOfSymbolAtPointReq (:file "$file1" :point 100))"""
+      s"""(:uses-of-symbol-at-point-req (:file "$file1" :point 100))"""
     )
 
     roundtrip(
       TypeByNameReq("foo.bar"): RpcRequest,
-      s"""(:TypeByNameReq (:name "foo.bar"))"""
+      s"""(:type-by-name-req (:name "foo.bar"))"""
     )
 
     roundtrip(
       TypeByNameAtPointReq("foo.bar", Left(file1), OffsetRange(1, 10)): RpcRequest,
-      s"""(:TypeByNameAtPointReq (:name "foo.bar" :file "$file1" :range (:from 1 :to 10)))"""
+      s"""(:type-by-name-at-point-req (:name "foo.bar" :file "$file1" :range (:from 1 :to 10)))"""
     )
 
     roundtrip(
       TypeAtPointReq(Left(file1), OffsetRange(1, 100)): RpcRequest,
-      s"""(:TypeAtPointReq (:file "$file1" :range (:from 1 :to 100)))"""
+      s"""(:type-at-point-req (:file "$file1" :range (:from 1 :to 100)))"""
     )
 
     roundtrip(
       InspectTypeAtPointReq(Left(file1), OffsetRange(1, 100)): RpcRequest,
-      s"""(:InspectTypeAtPointReq (:file "$file1" :range (:from 1 :to 100)))"""
+      s"""(:inspect-type-at-point-req (:file "$file1" :range (:from 1 :to 100)))"""
     )
 
     roundtrip(
       InspectTypeByNameReq("foo.Bar"): RpcRequest,
-      s"""(:InspectTypeByNameReq (:name "foo.Bar"))"""
+      s"""(:inspect-type-by-name-req (:name "foo.Bar"))"""
     )
 
     roundtrip(
       SymbolAtPointReq(Left(file1), 101): RpcRequest,
-      s"""(:SymbolAtPointReq (:file "$file1" :point 101))"""
+      s"""(:symbol-at-point-req (:file "$file1" :point 101))"""
     )
 
     roundtrip(
       SymbolByNameReq("foo.Bar", Some("baz"), None): RpcRequest,
-      s"""(:SymbolByNameReq (:type-full-name "foo.Bar" :member-name "baz"))"""
+      s"""(:symbol-by-name-req (:type-full-name "foo.Bar" :member-name "baz"))"""
     )
 
     roundtrip(
       InspectPackageByPathReq("foo.bar"): RpcRequest,
-      s"""(:InspectPackageByPathReq (:path "foo.bar"))"""
+      s"""(:inspect-package-by-path-req (:path "foo.bar"))"""
     )
 
     roundtrip(
       RefactorReq(1, RenameRefactorDesc("bar", file1, 1, 100), false): RpcRequest,
-      s"""(:RefactorReq (:proc-id 1 :params (:RenameRefactorDesc (:new-name "bar" :file "$file1" :start 1 :end 100))))"""
+      s"""(:refactor-req (:proc-id 1 :params (:rename-refactor-desc (:new-name "bar" :file "$file1" :start 1 :end 100))))"""
     )
 
     roundtrip(
@@ -169,7 +169,7 @@ class SwankyFormatsSpec extends EnsimeSpec with EnsimeTestData {
         Left(file1), 1, 100,
         List(ObjectSymbol, ValSymbol)
       ): RpcRequest,
-      s"""(:SymbolDesignationsReq (:file "$file1" :start 1 :end 100 :requested-types ((:ObjectSymbol nil) (:ValSymbol nil))))"""
+      s"""(:symbol-designations-req (:file "$file1" :start 1 :end 100 :requested-types ((:object-symbol nil) (:val-symbol nil))))"""
     )
 
     roundtrip(
@@ -177,114 +177,114 @@ class SwankyFormatsSpec extends EnsimeSpec with EnsimeTestData {
         Right(SourceFileInfo(file1, None, None)), 1, 100,
         List(ObjectSymbol, ValSymbol)
       ): RpcRequest,
-      s"""(:SymbolDesignationsReq (:file (:file "$file1") :start 1 :end 100 :requested-types ((:ObjectSymbol nil) (:ValSymbol nil))))"""
+      s"""(:symbol-designations-req (:file (:file "$file1") :start 1 :end 100 :requested-types ((:object-symbol nil) (:val-symbol nil))))"""
     )
 
     roundtrip(
       ExpandSelectionReq(file1, 100, 200): RpcRequest,
-      s"""(:ExpandSelectionReq (:file "$file1" :start 100 :end 200))"""
+      s"""(:expand-selection-req (:file "$file1" :start 100 :end 200))"""
     )
 
     roundtrip(
       ImplicitInfoReq(Left(file1), OffsetRange(0, 123)),
-      s"""(:ImplicitInfoReq (:file "$file1" :range (:from 0 :to 123)))"""
+      s"""(:implicit-info-req (:file "$file1" :range (:from 0 :to 123)))"""
     )
 
     roundtrip(
       StructureViewReq(sourceFileInfo): RpcRequest,
-      s"""(:StructureViewReq (:file-info (:file "$file1" :contents "{/* code here */}" :contents-in "$file2")))"""
+      s"""(:structure-view-req (:file-info (:file "$file1" :contents "{/* code here */}" :contents-in "$file2")))"""
     )
 
     roundtrip(
       AstAtPointReq(sourceFileInfo, OffsetRange(1, 100)): RpcRequest,
-      s"""(:AstAtPointReq (:file (:file "$file1" :contents "{/* code here */}" :contents-in "$file2") :offset (:from 1 :to 100)))"""
+      s"""(:ast-at-point-req (:file (:file "$file1" :contents "{/* code here */}" :contents-in "$file2") :offset (:from 1 :to 100)))"""
     )
   }
 
   it should "roundtrip RpcDebugRequests" in {
     roundtrip(
       DebugActiveVmReq: RpcRequest,
-      """(:DebugActiveVmReq nil)"""
+      """(:debug-active-vm-req nil)"""
     )
 
     roundtrip(
       DebugAttachReq("mylovelyhorse", "13"): RpcRequest,
-      """(:DebugAttachReq (:hostname "mylovelyhorse" :port "13"))"""
+      """(:debug-attach-req (:hostname "mylovelyhorse" :port "13"))"""
     )
 
     roundtrip(
       DebugStopReq: RpcRequest,
-      """(:DebugStopReq nil)"""
+      """(:debug-stop-req nil)"""
     )
 
     roundtrip(
       DebugSetBreakReq(file1, 13): RpcRequest,
-      s"""(:DebugSetBreakReq (:file "$file1" :line 13))"""
+      s"""(:debug-set-break-req (:file "$file1" :line 13))"""
     )
 
     roundtrip(
       DebugClearBreakReq(file1, 13): RpcRequest,
-      s"""(:DebugClearBreakReq (:file "$file1" :line 13))"""
+      s"""(:debug-clear-break-req (:file "$file1" :line 13))"""
     )
 
     roundtrip(
       DebugClearAllBreaksReq: RpcRequest,
-      s"""(:DebugClearAllBreaksReq nil)"""
+      s"""(:debug-clear-all-breaks-req nil)"""
     )
 
     roundtrip(
       DebugListBreakpointsReq: RpcRequest,
-      s"""(:DebugListBreakpointsReq nil)"""
+      s"""(:debug-list-breakpoints-req nil)"""
     )
 
     roundtrip(
       DebugRunReq: RpcRequest,
-      s"""(:DebugRunReq nil)"""
+      s"""(:debug-run-req nil)"""
     )
 
     roundtrip(
       DebugContinueReq(dtid): RpcRequest,
-      s"""(:DebugContinueReq (:thread-id 13))"""
+      s"""(:debug-continue-req (:thread-id 13))"""
     )
 
     roundtrip(
       DebugStepReq(dtid): RpcRequest,
-      s"""(:DebugStepReq (:thread-id 13))"""
+      s"""(:debug-step-req (:thread-id 13))"""
     )
 
     roundtrip(
       DebugNextReq(dtid): RpcRequest,
-      s"""(:DebugNextReq (:thread-id 13))"""
+      s"""(:debug-next-req (:thread-id 13))"""
     )
 
     roundtrip(
       DebugStepOutReq(dtid): RpcRequest,
-      s"""(:DebugStepOutReq (:thread-id 13))"""
+      s"""(:debug-step-out-req (:thread-id 13))"""
     )
 
     roundtrip(
       DebugLocateNameReq(dtid, "foo"): RpcRequest,
-      s"""(:DebugLocateNameReq (:thread-id 13 :name "foo"))"""
+      s"""(:debug-locate-name-req (:thread-id 13 :name "foo"))"""
     )
 
     roundtrip(
       DebugValueReq(debugLocationArray): RpcRequest,
-      s"""(:DebugValueReq (:loc (:DebugArrayElement (:object-id 13 :index 14))))"""
+      s"""(:debug-value-req (:loc (:debug-array-element (:object-id 13 :index 14))))"""
     )
 
     roundtrip(
       DebugToStringReq(dtid, debugLocationArray): RpcRequest,
-      s"""(:DebugToStringReq (:thread-id 13 :loc (:DebugArrayElement (:object-id 13 :index 14))))"""
+      s"""(:debug-to-string-req (:thread-id 13 :loc (:debug-array-element (:object-id 13 :index 14))))"""
     )
 
     roundtrip(
       DebugSetValueReq(debugLocationArray, "bar"): RpcRequest,
-      s"""(:DebugSetValueReq (:loc (:DebugArrayElement (:object-id 13 :index 14)) :new-value "bar"))"""
+      s"""(:debug-set-value-req (:loc (:debug-array-element (:object-id 13 :index 14)) :new-value "bar"))"""
     )
 
     roundtrip(
       DebugBacktraceReq(dtid, 100, 200): RpcRequest,
-      s"""(:DebugBacktraceReq (:thread-id 13 :index 100 :count 200))"""
+      s"""(:debug-backtrace-req (:thread-id 13 :index 100 :count 200))"""
     )
 
   }
@@ -292,22 +292,22 @@ class SwankyFormatsSpec extends EnsimeSpec with EnsimeTestData {
   it should "roundtrip EnsimeGeneralEvent as EnsimeEvent" in {
     roundtrip(
       SendBackgroundMessageEvent("ABCDEF", 1): EnsimeEvent,
-      """(:SendBackgroundMessageEvent (:detail "ABCDEF" :code 1))"""
+      """(:send-background-message-event (:detail "ABCDEF" :code 1))"""
     )
 
     roundtrip(
       AnalyzerReadyEvent: EnsimeEvent,
-      "(:AnalyzerReadyEvent nil)"
+      "(:analyzer-ready-event nil)"
     )
 
     roundtrip(
       FullTypeCheckCompleteEvent: EnsimeEvent,
-      "(:FullTypeCheckCompleteEvent nil)"
+      "(:full-type-check-complete-event nil)"
     )
 
     roundtrip(
       IndexerReadyEvent: EnsimeEvent,
-      "(:IndexerReadyEvent nil)"
+      "(:indexer-ready-event nil)"
     )
 
     roundtrip(
@@ -315,274 +315,274 @@ class SwankyFormatsSpec extends EnsimeSpec with EnsimeTestData {
         isFull = false,
         List(Note("foo.scala", "testMsg", NoteWarn, 50, 55, 77, 5))
       ): EnsimeEvent,
-      """(:NewScalaNotesEvent (:notes ((:file "foo.scala" :msg "testMsg" :severity (:NoteWarn nil) :beg 50 :end 55 :line 77 :col 5))))"""
+      """(:new-scala-notes-event (:notes ((:file "foo.scala" :msg "testMsg" :severity (:note-warn nil) :beg 50 :end 55 :line 77 :col 5))))"""
     )
 
     roundtrip(
       ClearAllScalaNotesEvent: EnsimeEvent,
-      "(:ClearAllScalaNotesEvent nil)"
+      "(:clear-all-scala-notes-event nil)"
     )
   }
 
   it should "roundtrip DebugEvent as EnsimeEvent" in {
     roundtrip(
       DebugOutputEvent("XXX"): EnsimeEvent,
-      """(:DebugOutputEvent (:body "XXX"))"""
+      """(:debug-output-event (:body "XXX"))"""
     )
 
     roundtrip(
       DebugStepEvent(DebugThreadId(207), "threadNameStr", sourcePos1.file, sourcePos1.line): EnsimeEvent,
-      s"""(:DebugStepEvent (:thread-id 207 :thread-name "threadNameStr" :file "$file1" :line 57))"""
+      s"""(:debug-step-event (:thread-id 207 :thread-name "threadNameStr" :file "$file1" :line 57))"""
     )
 
     roundtrip(
       DebugBreakEvent(DebugThreadId(209), "threadNameStr", sourcePos1.file, sourcePos1.line): EnsimeEvent,
-      s"""(:DebugBreakEvent (:thread-id 209 :thread-name "threadNameStr" :file "$file1" :line 57))"""
+      s"""(:debug-break-event (:thread-id 209 :thread-name "threadNameStr" :file "$file1" :line 57))"""
     )
 
     roundtrip(
       DebugVMStartEvent: EnsimeEvent,
-      """(:DebugVMStartEvent nil)"""
+      """(:debug-v-m-start-event nil)"""
     )
 
     roundtrip(
       DebugVMDisconnectEvent: EnsimeEvent,
-      """(:DebugVMDisconnectEvent nil)"""
+      """(:debug-v-m-disconnect-event nil)"""
     )
 
     roundtrip(
       DebugExceptionEvent(33L, dtid, "threadNameStr", Some(sourcePos1.file), Some(sourcePos1.line)): EnsimeEvent,
-      s"""(:DebugExceptionEvent (:exception 33 :thread-id 13 :thread-name "threadNameStr" :file "$file1" :line 57))"""
+      s"""(:debug-exception-event (:exception 33 :thread-id 13 :thread-name "threadNameStr" :file "$file1" :line 57))"""
     )
 
     roundtrip(
       DebugExceptionEvent(33L, dtid, "threadNameStr", None, None): EnsimeEvent,
-      """(:DebugExceptionEvent (:exception 33 :thread-id 13 :thread-name "threadNameStr"))"""
+      """(:debug-exception-event (:exception 33 :thread-id 13 :thread-name "threadNameStr"))"""
     )
 
     roundtrip(
       DebugThreadStartEvent(dtid): EnsimeEvent,
-      """(:DebugThreadStartEvent (:thread-id 13))"""
+      """(:debug-thread-start-event (:thread-id 13))"""
     )
 
     roundtrip(
       DebugThreadDeathEvent(dtid): EnsimeEvent,
-      """(:DebugThreadDeathEvent (:thread-id 13))"""
+      """(:debug-thread-death-event (:thread-id 13))"""
     )
   }
 
   it should "roundtrip DebugLocation" in {
     roundtrip(
       DebugObjectReference(57L): DebugLocation,
-      """(:DebugObjectReference (:object-id 57))"""
+      """(:debug-object-reference (:object-id 57))"""
     )
 
     roundtrip(
       DebugArrayElement(DebugObjectId(58L), 2): DebugLocation,
-      """(:DebugArrayElement (:object-id 58 :index 2))"""
+      """(:debug-array-element (:object-id 58 :index 2))"""
     )
 
     roundtrip(
       DebugObjectField(DebugObjectId(58L), "fieldName"): DebugLocation,
-      """(:DebugObjectField (:object-id 58 :field "fieldName"))"""
+      """(:debug-object-field (:object-id 58 :field "fieldName"))"""
     )
 
     roundtrip(
       DebugStackSlot(DebugThreadId(27), 12, 23): DebugLocation,
-      """(:DebugStackSlot (:thread-id 27 :frame 12 :offset 23))"""
+      """(:debug-stack-slot (:thread-id 27 :frame 12 :offset 23))"""
     )
   }
 
   it should "roundtrip DebugValue" in {
     roundtrip(
       DebugPrimitiveValue("summaryStr", "typeNameStr"): DebugValue,
-      """(:DebugPrimitiveValue (:summary "summaryStr" :type-name "typeNameStr"))"""
+      """(:debug-primitive-value (:summary "summaryStr" :type-name "typeNameStr"))"""
     )
 
     roundtrip(
       DebugStringInstance("summaryStr", List(debugClassField), "typeNameStr", DebugObjectId(5L)): DebugValue,
-      """(:DebugStringInstance (:summary "summaryStr" :fields ((:index 19 :name "nameStr" :type-name "typeNameStr" :summary "summaryStr")) :type-name "typeNameStr" :object-id 5))"""
+      """(:debug-string-instance (:summary "summaryStr" :fields ((:index 19 :name "nameStr" :type-name "typeNameStr" :summary "summaryStr")) :type-name "typeNameStr" :object-id 5))"""
     )
 
     roundtrip(
       DebugObjectInstance("summaryStr", List(debugClassField), "typeNameStr", DebugObjectId(5L)): DebugValue,
-      """(:DebugObjectInstance (:summary "summaryStr" :fields ((:index 19 :name "nameStr" :type-name "typeNameStr" :summary "summaryStr")) :type-name "typeNameStr" :object-id 5))"""
+      """(:debug-object-instance (:summary "summaryStr" :fields ((:index 19 :name "nameStr" :type-name "typeNameStr" :summary "summaryStr")) :type-name "typeNameStr" :object-id 5))"""
     )
 
     roundtrip(
       DebugNullValue("typeNameStr"): DebugValue,
-      """(:DebugNullValue (:type-name "typeNameStr"))"""
+      """(:debug-null-value (:type-name "typeNameStr"))"""
     )
 
     roundtrip(
       DebugArrayInstance(3, "typeName", "elementType", DebugObjectId(5L)): DebugValue,
-      """(:DebugArrayInstance (:length 3 :type-name "typeName" :element-type-name "elementType" :object-id 5))"""
+      """(:debug-array-instance (:length 3 :type-name "typeName" :element-type-name "elementType" :object-id 5))"""
     )
 
     roundtrip(
       debugClassField: DebugClassField,
-      """(:DebugClassField (:index 19 :name "nameStr" :type-name "typeNameStr" :summary "summaryStr"))"""
+      """(:debug-class-field (:index 19 :name "nameStr" :type-name "typeNameStr" :summary "summaryStr"))"""
     )
 
     roundtrip(
       debugStackLocal1: DebugStackLocal,
-      """(:DebugStackLocal (:index 3 :name "name1" :summary "summary1" :type-name "type1"))"""
+      """(:debug-stack-local (:index 3 :name "name1" :summary "summary1" :type-name "type1"))"""
     )
 
     roundtrip(
       debugStackFrame: DebugStackFrame,
-      s"""(:DebugStackFrame (:index 7 :locals ((:index 3 :name "name1" :summary "summary1" :type-name "type1") (:index 4 :name "name2" :summary "summary2" :type-name "type2")) :num-args 4 :class-name "class1" :method-name "method1" :pc-location (:file "$file1" :line 57) :this-object-id 7))"""
+      s"""(:debug-stack-frame (:index 7 :locals ((:index 3 :name "name1" :summary "summary1" :type-name "type1") (:index 4 :name "name2" :summary "summary2" :type-name "type2")) :num-args 4 :class-name "class1" :method-name "method1" :pc-location (:file "$file1" :line 57) :this-object-id 7))"""
     )
 
     roundtrip(
       DebugBacktrace(List(debugStackFrame), dtid, "thread1"): DebugBacktrace,
-      s"""(:DebugBacktrace (:frames ((:index 7 :locals ((:index 3 :name "name1" :summary "summary1" :type-name "type1") (:index 4 :name "name2" :summary "summary2" :type-name "type2")) :num-args 4 :class-name "class1" :method-name "method1" :pc-location (:file "$file1" :line 57) :this-object-id 7)) :thread-id 13 :thread-name "thread1"))"""
+      s"""(:debug-backtrace (:frames ((:index 7 :locals ((:index 3 :name "name1" :summary "summary1" :type-name "type1") (:index 4 :name "name2" :summary "summary2" :type-name "type2")) :num-args 4 :class-name "class1" :method-name "method1" :pc-location (:file "$file1" :line 57) :this-object-id 7)) :thread-id 13 :thread-name "thread1"))"""
     )
 
     roundtrip(
       sourcePos1: SourcePosition,
-      s"""(:LineSourcePosition (:file "$file1" :line 57))"""
+      s"""(:line-source-position (:file "$file1" :line 57))"""
     )
 
     roundtrip(
       sourcePos2: SourcePosition,
-      s"""(:LineSourcePosition (:file "$file1" :line 59))"""
+      s"""(:line-source-position (:file "$file1" :line 59))"""
     )
 
     roundtrip(
       sourcePos3: SourcePosition,
-      "(:EmptySourcePosition nil)"
+      "(:empty-source-position nil)"
     )
 
     roundtrip(
       sourcePos4: SourcePosition,
-      s"""(:OffsetSourcePosition (:file "$file1" :offset 456))"""
+      s"""(:offset-source-position (:file "$file1" :offset 456))"""
     )
 
     roundtrip(
       breakPoint1: Breakpoint,
-      s"""(:Breakpoint (:file "$file1" :line 57))"""
+      s"""(:breakpoint (:file "$file1" :line 57))"""
     )
 
     roundtrip(
       BreakpointList(List(breakPoint1), List(breakPoint2)): BreakpointList,
-      s"""(:BreakpointList (:active ((:file "$file1" :line 57)) :pending ((:file "$file1" :line 59))))"""
+      s"""(:breakpoint-list (:active ((:file "$file1" :line 57)) :pending ((:file "$file1" :line 59))))"""
     )
 
     roundtrip(
       DebugVmSuccess(): DebugVmStatus,
-      """(:DebugVmSuccess (:status "success"))"""
+      """(:debug-vm-success (:status "success"))"""
     )
 
     roundtrip(
       DebugVmError(303, "xxxx"): DebugVmStatus,
-      """(:DebugVmError (:error-code 303 :details "xxxx" :status "error"))"""
+      """(:debug-vm-error (:error-code 303 :details "xxxx" :status "error"))"""
     )
   }
 
   it should "roundtrip various informational types" in {
     roundtrip(
       note1: Note,
-      """(:Note (:file "file1" :msg "note1" :severity (:NoteError nil) :beg 23 :end 33 :line 19 :col 8))"""
+      """(:note (:file "file1" :msg "note1" :severity (:note-error nil) :beg 23 :end 33 :line 19 :col 8))"""
     )
 
     roundtrip(
       completionInfo: CompletionInfo,
-      """(:CompletionInfo (:type-info (:BasicTypeInfo (:name "type1" :decl-as (:Method nil) :full-name "FOO.type1")) :name "name" :relevance 90 :to-insert "BAZ"))"""
+      """(:completion-info (:type-info (:basic-type-info (:name "type1" :decl-as (:method nil) :full-name "FOO.type1")) :name "name" :relevance 90 :to-insert "BAZ"))"""
     )
 
     roundtrip(
       completionInfo2: CompletionInfo,
-      """(:CompletionInfo (:name "name2" :relevance 91))"""
+      """(:completion-info (:name "name2" :relevance 91))"""
     )
 
     roundtrip(
       CompletionInfoList("fooBar", List(completionInfo)): CompletionInfoList,
-      """(:CompletionInfoList (:prefix "fooBar" :completions ((:type-info (:BasicTypeInfo (:name "type1" :decl-as (:Method nil) :full-name "FOO.type1")) :name "name" :relevance 90 :to-insert "BAZ"))))"""
+      """(:completion-info-list (:prefix "fooBar" :completions ((:type-info (:basic-type-info (:name "type1" :decl-as (:method nil) :full-name "FOO.type1")) :name "name" :relevance 90 :to-insert "BAZ"))))"""
     )
 
     roundtrip(
       SymbolInfo("name", "localName", None, typeInfo): SymbolInfo,
-      """(:SymbolInfo (:name "name" :local-name "localName" :type (:BasicTypeInfo (:name "type1" :decl-as (:Method nil) :full-name "FOO.type1"))))"""
+      """(:symbol-info (:name "name" :local-name "localName" :type (:basic-type-info (:name "type1" :decl-as (:method nil) :full-name "FOO.type1"))))"""
     )
 
     roundtrip(
       NamedTypeMemberInfo("typeX", typeInfo, None, None, DeclaredAs.Method): EntityInfo,
-      """(:NamedTypeMemberInfo (:name "typeX" :type (:BasicTypeInfo (:name "type1" :decl-as (:Method nil) :full-name "FOO.type1")) :decl-as (:Method nil)))"""
+      """(:named-type-member-info (:name "typeX" :type (:basic-type-info (:name "type1" :decl-as (:method nil) :full-name "FOO.type1")) :decl-as (:method nil)))"""
     )
 
     roundtrip(
       entityInfo: EntityInfo,
-      """(:ArrowTypeInfo (:name "Arrow1" :full-name "example.Arrow1" :result-type (:BasicTypeInfo (:name "type1" :decl-as (:Method nil) :full-name "FOO.type1")) :param-sections ((:params ((:_1 "ABC" :_2 (:BasicTypeInfo (:name "type1" :decl-as (:Method nil) :full-name "FOO.type1"))))))))"""
+      """(:arrow-type-info (:name "Arrow1" :full-name "example.Arrow1" :result-type (:basic-type-info (:name "type1" :decl-as (:method nil) :full-name "FOO.type1")) :param-sections ((:params ((:_1 "ABC" :_2 (:basic-type-info (:name "type1" :decl-as (:method nil) :full-name "FOO.type1"))))))))"""
     )
 
     roundtrip(
       entityInfoTypeParams: EntityInfo,
-      s"""(:ArrowTypeInfo (:name "Arrow1" :full-name "example.Arrow1" :result-type (:BasicTypeInfo (:name "type1" :decl-as (:Method nil) :full-name "FOO.type1")) :param-sections ((:params ((:_1 "ABC" :_2 (:BasicTypeInfo (:name "type1" :decl-as (:Method nil) :full-name "FOO.type1")))))) :type-params ((:BasicTypeInfo (:name "A" :decl-as (:Nil nil) :full-name "example.Arrow1.A")) (:BasicTypeInfo (:name "B" :decl-as (:Nil nil) :full-name "example.Arrow1.B")))))"""
+      s"""(:arrow-type-info (:name "Arrow1" :full-name "example.Arrow1" :result-type (:basic-type-info (:name "type1" :decl-as (:method nil) :full-name "FOO.type1")) :param-sections ((:params ((:_1 "ABC" :_2 (:basic-type-info (:name "type1" :decl-as (:method nil) :full-name "FOO.type1")))))) :type-params ((:basic-type-info (:name "A" :decl-as (:nil nil) :full-name "example.Arrow1.A")) (:basic-type-info (:name "B" :decl-as (:nil nil) :full-name "example.Arrow1.B")))))"""
     )
 
     roundtrip(
       typeInfo: EntityInfo,
-      """(:BasicTypeInfo (:name "type1" :decl-as (:Method nil) :full-name "FOO.type1"))"""
+      """(:basic-type-info (:name "type1" :decl-as (:method nil) :full-name "FOO.type1"))"""
     )
 
     roundtrip(
       packageInfo: EntityInfo,
-      """(:PackageInfo (:name "name" :full-name "fullName"))"""
+      """(:package-info (:name "name" :full-name "fullName"))"""
     )
 
     roundtrip(
       interfaceInfo: InterfaceInfo,
-      """(:InterfaceInfo (:type (:BasicTypeInfo (:name "type1" :decl-as (:Method nil) :full-name "FOO.type1")) :via-view "DEF"))"""
+      """(:interface-info (:type (:basic-type-info (:name "type1" :decl-as (:method nil) :full-name "FOO.type1")) :via-view "DEF"))"""
     )
 
     roundtrip(
       TypeInspectInfo(typeInfo, List(interfaceInfo)): TypeInspectInfo,
-      """(:TypeInspectInfo (:type (:BasicTypeInfo (:name "type1" :decl-as (:Method nil) :full-name "FOO.type1")) :interfaces ((:type (:BasicTypeInfo (:name "type1" :decl-as (:Method nil) :full-name "FOO.type1")) :via-view "DEF")) :info-type typeInspect))"""
+      """(:type-inspect-info (:type (:basic-type-info (:name "type1" :decl-as (:method nil) :full-name "FOO.type1")) :interfaces ((:type (:basic-type-info (:name "type1" :decl-as (:method nil) :full-name "FOO.type1")) :via-view "DEF")) :info-type typeInspect))"""
     )
 
     roundtrip(
       structureView: StructureView,
-      s"""(:StructureView (:view ((:keyword "class" :name "StructureView" :position (:LineSourcePosition (:file "$file1" :line 57))) (:keyword "object" :name "StructureView" :position (:LineSourcePosition (:file "$file1" :line 59)) :members ((:keyword "type" :name "BasicType" :position (:OffsetSourcePosition (:file "$file1" :offset 456))))))))"""
+      s"""(:structure-view (:view ((:keyword "class" :name "StructureView" :position (:line-source-position (:file "$file1" :line 57))) (:keyword "object" :name "StructureView" :position (:line-source-position (:file "$file1" :line 59)) :members ((:keyword "type" :name "BasicType" :position (:offset-source-position (:file "$file1" :offset 456))))))))"""
     )
 
     roundtrip(
       astInfo: AstInfo,
-      """(:AstInfo (:ast "List(Apply(Select(Literal(Constant(1)), TermName(\"$plus\")), List(Literal(Constant(1)))))"))"""
+      """(:ast-info (:ast "List(Apply(Select(Literal(Constant(1)), TermName(\"$plus\")), List(Literal(Constant(1)))))"))"""
     )
   }
 
   it should "roundtrip search related responses" in {
     roundtrip(
       SymbolSearchResults(List(methodSearchRes, typeSearchRes)): SymbolSearchResults,
-      s"""(:SymbolSearchResults (:syms ((:MethodSearchResult (:name "abc" :local-name "a" :decl-as (:Method nil) :pos (:LineSourcePosition (:file "$abd" :line 10)) :owner-name "ownerStr")) (:TypeSearchResult (:name "abc" :local-name "a" :decl-as (:Trait nil) :pos (:LineSourcePosition (:file "$abd" :line 10)))))))"""
+      s"""(:symbol-search-results (:syms ((:method-search-result (:name "abc" :local-name "a" :decl-as (:method nil) :pos (:line-source-position (:file "$abd" :line 10)) :owner-name "ownerStr")) (:type-search-result (:name "abc" :local-name "a" :decl-as (:trait nil) :pos (:line-source-position (:file "$abd" :line 10)))))))"""
     )
 
     roundtrip(
       ImportSuggestions(List(List(methodSearchRes, typeSearchRes))): ImportSuggestions,
-      s"""(:ImportSuggestions (:sym-lists (((:MethodSearchResult (:name "abc" :local-name "a" :decl-as (:Method nil) :pos (:LineSourcePosition (:file "$abd" :line 10)) :owner-name "ownerStr")) (:TypeSearchResult (:name "abc" :local-name "a" :decl-as (:Trait nil) :pos (:LineSourcePosition (:file "$abd" :line 10))))))))"""
+      s"""(:import-suggestions (:sym-lists (((:method-search-result (:name "abc" :local-name "a" :decl-as (:method nil) :pos (:line-source-position (:file "$abd" :line 10)) :owner-name "ownerStr")) (:type-search-result (:name "abc" :local-name "a" :decl-as (:trait nil) :pos (:line-source-position (:file "$abd" :line 10))))))))"""
     )
 
     roundtrip(
       methodSearchRes: SymbolSearchResult,
-      s"""(:MethodSearchResult (:name "abc" :local-name "a" :decl-as (:Method nil) :pos (:LineSourcePosition (:file "$abd" :line 10)) :owner-name "ownerStr"))"""
+      s"""(:method-search-result (:name "abc" :local-name "a" :decl-as (:method nil) :pos (:line-source-position (:file "$abd" :line 10)) :owner-name "ownerStr"))"""
     )
 
     roundtrip(
       typeSearchRes: SymbolSearchResult,
-      s"""(:TypeSearchResult (:name "abc" :local-name "a" :decl-as (:Trait nil) :pos (:LineSourcePosition (:file "$abd" :line 10))))"""
+      s"""(:type-search-result (:name "abc" :local-name "a" :decl-as (:trait nil) :pos (:line-source-position (:file "$abd" :line 10))))"""
     )
   }
 
   it should "roundtrip ranges and semantic highlighting" in {
     roundtrip(
       ERangePositions(ERangePosition(batchSourceFile, 75, 70, 90) :: Nil),
-      """(:ERangePositions (:positions ((:file "/abc" :offset 75 :start 70 :end 90))))"""
+      """(:e-range-positions (:positions ((:file "/abc" :offset 75 :start 70 :end 90))))"""
     )
 
     roundtrip(
       FileRange("/abc", 7, 9): FileRange,
-      """(:FileRange (:file "/abc" :start 7 :end 9))"""
+      """(:file-range (:file "/abc" :start 7 :end 9))"""
     )
 
     roundtrip(
@@ -592,29 +592,29 @@ class SwankyFormatsSpec extends EnsimeSpec with EnsimeTestData {
         SymbolDesignation(11, 22, ClassSymbol)
       )
       ): SymbolDesignations,
-      s"""(:SymbolDesignations (:file "$symFile" :syms ((:start 7 :end 9 :sym-type (:VarFieldSymbol nil)) (:start 11 :end 22 :sym-type (:ClassSymbol nil)))))"""
+      s"""(:symbol-designations (:file "$symFile" :syms ((:start 7 :end 9 :sym-type (:var-field-symbol nil)) (:start 11 :end 22 :sym-type (:class-symbol nil)))))"""
     )
 
     roundtrip(
       ImplicitInfos(List(ImplicitConversionInfo(5, 6, symbolInfo))): ImplicitInfos,
-      """(:ImplicitInfos (:infos ((:ImplicitConversionInfo (:start 5 :end 6 :fun (:name "name" :local-name "localName" :type (:BasicTypeInfo (:name "type1" :decl-as (:Method nil) :full-name "FOO.type1"))))))))"""
+      """(:implicit-infos (:infos ((:implicit-conversion-info (:start 5 :end 6 :fun (:name "name" :local-name "localName" :type (:basic-type-info (:name "type1" :decl-as (:method nil) :full-name "FOO.type1"))))))))"""
     )
 
     roundtrip(
       ImplicitInfos(List(ImplicitParamInfo(5, 6, symbolInfo, List(symbolInfo, symbolInfo), true))): ImplicitInfos,
-      s"""(:ImplicitInfos (:infos ((:ImplicitParamInfo (:start 5 :end 6 :fun (:name "name" :local-name "localName" :type (:BasicTypeInfo (:name "type1" :decl-as (:Method nil) :full-name "FOO.type1"))) :params ((:name "name" :local-name "localName" :type (:BasicTypeInfo (:name "type1" :decl-as (:Method nil) :full-name "FOO.type1"))) (:name "name" :local-name "localName" :type (:BasicTypeInfo (:name "type1" :decl-as (:Method nil) :full-name "FOO.type1")))) :fun-is-implicit t)))))"""
+      s"""(:implicit-infos (:infos ((:implicit-param-info (:start 5 :end 6 :fun (:name "name" :local-name "localName" :type (:basic-type-info (:name "type1" :decl-as (:method nil) :full-name "FOO.type1"))) :params ((:name "name" :local-name "localName" :type (:basic-type-info (:name "type1" :decl-as (:method nil) :full-name "FOO.type1"))) (:name "name" :local-name "localName" :type (:basic-type-info (:name "type1" :decl-as (:method nil) :full-name "FOO.type1")))) :fun-is-implicit t)))))"""
     )
   }
 
   it should "roundtrip refactoring messages" in {
     roundtrip(
       RefactorFailure(7, "message"): RefactorFailure,
-      """(:RefactorFailure (:procedure-id 7 :reason "message" :status failure))"""
+      """(:refactor-failure (:procedure-id 7 :reason "message" :status failure))"""
     )
 
     roundtrip(
       refactorDiffEffect: RefactorDiffEffect,
-      s"""(:RefactorDiffEffect (:procedure-id 9 :refactor-type (:AddImport nil) :diff "$file2"))"""
+      s"""(:refactor-diff-effect (:procedure-id 9 :refactor-type (:add-import nil) :diff "$file2"))"""
     )
 
   }
@@ -622,22 +622,22 @@ class SwankyFormatsSpec extends EnsimeSpec with EnsimeTestData {
   it should "roundtrip legacy raw response types" in {
     roundtrip(
       FalseResponse,
-      "(:FalseResponse nil)"
+      "(:false-response nil)"
     )
 
     roundtrip(
       TrueResponse,
-      "(:TrueResponse nil)"
+      "(:true-response nil)"
     )
 
     roundtrip(
       StringResponse("wibble"),
-      """(:StringResponse (:text "wibble"))"""
+      """(:string-response (:text "wibble"))"""
     )
 
     roundtrip(
       VoidResponse,
-      """(:VoidResponse nil)"""
+      """(:void-response nil)"""
     )
 
   }

--- a/s-express/src/test/scala/org/ensime/sexp/formats/FamilyFormatsSpec.scala
+++ b/s-express/src/test/scala/org/ensime/sexp/formats/FamilyFormatsSpec.scala
@@ -157,9 +157,9 @@ package test {
 
     it should "support simple sealed families" in {
       roundtrip(Foo("foo"): SimpleTrait, """(:Foo (:s "foo"))""")
-      roundtrip(Bar(): SimpleTrait, """(:Bar nil)""")
-      roundtrip(Baz: SimpleTrait, """(:Baz nil)""")
-      roundtrip(Fuzz: SimpleTrait, """(:Fuzz nil)""")
+      roundtrip(Bar(): SimpleTrait, """:Bar""")
+      roundtrip(Baz: SimpleTrait, """:Baz""")
+      roundtrip(Fuzz: SimpleTrait, """:Fuzz""")
     }
 
     it should "fail when missing required coproduct disambiguators" in {
@@ -241,7 +241,7 @@ package test {
     it should "support an example ADT" in {
       import ExampleAst._
 
-      roundtrip(SpecialToken: TokenTree, """(:SpecialToken nil)""")
+      roundtrip(SpecialToken: TokenTree, """:SpecialToken""")
 
       val fieldTerm = FieldTerm("thing is ten", DatabaseField("THING"), "10")
       roundtrip(


### PR DESCRIPTION
some cleanups to the API.

A few outstanding thoughts:

- should we prefix all type hints with `ensime-` or `ensime-api-` ? It's really easy, and consistent on the emacs side, but it's really ugly.
- ~~the format for `case object`s is a bit ugly, like `(:Foo nil)` instead of `:Foo`. Changing it is a bit involved.~~ turned out to be easy, pushing a commit.