### PR TITLE
adds row,col to OffsetSourcePosition for kicks

### DIFF
--- a/api/src/main/scala/org/ensime/api/outgoing.scala
+++ b/api/src/main/scala/org/ensime/api/outgoing.scala
@@ -233,7 +233,8 @@ case object PosNeededYes extends PosNeeded
 
 sealed trait SourcePosition extends RpcResponse
 final case class EmptySourcePosition() extends SourcePosition
-final case class OffsetSourcePosition(file: File, offset: Int) extends SourcePosition
+final case class OffsetSourcePosition(file: File, offset: Int,
+  row: Option[Int] = None, col: Option[Int] = None) extends SourcePosition
 final case class LineSourcePosition(file: File, line: Int) extends SourcePosition
 
 final case class PackageInfo(

--- a/core/src/it/scala/org/ensime/core/JavaCompilerSpec.scala
+++ b/core/src/it/scala/org/ensime/core/JavaCompilerSpec.scala
@@ -65,9 +65,9 @@ class JavaCompilerSpec extends EnsimeSpec
       val test1 = SourceFileInfo(new File(config.rootDir, "testing/simple/src/main/java/org/example/Test1.java"))
       val test2 = SourceFileInfo(new File(config.rootDir, "testing/simple/src/main/java/org/example/Test2.java"))
 
-      cc.askLinkPos(ClassName(PackageName(List("org", "example")), "Test2"), test2) should matchPattern { case Some(OffsetSourcePosition(f, 22)) => }
+      cc.askLinkPos(ClassName(PackageName(List("org", "example")), "Test2"), test2) should matchPattern { case Some(OffsetSourcePosition(f, 22, None, None)) => }
       cc.askLinkPos(ClassName(PackageName(List("org", "example")), "Foo"), test2) should matchPattern { case None => }
-      cc.askLinkPos(ClassName(PackageName(List("org", "example")), "Test2.Bar"), test2) should matchPattern { case Some(OffsetSourcePosition(f, 260)) => }
+      cc.askLinkPos(ClassName(PackageName(List("org", "example")), "Test2.Bar"), test2) should matchPattern { case Some(OffsetSourcePosition(f, 260, None, None)) => }
       //    cc.askLinkPos(JavaFqn("org.example", "Test2", Some("compute()")), test2) should matchPattern { case Some(OffsetSourcePosition(f, 58)) => }
 
     }
@@ -110,19 +110,19 @@ class JavaCompilerSpec extends EnsimeSpec
             info.localName shouldBe "foo"
             info.`type`.name shouldBe "int"
             info.`type` shouldBe a[api.BasicTypeInfo]
-            info.declPos should matchPattern { case Some(OffsetSourcePosition(f, 174)) if f.getName == "Test1.java" => }
+            info.declPos should matchPattern { case Some(OffsetSourcePosition(f, 174, None, None)) if f.getName == "Test1.java" => }
           case "1" =>
             info.name shouldBe "args"
             info.localName shouldBe "args"
             info.`type`.name shouldBe "java.lang.String[]"
             info.`type` shouldBe a[api.BasicTypeInfo]
-            info.declPos should matchPattern { case Some(OffsetSourcePosition(f, 153)) if f.getName == "Test1.java" => }
+            info.declPos should matchPattern { case Some(OffsetSourcePosition(f, 153, None, None)) if f.getName == "Test1.java" => }
           case "2" =>
             info.name shouldBe "org.example.Test1.Foo"
             info.localName shouldBe "Foo"
             info.`type`.name shouldBe "org.example.Test1.Foo"
             info.`type` shouldBe a[api.BasicTypeInfo]
-            info.declPos should matchPattern { case Some(OffsetSourcePosition(f, 58)) if f.getName == "Test1.java" => }
+            info.declPos should matchPattern { case Some(OffsetSourcePosition(f, 58, None, None)) if f.getName == "Test1.java" => }
           case "3" =>
             info.name shouldBe "java.io.PrintStream.println(java.lang.Object)"
             info.localName shouldBe "println"
@@ -148,7 +148,7 @@ class JavaCompilerSpec extends EnsimeSpec
             info.localName shouldBe "Test2"
             info.`type`.name shouldBe "org.example.Test2"
             info.`type` shouldBe a[api.BasicTypeInfo]
-            info.declPos should matchPattern { case Some(OffsetSourcePosition(f, 22)) if f.getName == "Test2.java" => }
+            info.declPos should matchPattern { case Some(OffsetSourcePosition(f, 22, None, None)) if f.getName == "Test2.java" => }
           case "6" =>
             info.name shouldBe "org.example.Test2.compute()"
             info.localName shouldBe "compute"
@@ -162,7 +162,7 @@ class JavaCompilerSpec extends EnsimeSpec
             )
             info.declPos should matchPattern {
               case Some(LineSourcePosition(f, 8)) if f.getName == "Test2.java" =>
-              case Some(OffsetSourcePosition(f, 48)) if f.getName == "Test2.java" =>
+              case Some(OffsetSourcePosition(f, 48, None, None)) if f.getName == "Test2.java" =>
             }
           case "7" =>
             {}
@@ -186,26 +186,26 @@ class JavaCompilerSpec extends EnsimeSpec
               ) :: Nil, Nil
             )
             // "private static int compute(int a, int b)"
-            info.declPos should matchPattern { case Some(OffsetSourcePosition(f, 481)) if f.getName == "Test1.java" => }
+            info.declPos should matchPattern { case Some(OffsetSourcePosition(f, 481, None, None)) if f.getName == "Test1.java" => }
           case "8" =>
             info.name shouldBe "org.example.Test1.CONST"
             info.localName shouldBe "CONST"
             info.`type`.name shouldBe "int"
             info.`type` shouldBe a[api.BasicTypeInfo]
-            info.declPos should matchPattern { case Some(OffsetSourcePosition(f, 98)) if f.getName == "Test1.java" => }
+            info.declPos should matchPattern { case Some(OffsetSourcePosition(f, 98, None, None)) if f.getName == "Test1.java" => }
           case "9" =>
             info.name shouldBe "org.example.Test1.Day"
             info.localName shouldBe "Day"
             info.`type`.name shouldBe "org.example.Test1.Day"
             info.`type` shouldBe a[api.BasicTypeInfo]
-            info.declPos should matchPattern { case Some(OffsetSourcePosition(f, 653)) if f.getName == "Test1.java" => }
+            info.declPos should matchPattern { case Some(OffsetSourcePosition(f, 653, None, None)) if f.getName == "Test1.java" => }
           case "10" =>
             info.name shouldBe "org.example.Test1.Day.MON"
             info.localName shouldBe "MON"
             info.`type`.name shouldBe "org.example.Test1.Day"
             info.`type` shouldBe a[api.BasicTypeInfo]
             // Don't specify offset pos here as Java 6 seems to have a problem locating enums
-            info.declPos should matchPattern { case Some(OffsetSourcePosition(f, i: Int)) if f.getName == "Test1.java" => }
+            info.declPos should matchPattern { case Some(OffsetSourcePosition(f, i: Int, None, None)) if f.getName == "Test1.java" => }
           case "13" | "14" =>
             info.name shouldBe "k"
             info.`type`.name shouldBe "int"

--- a/core/src/it/scala/org/ensime/core/RichPresentationCompilerSpec.scala
+++ b/core/src/it/scala/org/ensime/core/RichPresentationCompilerSpec.scala
@@ -65,7 +65,7 @@ class RichPresentationCompilerSpec extends EnsimeSpec
         "object Abc { def main { Bla @2@!@3@ 0 } }") { (p, label, cc) =>
           val sym = cc.askSymbolInfoAt(p).get
           inside(sym.declPos) {
-            case Some(OffsetSourcePosition(f, i)) =>
+            case Some(OffsetSourcePosition(f, i, Some(row), Some(col))) =>
               i should be > 0
           }
         }
@@ -84,9 +84,10 @@ class RichPresentationCompilerSpec extends EnsimeSpec
         "object Bla { val x = 1 @0@+ 1 }") { (p, label, cc) =>
           val sym = cc.askSymbolInfoAt(p).get
           inside(sym.declPos) {
-            case Some(OffsetSourcePosition(f, i)) =>
+            case Some(OffsetSourcePosition(f, i, Some(row), Some(col))) =>
               f.parts should contain("Int.scala")
               i should be > 0
+              row should be >= 0
           }
         }
     }
@@ -103,7 +104,9 @@ class RichPresentationCompilerSpec extends EnsimeSpec
           sym.name shouldBe "fn"
           sym.localName shouldBe "fn"
           inside(sym.declPos) {
-            case Some(OffsetSourcePosition(f, i)) => i should be > 0
+            case Some(OffsetSourcePosition(f, i, Some(row), Some(col))) =>
+              i should be > 0
+              row should be >= 0
           }
         }
     }
@@ -125,7 +128,7 @@ class RichPresentationCompilerSpec extends EnsimeSpec
           sym.name shouldBe "apply"
           sym.localName shouldBe "apply"
           inside(sym.declPos) {
-            case Some(OffsetSourcePosition(f, i)) => i should be > 0
+            case Some(OffsetSourcePosition(f, i, Some(row), Some(col))) => i should be > 0
           }
         }
     }
@@ -148,7 +151,7 @@ class RichPresentationCompilerSpec extends EnsimeSpec
           sym.name shouldBe "copy"
           sym.localName shouldBe "copy"
           inside(sym.declPos) {
-            case Some(OffsetSourcePosition(f, i)) => i should be > 0
+            case Some(OffsetSourcePosition(f, i, Some(row), Some(col))) => i should be > 0
           }
         }
     }

--- a/core/src/it/scala/org/ensime/intg/BasicWorkflow.scala
+++ b/core/src/it/scala/org/ensime/intg/BasicWorkflow.scala
@@ -137,7 +137,7 @@ class BasicWorkflow extends EnsimeSpec
             case SymbolInfo(
               "testMethod",
               "testMethod",
-              Some(OffsetSourcePosition(`fooFile`, 114)),
+              Some(OffsetSourcePosition(`fooFile`, 114, None, None)),
               ArrowTypeInfo(
                 "(Int, String) => Int",
                 "(scala.Int, java.lang.String) => scala.Int",
@@ -154,13 +154,13 @@ class BasicWorkflow extends EnsimeSpec
           // M-.  external symbol
           project ! SymbolAtPointReq(Left(fooFile), 190)
           expectMsgPF() {
-            case SymbolInfo("Map", "Map", Some(OffsetSourcePosition(_, _)),
+            case SymbolInfo("Map", "Map", Some(OffsetSourcePosition(_, _, None, None)),
               BasicTypeInfo("Map", DeclaredAs.Object, "scala.collection.immutable.Map")) =>
           }
 
           project ! SymbolAtPointReq(Left(fooFile), 343)
           expectMsgPF() {
-            case SymbolInfo("fn", "fn", Some(OffsetSourcePosition(`fooFile`, 304)),
+            case SymbolInfo("fn", "fn", Some(OffsetSourcePosition(`fooFile`, 304, None, None)),
               api.BasicTypeInfo("(String) => Int", DeclaredAs.Trait, "(java.lang.String) => scala.Int",
                 List(
                   BasicTypeInfo("String", DeclaredAs.Class, "java.lang.String"),
@@ -170,7 +170,7 @@ class BasicWorkflow extends EnsimeSpec
 
           project ! SymbolAtPointReq(Left(barFile), 150)
           expectMsgPF() {
-            case SymbolInfo("apply", "apply", Some(OffsetSourcePosition(`barFile`, 59)),
+            case SymbolInfo("apply", "apply", Some(OffsetSourcePosition(`barFile`, 59, None, None)),
               ArrowTypeInfo("(String, Int) => Foo", "(java.lang.String, scala.Int) => org.example.Bar.Foo",
                 BasicTypeInfo("Foo", DeclaredAs.Class, "org.example.Bar.Foo"),
                 List(ParamSectionInfo(
@@ -182,7 +182,7 @@ class BasicWorkflow extends EnsimeSpec
 
           project ! SymbolAtPointReq(Left(barFile), 193)
           expectMsgPF() {
-            case SymbolInfo("copy", "copy", Some(OffsetSourcePosition(`barFile`, 59)),
+            case SymbolInfo("copy", "copy", Some(OffsetSourcePosition(`barFile`, 59, None, None)),
               ArrowTypeInfo("(String, Int) => Foo", "(java.lang.String, scala.Int) => org.example.Bar.Foo",
                 BasicTypeInfo("Foo", DeclaredAs.Class, "org.example.Bar.Foo"),
                 List(ParamSectionInfo(
@@ -194,7 +194,7 @@ class BasicWorkflow extends EnsimeSpec
 
           project ! SymbolAtPointReq(Left(fooFile), 600)
           expectMsgPF() {
-            case SymbolInfo("poly", "poly", Some(OffsetSourcePosition(`fooFile`, 548)),
+            case SymbolInfo("poly", "poly", Some(OffsetSourcePosition(`fooFile`, 548, None, None)),
               ArrowTypeInfo("(A, B) => (A, B)", "(org.example.WithPolyMethod.A, org.example.WithPolyMethod.B) => (org.example.WithPolyMethod.A, org.example.WithPolyMethod.B)",
                 api.BasicTypeInfo(
                   "(A, B)", DeclaredAs.Class, "(org.example.WithPolyMethod.A, org.example.WithPolyMethod.B)",

--- a/core/src/main/scala/org/ensime/model/ModelBuilders.scala
+++ b/core/src/main/scala/org/ensime/model/ModelBuilders.scala
@@ -335,8 +335,10 @@ object OffsetSourcePositionHelper {
 
   def fromPosition(p: Position): Option[OffsetSourcePosition] = p match {
     case NoPosition => None
-    case realPos =>
-      Some(new OffsetSourcePosition(File(realPos.source.file.path).canon, realPos.point))
+    case realPos => {
+      Some(new OffsetSourcePosition(File(realPos.source.file.path).canon, realPos.point,
+        Some(realPos.line), Some(realPos.column)))
+    }
   }
 }
 
@@ -353,4 +355,3 @@ object BasicTypeInfo {
       case _ => None
     }
 }
-


### PR DESCRIPTION
This isn't really a serious pull REQUEST at this point, but it felt like the easiest way to discuss code.

So the change to just add row, col seems pretty minor, but I guess protocol is a problem since we have named ADT:s for this. Probably doesn't make sense to add row, col to something named OffsetSourcePosition like I did here, but I wanted to try it all the way and code navigation now works in vscode for me.

I'm not too sure about how expensive package scala.reflect.internal.util.Position#calculateColumn() is either. Might be a problem if this is too expensive and used unnecessarily for clients that are offset based?
