### PR TITLE
Resolve source in non-standard locations

### DIFF
--- a/core/src/it/scala/org/ensime/indexer/SourceResolverSpec.scala
+++ b/core/src/it/scala/org/ensime/indexer/SourceResolverSpec.scala
@@ -38,6 +38,14 @@ class SourceResolverSpec extends EnsimeSpec
     find("org.example", "bad-convention.scala") shouldBe
       Some((scalaMain / "bad-convention.scala").getAbsolutePath)
   }
+
+  it should "resolve sources in the child directories in the project" in withSourceResolver { (c, r) =>
+    implicit val config = c
+    implicit val resolver = r
+    find("org.util.set", "badconvention.scala") shouldBe
+      Some((scalaMain / "util/badconvention.scala").getAbsolutePath)
+  }
+
 }
 
 trait SourceResolverTestUtils {

--- a/testing/simple/src/main/scala/util/badconvention.scala
+++ b/testing/simple/src/main/scala/util/badconvention.scala
@@ -1,0 +1,2 @@
+// this file exists for the SourceResolverSpec
+package org.util.set


### PR DESCRIPTION
This helps with resolving source files in projects which don't follow java notation of putting classes/objects/traits to the file structure matching package name.

[ReactiveMongo](https://github.com/ReactiveMongo/ReactiveMongo) is example of a such broken project. For example class [Authenticate](https://github.com/ReactiveMongo/ReactiveMongo/blob/0b168dc2ec27373cad88ace842de17a0488d72f8/driver/src/main/scala/core/nodeset.scala#L478) would get resolved correctly.