### PR TITLE
fix the exception related to completion with an empty context

### DIFF
--- a/core/src/it/scala/org/ensime/core/RichPresentationCompilerSpec.scala
+++ b/core/src/it/scala/org/ensime/core/RichPresentationCompilerSpec.scala
@@ -449,6 +449,14 @@ class RichPresentationCompilerSpec extends EnsimeSpec
     ).
       foreach(test(_, cc))
   }
+
+  ignore should "not fail when completion is requested inside an empty object" in withPosInCompiledSource(
+    // An exception can occur in the compiler thread. Check that there is no exception in logs.
+    "package com.example",
+    "object A { @@ }"
+  ) { (p, cc) =>
+      cc.completionsAt(p, 10, caseSens = false)
+    }
 }
 
 trait RichPresentationCompilerTestUtils {

--- a/core/src/main/scala/org/ensime/core/Completion.scala
+++ b/core/src/main/scala/org/ensime/core/Completion.scala
@@ -250,7 +250,15 @@ trait CompletionControl {
           case m @ ScopeMember(sym, tpe, accessible, viaView) =>
             val p = sym.pos
             val inSymbol = p.isRange && (context.offset >= p.startOrCursor && context.offset <= p.endOrCursor)
-            if (!sym.isConstructor && !inSymbol) {
+
+            val isBrokenType = tpe match {
+              // ByNameParamClass without args is the invalid object. PC generates it when there is no
+              // completion context. See the ignored test in RichPresentationCompilerSpec.
+              case TypeRef(_, definitions.ByNameParamClass, Nil) => true
+              case _ => false
+            }
+
+            if (!sym.isConstructor && !inSymbol & !isBrokenType) {
               buff ++= toCompletionInfo(context, sym, tpe, inherited = false, NoSymbol)
             }
           case m @ TypeMember(sym, tpe, accessible, inherited, viaView) =>


### PR DESCRIPTION
Steps to reproduce:
1. Place the cursor here: object A { | }.
2. Ask for completion.
3. See an error "head of empty list" inside the ENSIME log.