### PR TITLE
Switch from BuildTime to build date

### DIFF
--- a/project/EnsimeBuild.scala
+++ b/project/EnsimeBuild.scala
@@ -163,8 +163,14 @@ object EnsimeBuild extends Build {
     ) enablePlugins BuildInfoPlugin settings (
         buildInfoPackage := organization.value,
         buildInfoKeys += BuildInfoKey.action("gitSha")(Try("git rev-parse --verify HEAD".!! dropRight 1) getOrElse "n/a"),
-        buildInfoOptions += BuildInfoOption.BuildTime
+        buildInfoKeys += BuildInfoKey.action("builtAtString")(currentDateString())
       )
+
+  private def currentDateString() = {
+    val dtf = new java.text.SimpleDateFormat("yyyy-MM-dd")
+    dtf.setTimeZone(java.util.TimeZone.getTimeZone("UTC"))
+    dtf.format(new java.util.Date())
+  }
 
   val luceneVersion = "5.5.1"
   val streamsVersion = "2.0.4"


### PR DESCRIPTION
This makes continuous compilation faster, because it doesn't keep
compiling the BuildInfo object with the updated build timestamp.

It redefines "builtAtString" format to "yyyy-MM-dd", where it was
previously "yyyy-MM-dd HH:mm:ss.SSS"; and it also drops "builtAtMillis".