### PR TITLE
OrientDB schema change

### DIFF
--- a/core/src/it/scala/org/ensime/indexer/SearchServiceSpec.scala
+++ b/core/src/it/scala/org/ensime/indexer/SearchServiceSpec.scala
@@ -5,6 +5,7 @@ package org.ensime.indexer
 import scala.concurrent._
 import scala.concurrent.duration._
 import org.ensime.fixture._
+import org.ensime.indexer.graph.{ ClassDef, ClassHierarchy, HierarchyType }
 import org.ensime.util.EnsimeSpec
 import org.ensime.util.file._
 import org.scalatest.Matchers._
@@ -205,6 +206,43 @@ class SearchServiceSpec extends EnsimeSpec
 
   "exact searches" should "find type aliases" in withSearchService { implicit service =>
     service.findUnique("org.scalatest.fixture.ConfigMapFixture$FixtureParam") shouldBe defined
+  }
+
+  "class hierarchy viewer" should "find all classes implementing a trait" in withSearchService { implicit service =>
+    val someTrait = "org.hierarchy.SomeTrait"
+    val implementingClasses = service.getClassHierarchy(someTrait, HierarchyType.Subclasses)
+    implementingClasses shouldBe defined
+    inside(implementingClasses.get) {
+      case ClassHierarchy(classDef, refs) =>
+        classDef.fqn should ===(someTrait)
+        inside(refs) {
+          case Seq(ref1, ref2) =>
+            inside(ref1) {
+              case ClassHierarchy(aClass, Seq(subclass)) =>
+                aClass.fqn should ===("org.hierarchy.ExtendsTrait")
+                inside(subclass) {
+                  case cdef: ClassDef => cdef.fqn should ===("org.hierarchy.Subclass")
+                }
+            }
+            inside(ref2) {
+              case cdef: ClassDef => cdef.fqn should ===("org.hierarchy.ExtendsTraitToo")
+            }
+        }
+    }
+  }
+
+  it should "find all superclasses of a class" in withSearchService { implicit service =>
+    val hierarchy = service.getClassHierarchy("org.hierarchy.Qux", HierarchyType.Superclasses)
+    hierarchy shouldBe defined
+    hierarchy.get.toSet.map(_.fqn) should contain theSameElementsAs Set(
+      "org.hierarchy.Qux",
+      "scala.math.Ordered",
+      "org.hierarchy.Bar",
+      "org.hierarchy.NotBaz",
+      "java.lang.Runnable",
+      "java.lang.Comparable",
+      "java.lang.Object"
+    )
   }
 }
 

--- a/core/src/it/scala/org/ensime/indexer/SearchServiceSpec.scala
+++ b/core/src/it/scala/org/ensime/indexer/SearchServiceSpec.scala
@@ -60,6 +60,7 @@ class SearchServiceSpec extends EnsimeSpec
 
       classfile.delete()
       refresh() shouldBe ((1, 0))
+      searchExpectEmpty("org.example.Foo")
     }
   }
 

--- a/core/src/it/scala/org/ensime/model/SourcePositionSpec.scala
+++ b/core/src/it/scala/org/ensime/model/SourcePositionSpec.scala
@@ -4,7 +4,7 @@ package org.ensime.model
 
 import org.ensime.api._
 import org.ensime.fixture._
-import org.ensime.indexer.graph.FqnSymbol
+import org.ensime.indexer.graph.ClassDef
 import org.ensime.util.EnsimeSpec
 import org.ensime.util.file._
 import org.ensime.vfs._
@@ -67,7 +67,7 @@ class SourcePositionSpec extends EnsimeSpec
 
   def lookup(uri: String, line: Option[Int] = None)(implicit config: EnsimeConfig) = {
     withVFS { implicit vfs: EnsimeVFS =>
-      val sym = FqnSymbol(None, "", "", "", None, Some(uri), line, Some(0))
+      val sym = ClassDef("", "", "", Some(uri), line)
       LineSourcePositionHelper.fromFqnSymbol(sym)
     }
   }

--- a/core/src/it/scala/org/ensime/model/SourcePositionSpec.scala
+++ b/core/src/it/scala/org/ensime/model/SourcePositionSpec.scala
@@ -4,6 +4,7 @@ package org.ensime.model
 
 import org.ensime.api._
 import org.ensime.fixture._
+import org.ensime.indexer.Default
 import org.ensime.indexer.graph.ClassDef
 import org.ensime.util.EnsimeSpec
 import org.ensime.util.file._
@@ -67,7 +68,7 @@ class SourcePositionSpec extends EnsimeSpec
 
   def lookup(uri: String, line: Option[Int] = None)(implicit config: EnsimeConfig) = {
     withVFS { implicit vfs: EnsimeVFS =>
-      val sym = ClassDef("", "", "", Some(uri), line)
+      val sym = ClassDef("", "", "", Some(uri), line, Default)
       LineSourcePositionHelper.fromFqnSymbol(sym)
     }
   }

--- a/core/src/main/scala/org/ensime/indexer/IndexService.scala
+++ b/core/src/main/scala/org/ensime/indexer/IndexService.scala
@@ -91,12 +91,14 @@ class IndexService(path: Path) {
     1 - .25f * nonTrailing$s
   }
 
-  def persist(check: FileCheck, symbols: List[FqnSymbol], commit: Boolean, boost: Boolean): Unit = {
+  def persist(check: FileCheck, symbols: List[RawSymbol], commit: Boolean, boost: Boolean): Unit = {
     val f = Some(check)
     val fqns: List[Document] = symbols.map {
-      case Method(fqn, _, _) => MethodIndex(fqn, f).toDocument
-      case Field(fqn, _, _, _) => FieldIndex(fqn, f).toDocument
-      case ClassDef(fqn, _, _, _, _) =>
+      case RawType(name, _) => FieldIndex(name, f).toDocument
+      case RawMethod(name, _, _, _) => MethodIndex(name.fqnString, f).toDocument
+      case RawField(name, _, _, _) => FieldIndex(name.fqnString, f).toDocument
+      case RawClassfile(name, _, _, _, _, _, _, _, _) =>
+        val fqn = name.fqnString
         val penalty = calculatePenalty(fqn)
         val document = ClassIndex(fqn, f).toDocument
         document.boostText("fqn", penalty)

--- a/core/src/main/scala/org/ensime/indexer/IndexService.scala
+++ b/core/src/main/scala/org/ensime/indexer/IndexService.scala
@@ -94,9 +94,9 @@ class IndexService(path: Path) {
   def persist(check: FileCheck, symbols: List[FqnSymbol], commit: Boolean, boost: Boolean): Unit = {
     val f = Some(check)
     val fqns: List[Document] = symbols.map {
-      case FqnSymbol(_, _, _, fqn, _, _, _, _) if fqn.contains("(") => MethodIndex(fqn, f).toDocument
-      case FqnSymbol(_, _, _, fqn, Some(_), _, _, _) => FieldIndex(fqn, f).toDocument
-      case FqnSymbol(_, _, _, fqn, _, _, _, _) =>
+      case Method(fqn, _, _) => MethodIndex(fqn, f).toDocument
+      case Field(fqn, _, _, _) => FieldIndex(fqn, f).toDocument
+      case ClassDef(fqn, _, _, _, _) =>
         val penalty = calculatePenalty(fqn)
         val document = ClassIndex(fqn, f).toDocument
         document.boostText("fqn", penalty)

--- a/core/src/main/scala/org/ensime/indexer/SearchService.scala
+++ b/core/src/main/scala/org/ensime/indexer/SearchService.scala
@@ -34,6 +34,7 @@ class SearchService(
 ) extends ClassfileIndexer
     with FileChangeListener
     with SLF4JLogging {
+  import SearchService._
 
   private[indexer] def isUserFile(file: FileName): Boolean = {
     (config.allTargets map (vfs.vfile)) exists (file isAncestor _.getName)
@@ -170,15 +171,15 @@ class SearchService(
 
   def refreshResolver(): Unit = resolver.update()
 
-  def persist(check: FileCheck, symbols: List[FqnSymbol], commitIndex: Boolean, boost: Boolean): Future[Int] = {
-    val iwork = Future { blocking { index.persist(check, symbols, commitIndex, boost) } }
+  def persist(check: FileCheck, symbols: List[(RawSymbol, SourceInfo)], commitIndex: Boolean, boost: Boolean): Future[Int] = {
+    val iwork = Future { blocking { index.persist(check, symbols.map(_._1), commitIndex, boost) } }
     val dwork = db.persist(check, symbols)
     iwork.flatMap { _ => dwork }
   }
 
   // this method leak semaphore on every call, which must be released
   // when the List[FqnSymbol] has been processed (even if it is empty)
-  def extractSymbolsFromClassOrJar(file: FileObject): Future[List[FqnSymbol]] = {
+  def extractSymbolsFromClassOrJar(file: FileObject): Future[List[(RawSymbol, SourceInfo)]] = {
     def global: ExecutionContext = null // detach the global implicit
     val ec = actorSystem.dispatchers.lookup("akka.search-service-dispatcher")
 
@@ -206,7 +207,7 @@ class SearchService(
   private val blacklist = Set("sun/", "sunw/", "com/sun/")
   private val ignore = Set("$$", "$worker$")
   import org.ensime.util.RichFileObject._
-  private def extractSymbols(container: FileObject, f: FileObject): List[FqnSymbol] = {
+  private def extractSymbols(container: FileObject, f: FileObject): List[(RawSymbol, SourceInfo)] = {
     f.pathWithinArchive match {
       case Some(relative) if blacklist.exists(relative.startsWith) => Nil
       case _ =>
@@ -219,22 +220,26 @@ class SearchService(
         val source = resolver.resolve(clazz.name.pack, clazz.source)
         val sourceUri = source.map(_.getName.getURI)
 
+        val sourceFileInfo = (name, path, sourceUri)
         if (clazz.access != Public) Nil
         else {
-          ClassDef(clazz.name.fqnString, name, path, sourceUri, clazz.source.line) ::
-            clazz.methods.toList.filter(_.access == Public).map { method =>
-              Method(method.name.fqnString, method.line, sourceUri)
-            } ::: clazz.fields.toList.filter(_.access == Public).map { field =>
-              val internal = field.clazz.internalString
-              Field(field.name.fqnString, Some(internal), clazz.source.line, sourceUri)
-            } ::: depickler.getTypeAliases.toList.filter(_.access == Public).filterNot(_.fqn.contains("<refinement>")).map { rawType =>
-              // this is a hack, we shouldn't be storing Scala names in the JVM name space
-              // in particular, it creates fqn names that clash with the above ones
-              Field(rawType.fqn, None, None, sourceUri)
-            }
+          (clazz :: clazz.methods.toList ::: clazz.fields.toList ::: depickler.getTypeAliases.toList).map(_ -> sourceFileInfo)
         }
+      //        else {
+      //          ClassDef(clazz.name.fqnString, name, path, sourceUri, clazz.source.line) ::
+      //            clazz.methods.toList.filter(_.access == Public).map { method =>
+      //              Method(method.name.fqnString, method.line, sourceUri)
+      //            } ::: clazz.fields.toList.filter(_.access == Public).map { field =>
+      //              val internal = field.clazz.internalString
+      //              Field(field.name.fqnString, Some(internal), clazz.source.line, sourceUri)
+      //            } ::: depickler.getTypeAliases.toList.filter(_.access == Public).filterNot(_.fqn.contains("<refinement>")).map { rawType =>
+      //               this is a hack, we shouldn't be storing Scala names in the JVM name space
+      //               in particular, it creates fqn names that clash with the above ones
+      //              Field(rawType.fqn, None, None, sourceUri)
+      //            }
+      //        }
     }
-  }.filterNot(sym => ignore.exists(sym.fqn.contains))
+  }.filterNot(sym => ignore.exists(sym._1.fqn.contains))
 
   /** free-form search for classes */
   def searchClasses(query: String, max: Int): List[FqnSymbol] = {
@@ -250,6 +255,8 @@ class SearchService(
 
   /** only for exact fqns */
   def findUnique(fqn: String): Option[FqnSymbol] = Await.result(db.find(fqn), QUERY_TIMEOUT)
+
+  def getClassHierarchy(fqn: String, hierarchyType: HierarchyType): Option[Hierarchy] = Await.result(db.getClassHierarchy(fqn, hierarchyType), QUERY_TIMEOUT)
 
   /* DELETE then INSERT in H2 is ridiculously slow, so we put all modifications
    * into a blocking queue and dedicate a thread to block on draining the queue.
@@ -287,6 +294,10 @@ class SearchService(
   def shutdown(): Future[Unit] = {
     db.shutdown()
   }
+}
+
+object SearchService {
+  type SourceInfo = (String, String, Option[String])
 }
 
 final case class IndexFile(f: FileObject)

--- a/core/src/main/scala/org/ensime/indexer/SearchService.scala
+++ b/core/src/main/scala/org/ensime/indexer/SearchService.scala
@@ -225,19 +225,6 @@ class SearchService(
         else {
           (clazz :: clazz.methods.toList ::: clazz.fields.toList ::: depickler.getTypeAliases.toList).map(_ -> sourceFileInfo)
         }
-      //        else {
-      //          ClassDef(clazz.name.fqnString, name, path, sourceUri, clazz.source.line) ::
-      //            clazz.methods.toList.filter(_.access == Public).map { method =>
-      //              Method(method.name.fqnString, method.line, sourceUri)
-      //            } ::: clazz.fields.toList.filter(_.access == Public).map { field =>
-      //              val internal = field.clazz.internalString
-      //              Field(field.name.fqnString, Some(internal), clazz.source.line, sourceUri)
-      //            } ::: depickler.getTypeAliases.toList.filter(_.access == Public).filterNot(_.fqn.contains("<refinement>")).map { rawType =>
-      //               this is a hack, we shouldn't be storing Scala names in the JVM name space
-      //               in particular, it creates fqn names that clash with the above ones
-      //              Field(rawType.fqn, None, None, sourceUri)
-      //            }
-      //        }
     }
   }.filterNot(sym => ignore.exists(sym._1.fqn.contains))
 

--- a/core/src/main/scala/org/ensime/indexer/SearchService.scala
+++ b/core/src/main/scala/org/ensime/indexer/SearchService.scala
@@ -221,16 +221,16 @@ class SearchService(
 
         if (clazz.access != Public) Nil
         else {
-          FqnSymbol(None, name, path, clazz.name.fqnString, None, sourceUri, clazz.source.line) ::
+          ClassDef(clazz.name.fqnString, name, path, sourceUri, clazz.source.line) ::
             clazz.methods.toList.filter(_.access == Public).map { method =>
-              FqnSymbol(None, name, path, method.name.fqnString, None, sourceUri, method.line)
+              Method(method.name.fqnString, method.line, sourceUri)
             } ::: clazz.fields.toList.filter(_.access == Public).map { field =>
               val internal = field.clazz.internalString
-              FqnSymbol(None, name, path, field.name.fqnString, Some(internal), sourceUri, clazz.source.line)
+              Field(field.name.fqnString, Some(internal), clazz.source.line, sourceUri)
             } ::: depickler.getTypeAliases.toList.filter(_.access == Public).filterNot(_.fqn.contains("<refinement>")).map { rawType =>
               // this is a hack, we shouldn't be storing Scala names in the JVM name space
               // in particular, it creates fqn names that clash with the above ones
-              FqnSymbol(None, name, path, rawType.fqn, None, sourceUri, None)
+              Field(rawType.fqn, None, None, sourceUri)
             }
         }
     }

--- a/core/src/main/scala/org/ensime/indexer/domain.scala
+++ b/core/src/main/scala/org/ensime/indexer/domain.scala
@@ -195,17 +195,23 @@ final case class Descriptor(params: List[DescriptorType], ret: DescriptorType) {
     "(" + params.map(_.internalString).mkString("") + ")" + ret.internalString
 }
 
+sealed trait RawSymbol {
+  def fqn: String
+}
+
 final case class RawClassfile(
-  name: ClassName,
-  generics: Option[GenericClass],
-  superClass: Option[ClassName],
-  interfaces: List[ClassName],
-  access: Access,
-  deprecated: Boolean,
-  fields: Queue[RawField],
-  methods: Queue[RawMethod],
-  source: RawSource
-)
+    name: ClassName,
+    generics: Option[GenericClass],
+    superClass: Option[ClassName],
+    interfaces: List[ClassName],
+    access: Access,
+    deprecated: Boolean,
+    fields: Queue[RawField],
+    methods: Queue[RawMethod],
+    source: RawSource
+) extends RawSymbol {
+  override def fqn: String = name.fqnString
+}
 
 final case class RawSource(
   filename: Option[String],
@@ -215,21 +221,25 @@ final case class RawSource(
 final case class RawType(
   fqn: String,
   access: Access
-)
+) extends RawSymbol
 
 final case class RawField(
-  name: FieldName,
-  clazz: DescriptorType,
-  generics: Option[String],
-  access: Access
-)
+    name: FieldName,
+    clazz: DescriptorType,
+    generics: Option[String],
+    access: Access
+) extends RawSymbol {
+  override def fqn: String = name.fqnString
+}
 
 final case class RawMethod(
-  name: MethodName,
-  access: Access,
-  generics: Option[String],
-  line: Option[Int]
-)
+    name: MethodName,
+    access: Access,
+    generics: Option[String],
+    line: Option[Int]
+) extends RawSymbol {
+  override def fqn: String = name.fqnString
+}
 
 final case class RawScalaClass(
   javaName: ClassName,

--- a/core/src/main/scala/org/ensime/model/ModelBuilders.scala
+++ b/core/src/main/scala/org/ensime/model/ModelBuilders.scala
@@ -321,9 +321,9 @@ object LineSourcePositionHelper {
     }
 
   def fromFqnSymbol(sym: FqnSymbol)(implicit config: EnsimeConfig, vfs: EnsimeVFS): Option[LineSourcePosition] =
-    (sym.sourceFileObject, sym.line, sym.offset) match {
-      case (None, _, _) => None
-      case (Some(fo), lineOpt, offsetOpt) =>
+    (sym.sourceFileObject, sym.line) match {
+      case (None, _) => None
+      case (Some(fo), lineOpt) =>
         val f = possiblyExtractFile(fo)
         Some(new LineSourcePosition(f, lineOpt.getOrElse(0)))
     }

--- a/project/SensibleSettings.scala
+++ b/project/SensibleSettings.scala
@@ -51,7 +51,7 @@ object Sensible {
     javaOptions += "-Dfile.encoding=UTF8",
     //this is needed by OrientDB versions 2.2.0+, 512g is recommended on their github wiki
     //https://github.com/orientechnologies/orientdb-docs/blob/master/Release-2.2.0.md
-    javaOptions += "-XX:MaxDirectMemorySize=512g",
+    javaOptions += "-XX:MaxDirectMemorySize=4g",
     javaOptions ++= Seq("-XX:+UseConcMarkSweepGC", "-XX:+CMSIncrementalMode"),
     javaOptions in run ++= yourkitAgent, // interferes with sockets
 

--- a/testing/simple/src/main/scala/org/hierarchy/Bar.scala
+++ b/testing/simple/src/main/scala/org/hierarchy/Bar.scala
@@ -1,0 +1,18 @@
+package org.hierarchy
+
+trait Bar
+
+class Foo extends Bar
+
+trait NotBaz extends Runnable
+
+abstract class Qux extends Ordered[Foo] with NotBaz with Bar
+
+trait SomeTrait
+
+class ExtendsTrait extends SomeTrait
+
+class Subclass extends ExtendsTrait
+
+class ExtendsTraitToo extends SomeTrait
+


### PR DESCRIPTION
A couple of OrientDB convenience methods, some typesafe wrappers here and there, `BigDataFormat` for coproducts, basic support for viewing type hierarchies via `searchService.getClassHierarchy(someTrait, HierarchyType.Subclasses)`.