### PR TITLE
Migrate away from the Build trait. Fixes #1568

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,0 +1,23 @@
+lazy val monkeys = EnsimeBuild.monkeys
+lazy val util = EnsimeBuild.util
+lazy val testutil = EnsimeBuild.testutil
+lazy val s_express = EnsimeBuild.s_express
+lazy val api = EnsimeBuild.api
+lazy val jerky = EnsimeBuild.jerky
+lazy val swanky = EnsimeBuild.swanky
+lazy val core = EnsimeBuild.core
+lazy val server = EnsimeBuild.server
+
+lazy val testingEmpty = EnsimeBuild.testingEmpty
+lazy val testingSimple = EnsimeBuild.testingSimple
+lazy val testingSimpleJar = EnsimeBuild.testingSimpleJar
+lazy val testingImplicits = EnsimeBuild.testingImplicits
+lazy val testingTiming = EnsimeBuild.testingTiming
+lazy val testingMacros = EnsimeBuild.testingMacros
+lazy val testingShapeless = EnsimeBuild.testingShapeless
+lazy val testingFqns = EnsimeBuild.testingFqns
+lazy val testingDebug = EnsimeBuild.testingDebug
+lazy val testingDocs = EnsimeBuild.testingDocs
+lazy val testingJava = EnsimeBuild.testingJava
+
+lazy val root = EnsimeBuild.root

--- a/project/EnsimeBuild.scala
+++ b/project/EnsimeBuild.scala
@@ -12,13 +12,18 @@ import org.ensime.EnsimePlugin.JdkDir
 import sbtbuildinfo.BuildInfoPlugin, BuildInfoPlugin.autoImport._
 import de.heikoseeberger.sbtheader.{ HeaderKey, HeaderPlugin }
 
-object EnsimeBuild extends Build {
-  lazy override val settings = super.settings ++ Seq(
+object ProjectPlugin extends AutoPlugin {
+  override def requires = plugins.JvmPlugin
+  override def trigger = allRequirements
+
+  override def projectSettings = Seq(
     scalaVersion := "2.11.8",
     organization := "org.ensime",
     version := "2.0.0-SNAPSHOT"
   )
+}
 
+object EnsimeBuild {
   lazy val commonSettings = Sensible.settings ++ Seq(
     libraryDependencies ++= Sensible.testLibs() ++ Sensible.logback,
 


### PR DESCRIPTION
This way preserves most code in the EnsimeBuild.scala file, which I'm guessing you'll probably prefer.