### PR TITLE
[WIP] Persist reverse lookups

### DIFF
--- a/core/src/it/scala-2.11/org/ensime/core/TypelevelLibrariesSymbolToFqnSpec.scala
+++ b/core/src/it/scala-2.11/org/ensime/core/TypelevelLibrariesSymbolToFqnSpec.scala
@@ -41,9 +41,11 @@ class TypelevelLibrariesSymbolToFqnSpec extends EnsimeSpec
         scalaClass.fields.valuesIterator.foreach { field =>
           verify(field.javaName, field.scalaName, DeclaredAs.Field, cc)
         }
-        scalaClass.methods.foreach { method =>
-          val methodSym = cc.askSymbolByScalaName(method.scalaName, Some(DeclaredAs.Method)).get
-          methodSym shouldBe a[cc.TermSymbol]
+        scalaClass.methods.valuesIterator.foreach { methods =>
+          methods.foreach { method =>
+            val methodSym = cc.askSymbolByScalaName(method.scalaName, Some(DeclaredAs.Method)).get
+            methodSym shouldBe a[cc.TermSymbol]
+          }
         }
       }
     }

--- a/core/src/it/scala/org/ensime/indexer/SearchServiceSpec.scala
+++ b/core/src/it/scala/org/ensime/indexer/SearchServiceSpec.scala
@@ -296,12 +296,13 @@ class SearchServiceSpec extends EnsimeSpec
 
   it should "find usages of a regular class" in withSearchService { implicit service =>
     val usages = findUsages("org.reverselookups.MyException")
-    usages.length should ===(5)
+    usages.length should ===(6)
     usages.map(_.toSearchResult) should contain theSameElementsAs List(
       "Method org.reverselookups.MyException#<init>(): org.reverselookups.MyException",
       "Method org.reverselookups.ReverseLookups#throws(): scala.Unit",
       "Method org.reverselookups.ReverseLookups#catches(): scala.Int",
       "Method org.reverselookups.Overloads#foo[T <: org.reverselookups.MyException](t: T): scala.Unit",
+      "Method org.reverselookups.Extends#<init>(): org.reverselookups.Extends",
       "Class org.reverselookups.Extends"
     )
   }

--- a/core/src/it/scala/org/ensime/indexer/SearchServiceSpec.scala
+++ b/core/src/it/scala/org/ensime/indexer/SearchServiceSpec.scala
@@ -2,6 +2,8 @@
 // License: http://www.gnu.org/licenses/gpl-3.0.en.html
 package org.ensime.indexer
 
+import org.ensime.api.DeclaredAs
+
 import scala.concurrent._
 import scala.concurrent.duration._
 import org.ensime.fixture._
@@ -266,6 +268,74 @@ class SearchServiceSpec extends EnsimeSpec
       "java.lang.Object"
     )
   }
+
+  "reverse usage lookup" should "find usages of an annotation class" in withSearchService { implicit service =>
+    val usages = findUsages("org.reverselookups.MyAnnotation")
+    usages.length should ===(18)
+    usages.map(_.toSearchResult) should contain theSameElementsAs List(
+      "Field org.reverselookups.ReverseLookups#fieldType",
+      "Method org.reverselookups.ReverseLookups#fieldType: org.reverselookups.MyAnnotation",
+      "Field org.reverselookups.ReverseLookups#annotatedField",
+      "Field org.reverselookups.ReverseLookups.staticField",
+      "Method org.reverselookups.ReverseLookups.staticField: org.reverselookups.MyAnnotation",
+      "Method org.reverselookups.ReverseLookups.staticField()Lorg/reverselookups/MyAnnotation;", // synthetic method for class ReverseLookups
+      "Method org.reverselookups.ReverseLookups#annotatedMethod(): scala.Unit",
+      "Method org.reverselookups.ReverseLookups.<init>(): org.reverselookups.ReverseLookups",
+      "Method org.reverselookups.ReverseLookups#<init>(i: scala.Int): org.reverselookups.ReverseLookups",
+      "Method org.reverselookups.ReverseLookups#usesInBody(): scala.Unit",
+      "Method org.reverselookups.ReverseLookups#takesAsParam(ann: org.reverselookups.MyAnnotation): scala.Unit",
+      "Method org.reverselookups.ReverseLookups#polyMethod[A <: org.reverselookups.MyAnnotation](a: A): scala.Unit",
+      "Method org.reverselookups.ReverseLookups#returns(i: scala.Int): org.reverselookups.MyAnnotation",
+      "Method org.reverselookups.Overloads#foo(ann: org.reverselookups.MyAnnotation): scala.Unit",
+      "Method org.reverselookups.Overloads.<init>(): org.reverselookups.Overloads",
+      "Class org.reverselookups.ReverseLookups",
+      "Object org.reverselookups.ReverseLookups",
+      "Method org.reverselookups.ReverseLookups#methodUsage: scala.Unit"
+    )
+  }
+
+  it should "find usages of a regular class" in withSearchService { implicit service =>
+    val usages = findUsages("org.reverselookups.MyException")
+    usages.length should ===(5)
+    usages.map(_.toSearchResult) should contain theSameElementsAs List(
+      "Method org.reverselookups.MyException#<init>(): org.reverselookups.MyException",
+      "Method org.reverselookups.ReverseLookups#throws(): scala.Unit",
+      "Method org.reverselookups.ReverseLookups#catches(): scala.Int",
+      "Method org.reverselookups.Overloads#foo[T <: org.reverselookups.MyException](t: T): scala.Unit",
+      "Class org.reverselookups.Extends"
+    )
+  }
+
+  it should "find usages of a field/method" in withSearchService { implicit service =>
+    val fieldUsages = findUsages("org.reverselookups.ReverseLookups.intField()I")
+    fieldUsages.length should ===(3)
+    fieldUsages.map(_.toSearchResult) should contain theSameElementsAs List(
+      "Method org.reverselookups.ReverseLookups#returns$default$1: scala.Int", // field used as default arg
+      "Method org.reverselookups.ReverseLookups#takesAsParam(ann: org.reverselookups.MyAnnotation): scala.Unit", // field used in method body
+      "Method org.reverselookups.SelfType#<init>(): org.reverselookups.SelfType"
+    )
+
+    val methodUsages = findUsages("org.reverselookups.ReverseLookups.catches()I")
+    methodUsages.length should ===(4)
+    methodUsages.map(_.toSearchResult) should contain theSameElementsAs List(
+      "Method org.reverselookups.Overloads#asDefaultArg$default$1: scala.Int",
+      "Method org.reverselookups.Overloads#<init>(l: scala.Long): org.reverselookups.Overloads",
+      "Method org.reverselookups.ReverseLookups#<init>(i: scala.Int): org.reverselookups.ReverseLookups",
+      "Method org.reverselookups.ReverseLookups#throws(): scala.Unit"
+    )
+  }
+
+  "scala names" should "be correctly resolved for overloaded methods" in withSearchService { implicit service =>
+    val hits = service.searchClassesMethods(List("Overloads", "foo"), 100).filter(hit => hit.declAs == DeclaredAs.Method && hit.fqn.contains("Overloads.foo"))
+    hits.length should ===(5)
+    hits.map(hit => hit.fqn -> hit.toSearchResult) should contain theSameElementsAs List(
+      ("org.reverselookups.Overloads.foo()V", "Method org.reverselookups.Overloads#foo(): scala.Unit"),
+      ("org.reverselookups.Overloads.foo(I)V", "Method org.reverselookups.Overloads#foo(i: scala.Int): scala.Unit"),
+      ("org.reverselookups.Overloads.foo(Ljava/lang/String;I)V", "Method org.reverselookups.Overloads#foo(s: scala.Predef.String, i: scala.Int): scala.Unit"),
+      ("org.reverselookups.Overloads.foo(Lorg/reverselookups/MyException;)V", "Method org.reverselookups.Overloads#foo[T <: org.reverselookups.MyException](t: T): scala.Unit"),
+      ("org.reverselookups.Overloads.foo(Lorg/reverselookups/MyAnnotation;)V", "Method org.reverselookups.Overloads#foo(ann: org.reverselookups.MyAnnotation): scala.Unit")
+    )
+  }
 }
 
 object SearchServiceTestUtils {
@@ -329,5 +399,5 @@ object SearchServiceTestUtils {
     case TypeHierarchy(cdef, typeRefs) => Set(cdef) ++ typeRefs.flatMap(hierarchyToSet)
   }
 
-  def findUsages(fqn: String)(implicit service: SearchService): Iterable[FqnSymbol] = Await.result(service.findUsages(fqn), Duration.Inf)
+  def findUsages(fqn: String)(implicit service: SearchService): List[FqnSymbol] = Await.result(service.findUsages(fqn), Duration.Inf).toList
 }

--- a/core/src/it/scala/org/ensime/indexer/SearchServiceSpec.scala
+++ b/core/src/it/scala/org/ensime/indexer/SearchServiceSpec.scala
@@ -229,7 +229,7 @@ class SearchServiceSpec extends EnsimeSpec
   }
 
   "exact searches" should "find type aliases" in withSearchService { implicit service =>
-    service.findUnique("org.scalatest.fixture.ConfigMapFixture.FixtureParam") shouldBe defined
+    service.findUnique("org.scalatest.fixture.ConfigMapFixture$FixtureParam") shouldBe defined
   }
 
   "class hierarchy viewer" should "find all classes implementing a trait" in withSearchService { implicit service =>
@@ -319,7 +319,7 @@ object SearchServiceTestUtils {
     (queries.toList).foreach(searchClassesAndMethods(expect, _))
 
   def getClassHierarchy(fqn: String, hierarchyType: Hierarchy.Direction)(implicit service: SearchService): Hierarchy = {
-    val hierarchy = Await.result(service.getClassHierarchy(fqn, hierarchyType), Duration.Inf)
+    val hierarchy = Await.result(service.getTypeHierarchy(fqn, hierarchyType), Duration.Inf)
     withClue(s"No class hierarchy found for fqn = $fqn")(hierarchy shouldBe defined)
     hierarchy.get
   }
@@ -328,4 +328,6 @@ object SearchServiceTestUtils {
     case cdef: ClassDef => Set(cdef)
     case TypeHierarchy(cdef, typeRefs) => Set(cdef) ++ typeRefs.flatMap(hierarchyToSet)
   }
+
+  def findUsages(fqn: String)(implicit service: SearchService): Iterable[FqnSymbol] = Await.result(service.findUsages(fqn), Duration.Inf)
 }

--- a/core/src/main/scala/org/ensime/core/ScalapSymbolToFqn.scala
+++ b/core/src/main/scala/org/ensime/core/ScalapSymbolToFqn.scala
@@ -33,7 +33,8 @@ trait ScalapSymbolToFqn {
     else Public
 
   def rawType(s: AliasSymbol, parentPrefix: String): RawType = {
-    val javaName = FieldName(className(s.symbolInfo.owner), s.name)
+    val parentName = className(s.symbolInfo.owner)
+    val javaName = ClassName(parentName.pack, parentName.name + "$" + s.name)
     val scalaName = parentPrefix + s.name
     val access = getAccess(s)
     val typeSignature = withScalaSigPrinter { printer =>
@@ -75,7 +76,7 @@ trait ScalapSymbolToFqn {
 
     val aliases: Map[String, RawType] = sym.children.collect {
       case as: AliasSymbol =>
-        val alias = rawType(as, parentPrefix)
+        val alias = rawType(as, scalaName)
         alias.javaName.fqnString -> alias
     }(breakOut)
 

--- a/core/src/main/scala/org/ensime/core/ScalapSymbolToFqn.scala
+++ b/core/src/main/scala/org/ensime/core/ScalapSymbolToFqn.scala
@@ -34,13 +34,14 @@ trait ScalapSymbolToFqn {
 
   def rawType(s: AliasSymbol, parentPrefix: String): RawType = {
     val parentName = className(s.symbolInfo.owner)
-    val javaName = ClassName(parentName.pack, parentName.name + "$" + s.name)
-    val scalaName = parentPrefix + s.name
+    val isParentModule = parentName.fqnString.endsWith("$")
+    val javaName = ClassName(parentName.pack, parentName.name + (if (isParentModule) "" else "$") + s.name)
+    val scalaName = parentPrefix + (if (isParentModule) "." else "#") + s.name
     val access = getAccess(s)
     val typeSignature = withScalaSigPrinter { printer =>
       printer.printType(s.infoType, " = ")(printer.TypeFlags(true))
     }
-    RawType(javaName, scalaName, access, typeSignature)
+    RawType(parentName, javaName, scalaName, access, typeSignature)
   }
 
   def rawScalaClass(sym: ClassSymbol): RawScalapClass = {
@@ -69,10 +70,10 @@ trait ScalapSymbolToFqn {
         field.javaName.fqnString -> field
     }(breakOut)
 
-    val methods: Vector[RawScalapMethod] = sym.children.collect {
-      case ms: MethodSymbol if ms.isMethod && !ms.name.contains("default") && !ms.name.contains("<init>") =>
+    val methods: Map[String, IndexedSeq[RawScalapMethod]] = sym.children.collect {
+      case ms: MethodSymbol if ms.isMethod =>
         rawScalaMethod(ms, parentPrefix)
-    }(breakOut)
+    }(collection.breakOut).groupBy(_.simpleName)
 
     val aliases: Map[String, RawType] = sym.children.collect {
       case as: AliasSymbol =>
@@ -103,7 +104,7 @@ trait ScalapSymbolToFqn {
 
   private def rawScalaField(ms: MethodSymbol, parentPrefix: String): RawScalapField = {
     val aClass = className(ms.symbolInfo.owner)
-    val name = ms.name
+    val name = ms.name.trim
     val javaName = FieldName(aClass, name)
     val scalaName = parentPrefix + name
     val access = getAccess(ms)
@@ -122,7 +123,7 @@ trait ScalapSymbolToFqn {
       printer.printMethodType(ms.infoType, printResult = true)(printer.TypeFlags(true))
     }
 
-    RawScalapMethod(scalaName, signature, access)
+    RawScalapMethod(ms.name, scalaName, signature, access)
   }
 
 }

--- a/core/src/main/scala/org/ensime/core/SymbolToFqn.scala
+++ b/core/src/main/scala/org/ensime/core/SymbolToFqn.scala
@@ -88,7 +88,6 @@ trait SymbolToFqn { self: Global with PresentationCompilerBackCompat =>
 
   def toFqn(sym: Symbol): FullyQualifiedName = sym match {
     case p if sym.hasPackageFlag => packageName(sym)
-    case ts: AliasTypeSymbol => fieldName(ts)
     case ts: TypeSymbol => normaliseClass(className(ts))
     case ms: ModuleSymbol => className(ms)
     case ms: MethodSymbol => methodName(ms)

--- a/core/src/main/scala/org/ensime/indexer/ClassfileIndexer.scala
+++ b/core/src/main/scala/org/ensime/indexer/ClassfileIndexer.scala
@@ -217,7 +217,9 @@ trait ClassfileIndexer {
     override def visitMethodInsn(
       opcode: Int, owner: String, name: String, desc: String, itf: Boolean
     ): Unit = {
-      addRef(MethodName(ClassName.fromInternal(owner), name, DescriptorParser.parse(desc)))
+      val ownerName = ClassName.fromInternal(owner)
+      addRef(ownerName)
+      addRef(MethodName(ownerName, name, DescriptorParser.parse(desc)))
       addRefs(classesInDescriptor(desc))
     }
 

--- a/core/src/main/scala/org/ensime/indexer/ClassfileIndexer.scala
+++ b/core/src/main/scala/org/ensime/indexer/ClassfileIndexer.scala
@@ -2,12 +2,11 @@
 // License: http://www.gnu.org/licenses/gpl-3.0.en.html
 package org.ensime.indexer
 
-import scala.collection.immutable.Queue
-
 import akka.event.slf4j.SLF4JLogging
 import org.apache.commons.vfs2.FileObject
 import org.objectweb.asm._
 import org.objectweb.asm.Opcodes._
+import scala.collection.immutable.Queue
 
 trait ClassfileIndexer {
   this: SLF4JLogging =>
@@ -16,7 +15,7 @@ trait ClassfileIndexer {
    * @param file to index
    * @return the parsed version of the classfile and FQNs referenced within
    */
-  def indexClassfile(file: FileObject): (RawClassfile, Set[FullyQualifiedName]) = {
+  def indexClassfile(file: FileObject): RawClassfile = {
     val name = file.getName
     require(file.exists(), s"$name does not exist")
     require(name.getBaseName.endsWith(".class"), s"$name is not a class file")
@@ -29,7 +28,7 @@ trait ClassfileIndexer {
       receiver
     } finally in.close()
 
-    (raw.clazz, raw.refs)
+    raw.clazz
   }
 
   // extracts all the classnames from a descriptor
@@ -56,15 +55,22 @@ trait ClassfileIndexer {
         None
       }
 
+      val interfaceNames: List[ClassName] = interfaces.map(ClassName.fromInternal)(collection.breakOut)
+      val superClass = Option(superName).map(ClassName.fromInternal)
+
+      internalRefs = internalRefs ++ interfaceNames
+      internalRefs = internalRefs ++ superClass.toList
+
       clazz = RawClassfile(
         ClassName.fromInternal(name),
         signatureClass,
-        Option(superName).map(ClassName.fromInternal),
-        interfaces.toList.map(ClassName.fromInternal),
+        superClass,
+        interfaceNames,
         Access(access),
         (ACC_DEPRECATED & access) > 0,
-        Nil, Nil, RawSource(None, None),
-        isScala = false
+        Nil, Queue.empty, RawSource(None, None),
+        isScala = false,
+        internalRefs
       )
     }
 
@@ -80,13 +86,19 @@ trait ClassfileIndexer {
     }
 
     override def visitField(access: Int, name: String, desc: String, signature: String, value: AnyRef): FieldVisitor = {
-      val field = RawField(
-        FieldName(clazz.name, name),
-        DescriptorParser.parseType(desc),
-        Option(signature), Access(access)
-      )
-      clazz = clazz.copy(fields = field :: clazz.fields)
       super.visitField(access, name, desc, signature, value)
+      new FieldVisitor(ASM5) with ReferenceInFieldHunter {
+        override def visitEnd(): Unit = {
+          internalRefs = internalRefs + ClassName.fromDescriptor(desc)
+          val field = RawField(
+            FieldName(clazz.name, name),
+            DescriptorParser.parseType(desc),
+            Option(signature), Access(access),
+            internalRefs
+          )
+          clazz = clazz.copy(fields = field :: clazz.fields)
+        }
+      }
     }
 
     override def visitMethod(access: Int, region: String, desc: String, signature: String, exceptions: Array[String]): MethodVisitor = {
@@ -95,13 +107,13 @@ trait ClassfileIndexer {
         var firstLine: Option[Int] = None
 
         override def visitLineNumber(line: Int, start: Label): Unit = {
-          val isEarliestLineSeen = firstLine.map(_ < line).getOrElse(true)
+          val isEarliestLineSeen = firstLine.forall(_ < line)
           if (isEarliestLineSeen)
             firstLine = Some(line)
+          currentLine = line
         }
 
         override def visitEnd(): Unit = {
-          addRefs(internalRefs)
           region match {
             case "<init>" | "<clinit>" =>
               (clazz.source.line, firstLine) match {
@@ -112,9 +124,20 @@ trait ClassfileIndexer {
               }
             case name if name.contains("default") =>
             case name =>
+              if (exceptions != null) {
+                addRefs(exceptions.map(ClassName.fromInternal))
+              }
+              addRefs(classesInDescriptor(desc))
               val descriptor = DescriptorParser.parse(desc)
-              val method = RawMethod(MethodName(clazz.name, name, descriptor), Access(access), Option(signature), firstLine, clazz.methods.size)
-              clazz = clazz.copy(methods = method :: clazz.methods)
+              val method = RawMethod(
+                MethodName(clazz.name, name, descriptor),
+                Access(access),
+                Option(signature),
+                firstLine,
+                clazz.methods.size,
+                internalRefs
+              )
+              clazz = clazz.copy(methods = clazz.methods enqueue method)
           }
         }
       }
@@ -127,40 +150,7 @@ trait ClassfileIndexer {
 
     def clazz: RawClassfile
 
-    // NOTE: only mutate via addRefs
-    var refs = Set.empty[FullyQualifiedName]
-
-    protected def addRefs(seen: Seq[FullyQualifiedName]): Unit = {
-      refs ++= seen.filterNot(_.contains(clazz.name))
-    }
-    protected def addRef(seen: FullyQualifiedName): Unit = addRefs(seen :: Nil)
-
-    private val fieldVisitor = new FieldVisitor(ASM5) {
-      override def visitAnnotation(desc: String, visible: Boolean) = handleAnn(desc)
-      override def visitTypeAnnotation(
-        typeRef: Int, typePath: TypePath, desc: String, visible: Boolean
-      ) = handleAnn(desc)
-    }
-
-    override def visitField(access: Int, name: String, desc: String, signature: String, value: AnyRef): FieldVisitor = {
-      addRef(ClassName.fromDescriptor(desc))
-      fieldVisitor
-    }
-
-    override def visitMethod(access: Int, region: String, desc: String, signature: String, exceptions: Array[String]): MethodVisitor = {
-      addRefs(classesInDescriptor(desc))
-      if (exceptions != null)
-        addRefs(exceptions.map(ClassName.fromInternal))
-      null
-    }
-
-    override def visitInnerClass(name: String, outerName: String, innerName: String, access: Int): Unit = {
-      addRef(ClassName.fromInternal(name))
-    }
-
-    override def visitOuterClass(owner: String, name: String, desc: String): Unit = {
-      addRef(ClassName.fromInternal(owner))
-    }
+    var internalRefs = Set.empty[FullyQualifiedName]
 
     private val annVisitor: AnnotationVisitor = new AnnotationVisitor(ASM5) {
       override def visitAnnotation(name: String, desc: String) = handleAnn(desc)
@@ -168,8 +158,9 @@ trait ClassfileIndexer {
         name: String, desc: String, value: String
       ): Unit = handleAnn(desc)
     }
+
     private def handleAnn(desc: String): AnnotationVisitor = {
-      addRef(ClassName.fromDescriptor(desc))
+      internalRefs = internalRefs + ClassName.fromDescriptor(desc)
       annVisitor
     }
     override def visitAnnotation(desc: String, visible: Boolean) = handleAnn(desc)
@@ -178,11 +169,27 @@ trait ClassfileIndexer {
     ) = handleAnn(desc)
   }
 
+  private trait ReferenceInFieldHunter {
+    this: FieldVisitor =>
+
+    protected var internalRefs = Set.empty[FullyQualifiedName]
+
+    private val annVisitor = new AnnotationVisitor(ASM5) {
+      override def visitAnnotation(name: String, desc: String): AnnotationVisitor = handleAnn(desc)
+    }
+    private def handleAnn(desc: String): AnnotationVisitor = {
+      internalRefs = internalRefs + ClassName.fromDescriptor(desc)
+      annVisitor
+    }
+    override def visitTypeAnnotation(typeRef: Int, typePath: TypePath, desc: String, visible: Boolean): AnnotationVisitor = handleAnn(desc)
+    override def visitAnnotation(desc: String, visible: Boolean): AnnotationVisitor = handleAnn(desc)
+  }
+
   private trait ReferenceInMethodHunter {
     this: MethodVisitor =>
 
-    // NOTE: :+ and :+= are really slow (scala 2.10), prefer "enqueue"
-    protected var internalRefs = Queue.empty[FullyQualifiedName]
+    protected var internalRefs = Set.empty[FullyQualifiedName]
+    protected var currentLine: Int = 0
 
     // doesn't disambiguate FQNs of methods, so storing as FieldName references
     private def memberOrInit(owner: String, name: String): FullyQualifiedName =
@@ -191,38 +198,41 @@ trait ClassfileIndexer {
         case member => FieldName(ClassName.fromInternal(owner), member)
       }
 
+    protected def addRefs(refs: Seq[FullyQualifiedName]): Unit
+    = internalRefs = internalRefs ++ refs
+
+    protected def addRef(ref: FullyQualifiedName): Unit = addRefs(Seq(ref))
+
     override def visitLocalVariable(
       name: String, desc: String, signature: String,
       start: Label, end: Label, index: Int
     ): Unit = {
-      internalRefs = internalRefs enqueue ClassName.fromDescriptor(desc)
+      addRef(ClassName.fromDescriptor(desc))
     }
 
-    override def visitMultiANewArrayInsn(desc: String, dims: Int): Unit = {
-      internalRefs = internalRefs enqueue ClassName.fromDescriptor(desc)
-    }
+    override def visitMultiANewArrayInsn(desc: String, dims: Int): Unit =
+      addRef(ClassName.fromDescriptor(desc))
 
-    override def visitTypeInsn(opcode: Int, desc: String): Unit = {
-      internalRefs = internalRefs enqueue ClassName.fromInternal(desc)
-    }
+    override def visitTypeInsn(opcode: Int, desc: String): Unit =
+      addRef(ClassName.fromInternal(desc))
 
     override def visitFieldInsn(
       opcode: Int, owner: String, name: String, desc: String
     ): Unit = {
-      internalRefs = internalRefs enqueue memberOrInit(owner, name)
-      internalRefs = internalRefs enqueue ClassName.fromDescriptor(desc)
+      addRef(memberOrInit(owner, name))
+      addRef(ClassName.fromDescriptor(desc))
     }
 
     override def visitMethodInsn(
       opcode: Int, owner: String, name: String, desc: String, itf: Boolean
     ): Unit = {
-      internalRefs :+= memberOrInit(owner, name)
-      internalRefs = internalRefs.enqueue(classesInDescriptor(desc))
+      addRef(memberOrInit(owner, name))
+      addRefs(classesInDescriptor(desc))
     }
 
     override def visitInvokeDynamicInsn(name: String, desc: String, bsm: Handle, bsmArgs: AnyRef*): Unit = {
-      internalRefs :+= memberOrInit(bsm.getOwner, bsm.getName)
-      internalRefs = internalRefs.enqueue(classesInDescriptor(bsm.getDesc))
+      addRef(memberOrInit(bsm.getOwner, bsm.getName))
+      addRefs(classesInDescriptor(bsm.getDesc))
     }
 
     private val annVisitor: AnnotationVisitor = new AnnotationVisitor(ASM5) {
@@ -230,7 +240,7 @@ trait ClassfileIndexer {
       override def visitEnum(name: String, desc: String, value: String): Unit = handleAnn(desc)
     }
     private def handleAnn(desc: String): AnnotationVisitor = {
-      internalRefs = internalRefs enqueue ClassName.fromDescriptor(desc)
+      addRef(ClassName.fromDescriptor(desc))
       annVisitor
     }
     override def visitAnnotation(desc: String, visible: Boolean) = handleAnn(desc)

--- a/core/src/main/scala/org/ensime/indexer/IndexService.scala
+++ b/core/src/main/scala/org/ensime/indexer/IndexService.scala
@@ -93,7 +93,6 @@ class IndexService(path: Path) {
   }
 
   def persist(symbols: List[SourceSymbolInfo], commit: Boolean, boost: Boolean): Unit = {
-    log.debug(s"symbols size = ${symbols.size}")
     val fqns: List[Document] = symbols.collect {
       case SourceSymbolInfo(f, _, _, _, Some(bytecodeSymbol), scalapSymbol) =>
         bytecodeSymbol match {

--- a/core/src/main/scala/org/ensime/indexer/IndexService.scala
+++ b/core/src/main/scala/org/ensime/indexer/IndexService.scala
@@ -93,24 +93,21 @@ class IndexService(path: Path) {
   }
 
   def persist(symbols: List[SourceSymbolInfo], commit: Boolean, boost: Boolean): Unit = {
-    val checks = symbols.groupBy(s => Some(s.file))
-    val fqns: List[Document] = checks.flatMap {
-      case (f, syms) =>
-        syms.collect {
-          case SourceSymbolInfo(_, _, _, Some(bytecodeSymbol), scalapSymbol) =>
-            bytecodeSymbol match {
-              case method: RawMethod => MethodIndex(method.name.fqnString, f).toDocument
-              case field: RawField => FieldIndex(field.name.fqnString, f).toDocument
-              case aClass: RawClassfile =>
-                val fqn = aClass.name.fqnString
-                val penalty = calculatePenalty(fqn)
-                val document = ClassIndex(fqn, f).toDocument
-                document.boostText("fqn", penalty)
-                document
-            }
-          case SourceSymbolInfo(_, _, _, None, Some(t: RawType)) =>
-            FieldIndex(t.javaName.fqnString, f).toDocument
+    log.debug(s"symbols size = ${symbols.size}")
+    val fqns: List[Document] = symbols.collect {
+      case SourceSymbolInfo(f, _, _, _, Some(bytecodeSymbol), scalapSymbol) =>
+        bytecodeSymbol match {
+          case method: RawMethod => MethodIndex(method.name.fqnString, Some(f)).toDocument
+          case field: RawField => FieldIndex(field.name.fqnString, Some(f)).toDocument
+          case aClass: RawClassfile =>
+            val fqn = aClass.name.fqnString
+            val penalty = calculatePenalty(fqn)
+            val document = ClassIndex(fqn, Some(f)).toDocument
+            document.boostText("fqn", penalty)
+            document
         }
+      case SourceSymbolInfo(f, _, _, _, None, Some(t: RawType)) =>
+        FieldIndex(t.javaName.fqnString, Some(f)).toDocument
     }(collection.breakOut)
 
     if (boost) {

--- a/core/src/main/scala/org/ensime/indexer/SearchService.scala
+++ b/core/src/main/scala/org/ensime/indexer/SearchService.scala
@@ -36,9 +36,10 @@ class SearchService(
     with SLF4JLogging {
   import SearchService._
 
-  private[indexer] def isUserFile(file: FileName): Boolean = {
-    (config.allTargets map (vfs.vfile)) exists (file isAncestor _.getName)
-  }
+  private[indexer] val allTargets = config.allTargets.map(vfs.vfile)
+
+  private[indexer] def isUserFile(file: FileName): Boolean
+  = allTargets.exists(file isAncestor _.getName)
 
   private val QUERY_TIMEOUT = 30 seconds
 
@@ -46,6 +47,8 @@ class SearchService(
 
   /**
    * Changelog:
+   *
+   * 2.3g - persist reverse lookups info
    *
    * 2.2g - persist scalap information (scala names, type sigs, etc)
    *
@@ -69,7 +72,7 @@ class SearchService(
    *
    * 1.0 - initial schema
    */
-  private val version = "2.2"
+  private val version = "2.3"
 
   private val index = new IndexService((config.cacheDir / ("index-" + version)).toPath)
   private val db = new GraphService(config.cacheDir / ("graph-" + version))
@@ -80,6 +83,8 @@ class SearchService(
   // data is persisted. This is to keep the heap usage down and is a
   // poor man's backpressure.
   val semaphore = new Semaphore(Properties.propOrElse("ensime.index.parallel", "10").toInt, true)
+
+  private val noReverseLookups = Properties.propOrFalse("ensime.index.no.reverse.lookups")
 
   private[indexer] def getTopLevelClassFile(f: FileObject): FileObject = {
     import scala.reflect.NameTransformer
@@ -152,15 +157,17 @@ class SearchService(
       fileCheck: Option[FileCheck],
       grouped: Map[FileName, Set[FileObject]]
     ): Future[Int] = {
-      val outOfDate = fileCheck.forall(_.changed)
       val base = vfs.vfile(baseName.getURI)
+      val outOfDate = fileCheck.forall(_.changed)
       if (!outOfDate || !base.exists()) Future.successful(0)
       else {
         val boost = isUserFile(baseName)
         val indexed = extractSymbolsFromClassOrJar(base, grouped).flatMap(persist(_, commitIndex = false, boost = boost))
-        indexed.onComplete { _ => semaphore.release() }
-        if (baseName.getExtension == "jar") {
-          log.debug(s"finished indexing $base")
+        indexed.onComplete { _ =>
+          if (base.getName.getExtension == "jar") {
+            log.debug(s"finished indexing $base")
+          }
+          semaphore.release()
         }
         indexed
       }
@@ -254,6 +261,9 @@ class SearchService(
     files: collection.Set[FileObject],
     rootClassFile: FileObject
   ): List[SourceSymbolInfo] = {
+    def getInternalRefs(isUserFile: Boolean, s: RawSymbol): Set[FullyQualifiedName]
+    = if (isUserFile && !noReverseLookups) s.internalRefs else Set.empty
+
     val depickler = new ClassfileDepickler(rootClassFile)
     val name = container.getName.getURI
     val scalapClasses = depickler.getClasses
@@ -266,31 +276,31 @@ class SearchService(
           val file = if (path.startsWith("jar") || path.startsWith("zip")) {
             FileCheck(container)
           } else FileCheck(f)
-          val (clazz, refs) = indexClassfile(f)
-
+          val clazz = indexClassfile(f)
+          val userFile = isUserFile(f.getName)
           val source = resolver.resolve(clazz.name.pack, clazz.source)
           val sourceUri = source.map(_.getName.getURI)
           val scalapClassInfo = scalapClasses.get(clazz.name.fqnString)
 
           scalapClassInfo match {
             case _ if clazz.access != Public => Nil
-            case None if clazz.isScala => List(SourceSymbolInfo(file, path, None, None, None))
+            case None if clazz.isScala => List(SourceSymbolInfo(file, path, None, Set.empty, None, None))
             case Some(scalapSymbol) =>
-              val classInfo = SourceSymbolInfo(file, path, sourceUri, Some(clazz), Some(scalapSymbol))
+              val classInfo = SourceSymbolInfo(file, path, sourceUri, getInternalRefs(userFile, clazz), Some(clazz), Some(scalapSymbol))
               val fields = clazz.fields.map(f =>
-                SourceSymbolInfo(file, path, sourceUri, Some(f), scalapSymbol.fields.get(f.fqn)))
-              val methods = clazz.methods.map(m => {
+                SourceSymbolInfo(file, path, sourceUri, getInternalRefs(userFile, f), Some(f), scalapSymbol.fields.get(f.fqn))).toList
+              val methods = clazz.methods.map { m =>
                 val scalapMethod =
                   if (m.indexInParent < scalapSymbol.methods.size) Some(scalapSymbol.methods(m.indexInParent))
                   else None
-                SourceSymbolInfo(file, path, sourceUri, Some(m), scalapMethod)
-              })
+                SourceSymbolInfo(file, path, sourceUri, getInternalRefs(userFile, m), Some(m), scalapMethod)
+              }
               val aliases = scalapSymbol.typeAliases.valuesIterator.map(alias =>
-                SourceSymbolInfo(file, path, sourceUri, None, Some(alias))).toList
+                SourceSymbolInfo(file, path, sourceUri, Set.empty, None, Some(alias))).toList
               classInfo :: fields ::: methods ::: aliases
             case None =>
               (clazz :: clazz.methods ::: clazz.fields)
-                .map(s => SourceSymbolInfo(file, path, sourceUri, Some(s)))
+                .map(s => SourceSymbolInfo(file, path, sourceUri, getInternalRefs(userFile, s), Some(s)))
           }
       }
     }.filterNot(sym => ignore.exists(sym.fqn.contains))
@@ -311,7 +321,11 @@ class SearchService(
   /** only for exact fqns */
   def findUnique(fqn: String): Option[FqnSymbol] = Await.result(db.find(fqn), QUERY_TIMEOUT)
 
-  def getClassHierarchy(fqn: String, hierarchyType: Hierarchy.Direction): Future[Option[Hierarchy]] = db.getClassHierarchy(fqn, hierarchyType)
+  /** returns hierarchy of a type identified by fqn */
+  def getTypeHierarchy(fqn: String, hierarchyType: Hierarchy.Direction): Future[Option[Hierarchy]] = db.getClassHierarchy(fqn, hierarchyType)
+
+  /** returns FqnSymbol which reference given fqn */
+  def findUsages(fqn: String): Future[Iterable[FqnSymbol]] = db.findUsages(fqn)
 
   /* DELETE then INSERT in H2 is ridiculously slow, so we put all modifications
    * into a blocking queue and dedicate a thread to block on draining the queue.
@@ -356,6 +370,7 @@ object SearchService {
       file: FileCheck,
       path: String,
       source: Option[String],
+      usageInfo: Set[FullyQualifiedName],
       bytecodeSymbol: Option[RawSymbol],
       scalapSymbol: Option[RawScalapSymbol] = None
   ) {

--- a/core/src/main/scala/org/ensime/indexer/domain.scala
+++ b/core/src/main/scala/org/ensime/indexer/domain.scala
@@ -236,7 +236,6 @@ final case class RawMethod(
     access: Access,
     generics: Option[String],
     line: Option[Int],
-    indexInParent: Int,
     internalRefs: Set[FullyQualifiedName]
 ) extends RawSymbol {
   override def fqn: String = name.fqnString
@@ -256,7 +255,7 @@ final case class RawScalapClass(
   access: Access,
   declaredAs: DeclaredAs,
   fields: Map[String, RawScalapField],
-  methods: Vector[RawScalapMethod],
+  methods: Map[String, IndexedSeq[RawScalapMethod]],
   typeAliases: Map[String, RawType]
 ) extends RawScalapSymbol
 
@@ -270,7 +269,8 @@ final case class RawScalapField(
 }
 
 final case class RawScalapMethod(
-    scalaName: String,
+    simpleName: String, //name of a method symbol, used to identify a group of overloaded methods (e.g. `foo`)
+    scalaName: String, //full scala name of a method (e.g. `org.example.Foo#foo`)
     typeSignature: String,
     access: Access
 ) extends RawScalapSymbol {
@@ -278,6 +278,7 @@ final case class RawScalapMethod(
 }
 
 final case class RawType(
+    owner: ClassName,
     javaName: ClassName,
     scalaName: String,
     access: Access,

--- a/core/src/main/scala/org/ensime/indexer/domain.scala
+++ b/core/src/main/scala/org/ensime/indexer/domain.scala
@@ -3,6 +3,7 @@
 package org.ensime.indexer
 
 import org.ensime.api.DeclaredAs
+import scala.collection.immutable.Queue
 
 import org.objectweb.asm.Opcodes._
 
@@ -196,6 +197,7 @@ final case class Descriptor(params: List[DescriptorType], ret: DescriptorType) {
 
 sealed trait RawSymbol {
   def fqn: String
+  def internalRefs: Set[FullyQualifiedName]
 }
 
 final case class RawClassfile(
@@ -206,9 +208,10 @@ final case class RawClassfile(
     access: Access,
     deprecated: Boolean,
     fields: List[RawField],
-    methods: List[RawMethod],
+    methods: Queue[RawMethod],
     source: RawSource,
-    isScala: Boolean
+    isScala: Boolean,
+    internalRefs: Set[FullyQualifiedName]
 ) extends RawSymbol {
   override def fqn: String = name.fqnString
 }
@@ -222,7 +225,8 @@ final case class RawField(
     name: FieldName,
     clazz: DescriptorType,
     generics: Option[String],
-    access: Access
+    access: Access,
+    internalRefs: Set[FullyQualifiedName]
 ) extends RawSymbol {
   override def fqn: String = name.fqnString
 }
@@ -232,7 +236,8 @@ final case class RawMethod(
     access: Access,
     generics: Option[String],
     line: Option[Int],
-    indexInParent: Int
+    indexInParent: Int,
+    internalRefs: Set[FullyQualifiedName]
 ) extends RawSymbol {
   override def fqn: String = name.fqnString
 }
@@ -273,7 +278,7 @@ final case class RawScalapMethod(
 }
 
 final case class RawType(
-    javaName: FieldName,
+    javaName: ClassName,
     scalaName: String,
     access: Access,
     typeSignature: String

--- a/core/src/main/scala/org/ensime/indexer/domain.scala
+++ b/core/src/main/scala/org/ensime/indexer/domain.scala
@@ -53,6 +53,8 @@ final case class ClassName(pack: PackageName, name: String)
     if (pack.path.isEmpty) name
     else pack.fqnString + "." + name
 
+  def isPrimitive: Boolean = pack == ClassName.Root
+
   private def nonPrimitiveInternalString: String =
     "L" + (if (pack.path.isEmpty) name else pack.path.mkString("/") + "/" + name) + ";"
 

--- a/core/src/main/scala/org/ensime/indexer/graph/GraphService.scala
+++ b/core/src/main/scala/org/ensime/indexer/graph/GraphService.scala
@@ -175,7 +175,7 @@ class GraphService(dir: File) extends SLF4JLogging {
 
     // is this just needed on schema creation or always?
     // https://github.com/orientechnologies/orientdb/issues/5322
-    //    g.setUseLightweightEdges(true)
+    g.setUseLightweightEdges(true)
     g.setUseLog(false)
 
     g.shutdown()
@@ -240,7 +240,7 @@ class GraphService(dir: File) extends SLF4JLogging {
               None
 
             case (None, Some(t: RawType)) => // only scalap symbol (type alias case)
-              val owningClass = RichGraph.readUniqueV[ClassDef, String](t.javaName.owner.fqnString)
+              val owningClass = RichGraph.readUniqueV[ClassDef, String](t.owner.fqnString)
               val field = Field(t.javaName.fqnString, None, None, source, t.access, Some(t.scalaName + t.typeSignature))
               val fieldV: VertexT[Member] = RichGraph.upsertV[Field, String](field)
               owningClass.foreach(classV =>

--- a/core/src/main/scala/org/ensime/indexer/orientdb/SimpleOrient.scala
+++ b/core/src/main/scala/org/ensime/indexer/orientdb/SimpleOrient.scala
@@ -12,11 +12,12 @@ import akka.event.slf4j.SLF4JLogging
 import com.orientechnologies.orient.core.metadata.schema.OClass
 import com.tinkerpop.blueprints._
 import com.tinkerpop.blueprints.impls.orient._
-import org.ensime.indexer.graph.GraphService.IsParent
+import org.ensime.indexer.graph.GraphService.{ IsParent, UsedIn }
 import org.ensime.indexer.graph._
 import org.ensime.indexer.orientdb.api.{ NotUnique, OrientProperty }
 import org.ensime.indexer.stringymap.api._
 import org.ensime.indexer.stringymap.syntax._
+import shapeless.Typeable
 
 // NOTE: this uses the v2 version of tinkerpop. v3 is on Java 8.
 //       https://github.com/mpollmeier/gremlin-scala/issues/102
@@ -79,10 +80,11 @@ package object syntax {
     def createIndexOn[E <: Element, T, F](idx: IndexT = NotUnique)(
       implicit
       tag: Indexable[E],
-      bdf: BigDataFormat[T],
+      tpe: Typeable[T],
       id: BigDataFormatId[T, F]
     ): RichOrientGraph = {
-      graph.createKeyIndex(id.key, tag.aClass, "type" -> idx.orientKey, "class" -> bdf.label)
+      val label = tpe.describe.replace(".type", "")
+      graph.createKeyIndex(id.key, tag.aClass, "type" -> idx.orientKey, "class" -> label)
       this
     }
 
@@ -133,12 +135,12 @@ package object syntax {
 
     def setProperty[P](key: String, p: P): Unit = v.underlying.setProperty(key, p)
 
-    def getChildVertices[S, E <: EdgeT[S, T]](
+    def getInVertices[S, E <: EdgeT[S, T]](
       implicit
       bdf: BigDataFormat[E]
     ): Iterable[VertexT[S]] = v.underlying.getVertices(Direction.IN, bdf.label).asScala.map(VertexT[S])
 
-    def getParentVertices[S, E <: EdgeT[T, S]](
+    def getOutVertices[S, E <: EdgeT[T, S]](
       implicit
       bdf: BigDataFormat[E]
     ): Iterable[VertexT[S]] = v.underlying.getVertices(Direction.OUT, bdf.label).asScala.map(VertexT[S])
@@ -170,7 +172,7 @@ package object syntax {
     /** Side-effecting vertex insertion. */
     def insertV[T](t: T)(implicit graph: Graph, s: BigDataFormat[T]): VertexT[T] = {
       val props = t.toProperties
-      val v = graph.addVertex("class:" + t.label)
+      val v = graph.addVertex("class:" + props.get("typehint"))
       props.asScala.foreach {
         case (key, value) => v.setProperty(key, value)
       }
@@ -311,17 +313,17 @@ package object syntax {
       implicit
       graph: OrientBaseGraph,
       s: BigDataFormat[ClassDef],
-      bdf: BigDataFormat[IsParent.type],
       u: BigDataFormatId[ClassDef, P],
       p: SPrimitive[P]
     ): Option[Hierarchy] = {
+      import GraphService.IsParentS
 
       def traverseClassHierarchy(
         v: VertexT[ClassDef]
       ): Hierarchy = {
         val vertices: Iterable[VertexT[ClassDef]] = hierarchyType match {
-          case Hierarchy.Subtypes => v.getChildVertices[ClassDef, IsParent.type]
-          case Hierarchy.Supertypes => v.getParentVertices[ClassDef, IsParent.type]
+          case Hierarchy.Subtypes => v.getInVertices[ClassDef, IsParent.type]
+          case Hierarchy.Supertypes => v.getOutVertices[ClassDef, IsParent.type]
         }
 
         vertices.toList match {
@@ -333,6 +335,23 @@ package object syntax {
       readUniqueV[ClassDef, P](value) match {
         case Some(vertexT) => Some(traverseClassHierarchy(vertexT))
         case None => None
+      }
+    }
+
+    def findUsages[P](
+      value: P
+    )(
+      implicit
+      graph: OrientBaseGraph,
+      bdf: BigDataFormat[FqnSymbol],
+      bdfId: BigDataFormatId[FqnSymbol, P],
+      p: SPrimitive[P]
+    ): Iterable[VertexT[FqnSymbol]] = {
+      import GraphService.UsedInS
+
+      readUniqueV[FqnSymbol, P](value) match {
+        case Some(vertexT) => vertexT.getOutVertices[FqnSymbol, UsedIn.type]
+        case None => Iterable.empty
       }
     }
   }

--- a/core/src/test/scala/org/ensime/indexer/ClassfileDepicklerSpec.scala
+++ b/core/src/test/scala/org/ensime/indexer/ClassfileDepicklerSpec.scala
@@ -25,15 +25,14 @@ class ClassfileDepicklerSpec extends EnsimeSpec with SharedEnsimeVFSFixture {
   }
 
   it should "find type aliases" in withVFS { vfs =>
-    new ClassfileDepickler(vfs.vres("scala/Predef.class")).getClasses("scala.Predef$").typeAliases should contain(
-      "scala.Predef$.String" ->
-        RawType(
-          ClassName(PackageName(List("scala")), "Predef$"),
-          ClassName(PackageName(List("scala")), "Predef$$String"),
-          "scala.Predef.String",
-          Public,
-          " = java.lang.String"
-        )
-    )
+    new ClassfileDepickler(vfs.vres("scala/Predef.class")).getClasses("scala.Predef$").typeAliases.get(s"scala.Predef$$String") should ===(Some(
+      RawType(
+        ClassName(PackageName(List("scala")), "Predef$"),
+        ClassName(PackageName(List("scala")), s"Predef$$String"),
+        "scala.Predef.String",
+        Public,
+        " = java.lang.String"
+      )
+    ))
   }
 }

--- a/core/src/test/scala/org/ensime/indexer/ClassfileDepicklerSpec.scala
+++ b/core/src/test/scala/org/ensime/indexer/ClassfileDepicklerSpec.scala
@@ -28,7 +28,8 @@ class ClassfileDepicklerSpec extends EnsimeSpec with SharedEnsimeVFSFixture {
     new ClassfileDepickler(vfs.vres("scala/Predef.class")).getClasses("scala.Predef$").typeAliases should contain(
       "scala.Predef$.String" ->
         RawType(
-          FieldName(ClassName(PackageName(List("scala")), "Predef$"), "String"),
+          ClassName(PackageName(List("scala")), "Predef$"),
+          ClassName(PackageName(List("scala")), "Predef$$String"),
           "scala.Predef.String",
           Public,
           " = java.lang.String"

--- a/core/src/test/scala/org/ensime/indexer/ClassfileIndexerSpec.scala
+++ b/core/src/test/scala/org/ensime/indexer/ClassfileIndexerSpec.scala
@@ -6,6 +6,7 @@ import akka.event.slf4j.SLF4JLogging
 import org.ensime.fixture.IsolatedEnsimeVFSFixture
 import org.ensime.util.EnsimeSpec
 import org.ensime.vfs._
+import scala.collection.immutable.Queue
 
 class ClassfileIndexerSpec extends EnsimeSpec with IsolatedEnsimeVFSFixture {
 
@@ -21,7 +22,26 @@ class ClassfileIndexerSpec extends EnsimeSpec with IsolatedEnsimeVFSFixture {
     clazz.access shouldBe Default
     clazz.deprecated shouldBe false
     clazz.fields shouldBe List()
-    clazz.methods shouldBe List(
+    clazz.methods shouldBe Queue(
+      RawMethod(
+        MethodName(
+          ClassName(PackageName(Nil), "Test"),
+          "<init>",
+          Descriptor(Nil, ClassName(PackageName(Nil), "void"))
+        ),
+        Default,
+        None,
+        Some(1),
+        Set(
+          ClassName(PackageName(List("java", "lang")), "Object"),
+          MethodName(
+            ClassName(PackageName(List("java", "lang")), "Object"),
+            "<init>",
+            Descriptor(Nil, ClassName(PackageName(Nil), "void"))
+          ),
+          ClassName(PackageName(Nil), "void")
+        )
+      ),
       RawMethod(
         name = MethodName(
           ClassName(PackageName(Nil), "Test"),
@@ -51,8 +71,12 @@ class ClassfileIndexerSpec extends EnsimeSpec with IsolatedEnsimeVFSFixture {
       ClassName(PackageName(Nil), "void"),
       ClassName(PackageName(List("java", "lang")), "Object"),
       FieldName(ClassName(PackageName(List("java", "lang")), "System"), "out"),
-      ClassName(PackageName(List("java", "lang")), "Object"),
       ClassName(PackageName(List("java", "io")), "PrintStream"),
+      MethodName(
+        ClassName(PackageName(List("java", "lang")), "Object"),
+        "<init>",
+        Descriptor(Nil, ClassName(PackageName(Nil), "void"))
+      ),
       MethodName(
         ClassName(PackageName(List("java", "io")), "PrintStream"),
         "print",

--- a/core/src/test/scala/org/ensime/indexer/ClassfileIndexerSpec.scala
+++ b/core/src/test/scala/org/ensime/indexer/ClassfileIndexerSpec.scala
@@ -2,8 +2,6 @@
 // License: http://www.gnu.org/licenses/gpl-3.0.en.html
 package org.ensime.indexer
 
-import scala.collection.immutable.Queue
-
 import akka.event.slf4j.SLF4JLogging
 import org.ensime.fixture.IsolatedEnsimeVFSFixture
 import org.ensime.util.EnsimeSpec
@@ -22,8 +20,8 @@ class ClassfileIndexerSpec extends EnsimeSpec with IsolatedEnsimeVFSFixture {
     clazz.interfaces shouldBe Nil
     clazz.access shouldBe Default
     clazz.deprecated shouldBe false
-    clazz.fields shouldBe Queue()
-    clazz.methods shouldBe Queue(
+    clazz.fields shouldBe List()
+    clazz.methods shouldBe List(
       RawMethod(
         name = MethodName(
           ClassName(PackageName(Nil), "Test"),
@@ -33,8 +31,17 @@ class ClassfileIndexerSpec extends EnsimeSpec with IsolatedEnsimeVFSFixture {
         access = Public,
         generics = None,
         line = Some(4),
-        0,
-        Set.empty
+        Set(
+          ClassName(PackageName(Nil), "void"),
+          FieldName(ClassName(PackageName(List("java", "lang")), "System"), "out"),
+          ClassName(PackageName(List("java", "io")), "PrintStream"),
+          ClassName(PackageName(List("java", "lang")), "String"),
+          MethodName(
+            ClassName(PackageName(List("java", "io")), "PrintStream"),
+            "print",
+            Descriptor(List(ClassName(PackageName(List("java", "lang")), "String")), ClassName(PackageName(Nil), "void"))
+          )
+        )
       )
     )
     clazz.source shouldBe RawSource(Some("Test.java"), Some(1))
@@ -46,7 +53,11 @@ class ClassfileIndexerSpec extends EnsimeSpec with IsolatedEnsimeVFSFixture {
       FieldName(ClassName(PackageName(List("java", "lang")), "System"), "out"),
       ClassName(PackageName(List("java", "lang")), "Object"),
       ClassName(PackageName(List("java", "io")), "PrintStream"),
-      FieldName(ClassName(PackageName(List("java", "io")), "PrintStream"), "print"),
+      MethodName(
+        ClassName(PackageName(List("java", "io")), "PrintStream"),
+        "print",
+        Descriptor(List(ClassName(PackageName(List("java", "lang")), "String")), ClassName(PackageName(Nil), "void"))
+      ),
       ClassName(PackageName(List("java", "lang")), "String")
     )
   }

--- a/project/SensibleSettings.scala
+++ b/project/SensibleSettings.scala
@@ -47,7 +47,7 @@ object Sensible {
     ),
     javacOptions in doc ++= Seq("-source", "1.7"),
 
-    javaOptions := Seq("-Xss2m", "-XX:MaxPermSize=256m", "-Xms384m", "-Xmx384m"),
+    javaOptions := Seq("-Xss2m", "-XX:MaxPermSize=256m", "-Xms512m", "-Xmx1g"),
     javaOptions += "-Dfile.encoding=UTF8",
     //this is needed by OrientDB versions 2.2.0+, 512g is recommended on their github wiki
     //https://github.com/orientechnologies/orientdb-docs/blob/master/Release-2.2.0.md

--- a/testing/simple/src/main/scala/org/reverselookups/MyAnnotation.java
+++ b/testing/simple/src/main/scala/org/reverselookups/MyAnnotation.java
@@ -1,0 +1,3 @@
+package org.reverselookups;
+
+public @interface MyAnnotation {}

--- a/testing/simple/src/main/scala/org/reverselookups/Overloads.scala
+++ b/testing/simple/src/main/scala/org/reverselookups/Overloads.scala
@@ -1,0 +1,20 @@
+package org.reverselookups
+
+class Overloads(l: Long) {
+  val rl = new ReverseLookups(123)
+  rl.catches()
+
+  def foo(): Unit = ???
+  def foo(i: Int): Unit = ???
+  def foo(s: String, i: Int): Unit = ???
+  def foo(ann: MyAnnotation): Unit = ???
+  def foo[T <: MyException](t: T): Unit = ???
+  def asDefaultArg(i: Int = rl.catches()): Unit = ???
+}
+
+object Overloads {
+  new MyAnnotation
+
+  def foo(): Unit = ???
+  def foo(i: Int): Unit = ???
+}

--- a/testing/simple/src/main/scala/org/reverselookups/ReverseLookups.scala
+++ b/testing/simple/src/main/scala/org/reverselookups/ReverseLookups.scala
@@ -1,0 +1,63 @@
+package org.reverselookups
+
+class MyException extends RuntimeException
+
+@MyAnnotation
+class ReverseLookups(val i: Int) {
+  val fieldType: MyAnnotation = null
+
+  val fieldInit: String = new MyAnnotation().toString
+
+  val intField = catches()
+
+  def methodUsage: Unit = returns(123)
+
+  @MyAnnotation
+  val annotatedField = 1
+
+  def takesAsParam(ann: MyAnnotation): Unit = {
+    println(intField)
+    ???
+  }
+
+  def returns(i: Int = intField): MyAnnotation = ???
+
+  def usesInBody(): Unit = {
+    val ann = new MyAnnotation
+  }
+
+  @MyAnnotation
+  def annotatedMethod(): Unit = ???
+
+  def polyMethod[A <: MyAnnotation](a: A): Unit = ???
+
+  def throws(): Unit = {
+    val a = catches()
+    throw new MyException
+  }
+
+  def catches(): Int = {
+    try {
+      1
+    } catch {
+      case e: MyException => 2
+    }
+  }
+}
+
+@MyAnnotation
+object ReverseLookups {
+  new ReverseLookups(1).returns(123)
+  new MyAnnotation
+
+  val staticField = new MyAnnotation
+
+  def staticMethod[A >: MyAnnotation](a: A): Unit = ???
+}
+
+abstract class Extends extends MyException
+
+class SelfType {
+  this: MyAnnotation with MyException =>
+  val usesField = new ReverseLookups(1).intField
+}


### PR DESCRIPTION
An attempt to persist reverse lookups information to optimise features such as find usages and refactor-rename across multiple files. Can be turned off by system property `ensime.index.no.reverse.lookups`.

# Known limitations

- Using class in self type annotation is not considered a usage atm (need to hack something with scalap to fix that)
- Initialising trait as an anonymous class doesn't always work
- If trying to find references to a field, we instead have to search for references to fqn of generated getter of this field 
