### PR TITLE
[WIP] Use reverse lookups in find usages and refactor rename

### DIFF
--- a/core/src/it/scala/org/ensime/indexer/SearchServiceSpec.scala
+++ b/core/src/it/scala/org/ensime/indexer/SearchServiceSpec.scala
@@ -329,6 +329,11 @@ class SearchServiceSpec extends EnsimeSpec
     )
   }
 
+  it should "detect uses of outer classes in inner class calls" in withSearchService { implicit service =>
+    val barUsages = findUsages("org.example.Bar$")
+    barUsages.map(mn => unifyMethodName(mn.toSearchResult)) should contain("Method org.example.Qux#<init>(): org.example.Qux")
+  }
+
   "scala names" should "be correctly resolved for overloaded methods" in withSearchService { implicit service =>
     val hits = service.searchClassesMethods(List("Overloads", "foo"), 100).filter(hit => hit.declAs == DeclaredAs.Method && hit.fqn.contains("Overloads.foo"))
     hits.length should ===(5)

--- a/core/src/it/scala/org/ensime/intg/BasicWorkflow.scala
+++ b/core/src/it/scala/org/ensime/intg/BasicWorkflow.scala
@@ -128,6 +128,11 @@ class BasicWorkflow extends EnsimeSpec
             ERangePosition(`packageFilePath`, 94, 80, 104)
           )
 
+          asyncHelper.fishForMessage() {
+            case FullTypeCheckCompleteEvent => true
+            case _ => false
+          }
+
           // note that the line numbers appear to have been stripped from the
           // scala library classfiles, so offset/line comes out as zero unless
           // loaded by the pres compiler
@@ -240,6 +245,7 @@ class BasicWorkflow extends EnsimeSpec
             BasicTypeInfo("Test2", DeclaredAs.Object, "org.example.Test2"),
             BasicTypeInfo("WithPolyMethod", DeclaredAs.Object, "org.example.WithPolyMethod"),
             BasicTypeInfo("WithPolyMethod", DeclaredAs.Class, "org.example.WithPolyMethod"),
+            BasicTypeInfo("package", DeclaredAs.Object, "org.example.package"),
             BasicTypeInfo("package", DeclaredAs.Object, "org.example.package")
           )
 

--- a/core/src/it/scala/org/ensime/intg/BasicWorkflow.scala
+++ b/core/src/it/scala/org/ensime/intg/BasicWorkflow.scala
@@ -119,9 +119,13 @@ class BasicWorkflow extends EnsimeSpec
 
           asyncHelper.expectMsg(FullTypeCheckCompleteEvent)
 
+          val packageFile = sourceRoot / "org/example/package.scala"
+          val packageFilePath = packageFile.getAbsolutePath
           project ! UsesOfSymbolAtPointReq(Left(fooFile), 119) // point on testMethod
           expectMsgType[ERangePositions].positions should contain theSameElementsAs List(
-            ERangePosition(`fooFilePath`, 114, 110, 172), ERangePosition(`fooFilePath`, 273, 269, 283)
+            ERangePosition(`fooFilePath`, 114, 110, 172),
+            ERangePosition(`fooFilePath`, 273, 269, 283),
+            ERangePosition(`packageFilePath`, 94, 80, 104)
           )
 
           // note that the line numbers appear to have been stripped from the

--- a/core/src/it/scala/org/ensime/intg/ReverseLookupsSpec.scala
+++ b/core/src/it/scala/org/ensime/intg/ReverseLookupsSpec.scala
@@ -9,8 +9,6 @@ import org.ensime.util.EnsimeSpec
 import org.ensime.util.ensimefile.Implicits.DefaultCharset
 import org.ensime.util.file._
 
-import scala.util.Properties
-
 class ReverseLookupsSpec extends EnsimeSpec
     with IsolatedEnsimeConfigFixture
     with IsolatedTestKitFixture
@@ -37,28 +35,6 @@ class ReverseLookupsSpec extends EnsimeSpec
         )
       }
     }
-  }
-
-  it should "only search files loaded into pres. compiler when reverse lookups are turned off" in {
-    try {
-      Properties.setProp("ensime.index.no.reverse.lookups", "true")
-      withEnsimeConfig { implicit config =>
-        withTestKit { implicit testKit =>
-          withProject { (project, asyncHelper) =>
-            import testKit._
-            val sourceRoot = scalaMain(config)
-            val fooFile = sourceRoot / "org/example/Foo.scala"
-
-            project ! UsesOfSymbolAtPointReq(Left(fooFile), 119)
-            val uses = expectMsgType[ERangePositions]
-            uses.positions.map(usage => (s"${File(usage.file).getName}", usage.offset, usage.start, usage.end)) should contain theSameElementsAs List(
-              ("Foo.scala", 114, 110, 172),
-              ("Foo.scala", 273, 269, 283)
-            )
-          }
-        }
-      }
-    } finally Properties.clearProp("ensime.index.no.reverse.lookups")
   }
 
   "Refactor Rename" should "make use of reverse lookups information" in withEnsimeConfig { implicit config =>
@@ -102,43 +78,5 @@ class ReverseLookupsSpec extends EnsimeSpec
         }
       }
     }
-  }
-
-  it should "only search files loaded into pres. compiler when reverse lookups are turned off" in {
-    try {
-      Properties.setProp("ensime.index.no.reverse.lookups", "true")
-      withEnsimeConfig { implicit config =>
-        withTestKit { implicit testKit =>
-          withProject { (project, asyncHelper) =>
-            import testKit._
-            val sourceRoot = scalaMain(config)
-            val fooFile = sourceRoot / "org/example/Foo.scala"
-
-            project ! RefactorReq(1234, RenameRefactorDesc("notATestMethod", fooFile, 119, 119), interactive = false)
-            expectMsgPF() {
-              case response @ RefactorDiffEffect(1234, RefactorType.Rename, diff) =>
-                val relevantExpectedPartFoo =
-                  s"""|@@ -9,3 +9,3 @@
-                      |   class Foo extends Bar {
-                      |-    def testMethod(i: Int, s: String) = {
-                      |+    def notATestMethod(i: Int, s: String) = {
-                      |       i + s.length
-                      |@@ -16,3 +16,3 @@
-                      |   println("Hello, " + foo.x)
-                      |-  println(foo.testMethod(7, "seven"))
-                      |+  println(foo.notATestMethod(7, "seven"))
-                      | 
-                      |""".stripMargin
-
-                val diffContents = diff.canon.readString()
-                val expectedContents = expectedDiffContent(fooFile.getPath, relevantExpectedPartFoo)
-
-                if (diffContents == expectedContents) true
-                else fail(s"Different diff content than expected. \n Actual content: '$diffContents' \n ExpectedRelevantContent: '$expectedContents'")
-            }
-          }
-        }
-      }
-    } finally Properties.clearProp("ensime.index.no.reverse.lookups")
   }
 }

--- a/core/src/it/scala/org/ensime/intg/ReverseLookupsSpec.scala
+++ b/core/src/it/scala/org/ensime/intg/ReverseLookupsSpec.scala
@@ -27,10 +27,6 @@ class ReverseLookupsSpec extends EnsimeSpec
         val sourceRoot = scalaMain(config)
         val fooFile = sourceRoot / "org/example/Foo.scala"
 
-        project ! TypecheckFilesReq(List(Left(fooFile)))
-        expectMsg(VoidResponse)
-        asyncHelper.expectMsg(FullTypeCheckCompleteEvent)
-
         // uses of `testMethod`
         project ! UsesOfSymbolAtPointReq(Left(fooFile), 119)
         val uses = expectMsgType[ERangePositions]
@@ -52,10 +48,6 @@ class ReverseLookupsSpec extends EnsimeSpec
           val sourceRoot = scalaMain(config)
           val fooFile = sourceRoot / "org/example/Foo.scala"
 
-          project ! TypecheckFilesReq(List(Left(fooFile)))
-          expectMsg(VoidResponse)
-          asyncHelper.expectMsg(FullTypeCheckCompleteEvent)
-
           project ! UsesOfSymbolAtPointReq(Left(fooFile), 119)
           val uses = expectMsgType[ERangePositions]
           uses.positions.map(usage => (s"${File(usage.file).getName}", usage.offset, usage.start, usage.end)) should contain theSameElementsAs List(
@@ -74,10 +66,6 @@ class ReverseLookupsSpec extends EnsimeSpec
         val sourceRoot = scalaMain(config)
         val fooFile = sourceRoot / "org/example/Foo.scala"
         val packageFile = sourceRoot / "org/example/package.scala"
-
-        project ! TypecheckFilesReq(List(Left(fooFile)))
-        expectMsg(VoidResponse)
-        asyncHelper.expectMsg(FullTypeCheckCompleteEvent)
 
         project ! RefactorReq(1234, RenameRefactorDesc("notATestMethod", fooFile, 119, 119), interactive = false)
         expectMsgPF() {
@@ -122,11 +110,6 @@ class ReverseLookupsSpec extends EnsimeSpec
           import testKit._
           val sourceRoot = scalaMain(config)
           val fooFile = sourceRoot / "org/example/Foo.scala"
-          val packageFile = sourceRoot / "org/example/package.scala"
-
-          project ! TypecheckFilesReq(List(Left(fooFile)))
-          expectMsg(VoidResponse)
-          asyncHelper.expectMsg(FullTypeCheckCompleteEvent)
 
           project ! RefactorReq(1234, RenameRefactorDesc("notATestMethod", fooFile, 119, 119), interactive = false)
           expectMsgPF() {

--- a/core/src/it/scala/org/ensime/intg/ReverseLookupsSpec.scala
+++ b/core/src/it/scala/org/ensime/intg/ReverseLookupsSpec.scala
@@ -1,0 +1,156 @@
+// Copyright: 2010 - 2016 https://github.com/ensime/ensime-server/graphs
+// License: http://www.gnu.org/licenses/gpl-3.0.en.html
+package org.ensime.intg
+
+import org.ensime.api._
+import org.ensime.core.RefactoringHandlerTestUtils
+import org.ensime.fixture.{ IsolatedEnsimeConfigFixture, _ }
+import org.ensime.util.EnsimeSpec
+import org.ensime.util.file._
+
+import scala.util.Properties
+
+class ReverseLookupsSpec extends EnsimeSpec
+    with IsolatedEnsimeConfigFixture
+    with IsolatedTestKitFixture
+    with IsolatedProjectFixture
+    with IsolatedAnalyzerFixture
+    with RefactoringHandlerTestUtils {
+
+  override def original: EnsimeConfig = EnsimeConfigFixture.SimpleTestProject
+
+  "FindUsages" should "find usages using reverse lookups info" in withEnsimeConfig { implicit config =>
+    withTestKit { implicit testKit =>
+      withProject { (project, asyncHelper) =>
+        import testKit._
+        val sourceRoot = scalaMain(config)
+        val fooFile = sourceRoot / "org/example/Foo.scala"
+
+        project ! TypecheckFilesReq(List(Left(fooFile)))
+        expectMsg(VoidResponse)
+        asyncHelper.expectMsg(FullTypeCheckCompleteEvent)
+
+        // uses of `testMethod`
+        project ! UsesOfSymbolAtPointReq(Left(fooFile), 119)
+        val uses = expectMsgType[ERangePositions]
+        uses.positions.map(usage => (s"${usage.file.split("/").last}", usage.offset, usage.start, usage.end)) should contain theSameElementsAs List(
+          ("Foo.scala", 114, 110, 172),
+          ("Foo.scala", 273, 269, 283),
+          ("package.scala", 94, 80, 104)
+        )
+      }
+    }
+  }
+
+  it should "only search files loaded into pres. compiler when reverse lookups are turned off" in withEnsimeConfig { implicit config =>
+    withTestKit { implicit testKit =>
+      withProject { (project, asyncHelper) =>
+        try {
+          Properties.setProp("ensime.index.no.reverse.lookups", "true")
+          import testKit._
+          val sourceRoot = scalaMain(config)
+          val fooFile = sourceRoot / "org/example/Foo.scala"
+
+          project ! TypecheckFilesReq(List(Left(fooFile)))
+          expectMsg(VoidResponse)
+          asyncHelper.expectMsg(FullTypeCheckCompleteEvent)
+
+          project ! UsesOfSymbolAtPointReq(Left(fooFile), 119)
+          val uses = expectMsgType[ERangePositions]
+          uses.positions.map(usage => (s"${usage.file.split("/").last}", usage.offset, usage.start, usage.end)) should contain theSameElementsAs List(
+            ("Foo.scala", 114, 110, 172),
+            ("Foo.scala", 273, 269, 283)
+          )
+        } finally Properties.clearProp("ensime.index.no.reverse.lookups")
+      }
+    }
+  }
+
+  "Refactor Rename" should "make use of reverse lookups information" in withEnsimeConfig { implicit config =>
+    withTestKit { implicit testKit =>
+      withProject { (project, asyncHelper) =>
+        import testKit._
+        val sourceRoot = scalaMain(config)
+        val fooFile = sourceRoot / "org/example/Foo.scala"
+        val packageFile = sourceRoot / "org/example/package.scala"
+
+        project ! TypecheckFilesReq(List(Left(fooFile)))
+        expectMsg(VoidResponse)
+        asyncHelper.expectMsg(FullTypeCheckCompleteEvent)
+
+        project ! RefactorReq(1234, RenameRefactorDesc("notATestMethod", fooFile, 119, 119), interactive = false)
+        expectMsgPF() {
+          case response @ RefactorDiffEffect(1234, RefactorType.Rename, diff) =>
+            val relevantExpectedPartFoo =
+              s"""|@@ -9,3 +9,3 @@
+                    |   class Foo extends Bar {
+                    |-    def testMethod(i: Int, s: String) = {
+                    |+    def notATestMethod(i: Int, s: String) = {
+                    |       i + s.length
+                    |@@ -16,3 +16,3 @@
+                    |   println("Hello, " + foo.x)
+                    |-  println(foo.testMethod(7, "seven"))
+                    |+  println(foo.notATestMethod(7, "seven"))
+                    | 
+                    |""".stripMargin
+
+            val relevantExpectedPartPackage =
+              s"""|@@ -6,3 +6,3 @@
+                    | 
+                    |-  new Foo.Foo().testMethod(1, "")
+                    |+  new Foo.Foo().notATestMethod(1, "")
+                    | }
+                    |""".stripMargin
+
+            val diffContents = diff.canon.readString()
+            val expectedContentsFoo = expectedDiffContent(fooFile.getPath, relevantExpectedPartFoo)
+            val expectedContentsPackage = expectedDiffContent(packageFile.getPath, relevantExpectedPartPackage)
+            val expectedContents = s"$expectedContentsFoo\n$expectedContentsPackage"
+            if (diffContents == expectedContents) true
+            else fail(s"Different diff content than expected. \n Actual content: '$diffContents' \n ExpectedRelevantContent: '$expectedContents'")
+        }
+      }
+    }
+  }
+
+  it should "only search files loaded into pres. compiler when reverse lookups are turned off" in withEnsimeConfig { implicit config =>
+    withTestKit { implicit testKit =>
+      withProject { (project, asyncHelper) =>
+        try {
+          Properties.setProp("ensime.index.no.reverse.lookups", "true")
+          import testKit._
+          val sourceRoot = scalaMain(config)
+          val fooFile = sourceRoot / "org/example/Foo.scala"
+          val packageFile = sourceRoot / "org/example/package.scala"
+
+          project ! TypecheckFilesReq(List(Left(fooFile)))
+          expectMsg(VoidResponse)
+          asyncHelper.expectMsg(FullTypeCheckCompleteEvent)
+
+          project ! RefactorReq(1234, RenameRefactorDesc("notATestMethod", fooFile, 119, 119), interactive = false)
+          expectMsgPF() {
+            case response @ RefactorDiffEffect(1234, RefactorType.Rename, diff) =>
+              val relevantExpectedPartFoo =
+                s"""|@@ -9,3 +9,3 @@
+                    |   class Foo extends Bar {
+                    |-    def testMethod(i: Int, s: String) = {
+                    |+    def notATestMethod(i: Int, s: String) = {
+                    |       i + s.length
+                    |@@ -16,3 +16,3 @@
+                    |   println("Hello, " + foo.x)
+                    |-  println(foo.testMethod(7, "seven"))
+                    |+  println(foo.notATestMethod(7, "seven"))
+                    | 
+                      |""".stripMargin
+
+              val diffContents = diff.canon.readString()
+              val expectedContents = expectedDiffContent(fooFile.getPath, relevantExpectedPartFoo)
+
+              if (diffContents == expectedContents) true
+              else fail(s"Different diff content than expected. \n Actual content: '$diffContents' \n ExpectedRelevantContent: '$expectedContents'")
+          }
+        } finally Properties.clearProp("ensime.index.no.reverse.lookups")
+      }
+    }
+  }
+}

--- a/core/src/it/scala/org/ensime/intg/ReverseLookupsSpec.scala
+++ b/core/src/it/scala/org/ensime/intg/ReverseLookupsSpec.scala
@@ -34,7 +34,7 @@ class ReverseLookupsSpec extends EnsimeSpec
         // uses of `testMethod`
         project ! UsesOfSymbolAtPointReq(Left(fooFile), 119)
         val uses = expectMsgType[ERangePositions]
-        uses.positions.map(usage => (s"${usage.file.split("/").last}", usage.offset, usage.start, usage.end)) should contain theSameElementsAs List(
+        uses.positions.map(usage => (s"${File(usage.file).getName}", usage.offset, usage.start, usage.end)) should contain theSameElementsAs List(
           ("Foo.scala", 114, 110, 172),
           ("Foo.scala", 273, 269, 283),
           ("package.scala", 94, 80, 104)
@@ -58,7 +58,7 @@ class ReverseLookupsSpec extends EnsimeSpec
 
           project ! UsesOfSymbolAtPointReq(Left(fooFile), 119)
           val uses = expectMsgType[ERangePositions]
-          uses.positions.map(usage => (s"${usage.file.split("/").last}", usage.offset, usage.start, usage.end)) should contain theSameElementsAs List(
+          uses.positions.map(usage => (s"${File(usage.file).getName}", usage.offset, usage.start, usage.end)) should contain theSameElementsAs List(
             ("Foo.scala", 114, 110, 172),
             ("Foo.scala", 273, 269, 283)
           )

--- a/core/src/it/scala/org/ensime/intg/ReverseLookupsSpec.scala
+++ b/core/src/it/scala/org/ensime/intg/ReverseLookupsSpec.scala
@@ -39,24 +39,26 @@ class ReverseLookupsSpec extends EnsimeSpec
     }
   }
 
-  it should "only search files loaded into pres. compiler when reverse lookups are turned off" in withEnsimeConfig { implicit config =>
-    withTestKit { implicit testKit =>
-      withProject { (project, asyncHelper) =>
-        try {
-          Properties.setProp("ensime.index.no.reverse.lookups", "true")
-          import testKit._
-          val sourceRoot = scalaMain(config)
-          val fooFile = sourceRoot / "org/example/Foo.scala"
+  it should "only search files loaded into pres. compiler when reverse lookups are turned off" in {
+    try {
+      Properties.setProp("ensime.index.no.reverse.lookups", "true")
+      withEnsimeConfig { implicit config =>
+        withTestKit { implicit testKit =>
+          withProject { (project, asyncHelper) =>
+            import testKit._
+            val sourceRoot = scalaMain(config)
+            val fooFile = sourceRoot / "org/example/Foo.scala"
 
-          project ! UsesOfSymbolAtPointReq(Left(fooFile), 119)
-          val uses = expectMsgType[ERangePositions]
-          uses.positions.map(usage => (s"${File(usage.file).getName}", usage.offset, usage.start, usage.end)) should contain theSameElementsAs List(
-            ("Foo.scala", 114, 110, 172),
-            ("Foo.scala", 273, 269, 283)
-          )
-        } finally Properties.clearProp("ensime.index.no.reverse.lookups")
+            project ! UsesOfSymbolAtPointReq(Left(fooFile), 119)
+            val uses = expectMsgType[ERangePositions]
+            uses.positions.map(usage => (s"${File(usage.file).getName}", usage.offset, usage.start, usage.end)) should contain theSameElementsAs List(
+              ("Foo.scala", 114, 110, 172),
+              ("Foo.scala", 273, 269, 283)
+            )
+          }
+        }
       }
-    }
+    } finally Properties.clearProp("ensime.index.no.reverse.lookups")
   }
 
   "Refactor Rename" should "make use of reverse lookups information" in withEnsimeConfig { implicit config =>
@@ -102,39 +104,41 @@ class ReverseLookupsSpec extends EnsimeSpec
     }
   }
 
-  it should "only search files loaded into pres. compiler when reverse lookups are turned off" in withEnsimeConfig { implicit config =>
-    withTestKit { implicit testKit =>
-      withProject { (project, asyncHelper) =>
-        try {
-          Properties.setProp("ensime.index.no.reverse.lookups", "true")
-          import testKit._
-          val sourceRoot = scalaMain(config)
-          val fooFile = sourceRoot / "org/example/Foo.scala"
+  it should "only search files loaded into pres. compiler when reverse lookups are turned off" in {
+    try {
+      Properties.setProp("ensime.index.no.reverse.lookups", "true")
+      withEnsimeConfig { implicit config =>
+        withTestKit { implicit testKit =>
+          withProject { (project, asyncHelper) =>
+            import testKit._
+            val sourceRoot = scalaMain(config)
+            val fooFile = sourceRoot / "org/example/Foo.scala"
 
-          project ! RefactorReq(1234, RenameRefactorDesc("notATestMethod", fooFile, 119, 119), interactive = false)
-          expectMsgPF() {
-            case response @ RefactorDiffEffect(1234, RefactorType.Rename, diff) =>
-              val relevantExpectedPartFoo =
-                s"""|@@ -9,3 +9,3 @@
-                    |   class Foo extends Bar {
-                    |-    def testMethod(i: Int, s: String) = {
-                    |+    def notATestMethod(i: Int, s: String) = {
-                    |       i + s.length
-                    |@@ -16,3 +16,3 @@
-                    |   println("Hello, " + foo.x)
-                    |-  println(foo.testMethod(7, "seven"))
-                    |+  println(foo.notATestMethod(7, "seven"))
-                    | 
+            project ! RefactorReq(1234, RenameRefactorDesc("notATestMethod", fooFile, 119, 119), interactive = false)
+            expectMsgPF() {
+              case response @ RefactorDiffEffect(1234, RefactorType.Rename, diff) =>
+                val relevantExpectedPartFoo =
+                  s"""|@@ -9,3 +9,3 @@
+                      |   class Foo extends Bar {
+                      |-    def testMethod(i: Int, s: String) = {
+                      |+    def notATestMethod(i: Int, s: String) = {
+                      |       i + s.length
+                      |@@ -16,3 +16,3 @@
+                      |   println("Hello, " + foo.x)
+                      |-  println(foo.testMethod(7, "seven"))
+                      |+  println(foo.notATestMethod(7, "seven"))
+                      | 
                       |""".stripMargin
 
-              val diffContents = diff.canon.readString()
-              val expectedContents = expectedDiffContent(fooFile.getPath, relevantExpectedPartFoo)
+                val diffContents = diff.canon.readString()
+                val expectedContents = expectedDiffContent(fooFile.getPath, relevantExpectedPartFoo)
 
-              if (diffContents == expectedContents) true
-              else fail(s"Different diff content than expected. \n Actual content: '$diffContents' \n ExpectedRelevantContent: '$expectedContents'")
+                if (diffContents == expectedContents) true
+                else fail(s"Different diff content than expected. \n Actual content: '$diffContents' \n ExpectedRelevantContent: '$expectedContents'")
+            }
           }
-        } finally Properties.clearProp("ensime.index.no.reverse.lookups")
+        }
       }
-    }
+    } finally Properties.clearProp("ensime.index.no.reverse.lookups")
   }
 }

--- a/core/src/it/scala/org/ensime/intg/ReverseLookupsSpec.scala
+++ b/core/src/it/scala/org/ensime/intg/ReverseLookupsSpec.scala
@@ -6,6 +6,7 @@ import org.ensime.api._
 import org.ensime.core.RefactoringHandlerTestUtils
 import org.ensime.fixture.{ IsolatedEnsimeConfigFixture, _ }
 import org.ensime.util.EnsimeSpec
+import org.ensime.util.ensimefile.Implicits.DefaultCharset
 import org.ensime.util.file._
 
 import scala.util.Properties

--- a/core/src/main/scala/org/ensime/core/Analyzer.scala
+++ b/core/src/main/scala/org/ensime/core/Analyzer.scala
@@ -182,7 +182,7 @@ class Analyzer(
       config.modules get (moduleName) foreach {
         case module =>
           val files: List[SourceFileInfo] = module.scalaSourceFiles.map(SourceFileInfo(_, None, None))(breakOut)
-          sender ! handleReloadFiles(files)
+          sender ! scalaCompiler.handleReloadFiles(files)
       }
     case UnloadModuleReq(moduleName) =>
       config.modules get (moduleName) foreach {
@@ -192,9 +192,9 @@ class Analyzer(
           sender ! VoidResponse
       }
     case TypecheckFileReq(fileInfo) =>
-      sender ! handleReloadFiles(List(fileInfo))
+      sender ! scalaCompiler.handleReloadFiles(List(fileInfo))
     case TypecheckFilesReq(files) =>
-      sender ! handleReloadFiles(files.map(toSourceFileInfo))
+      sender ! scalaCompiler.handleReloadFiles(files.map(toSourceFileInfo))
     case req: RefactorReq =>
       sender ! handleRefactorRequest(req)
     case CompletionsReq(fileInfo, point, maxResults, caseSens, _reload) =>
@@ -205,8 +205,7 @@ class Analyzer(
     case UsesOfSymbolAtPointReq(file, point) =>
       sender ! withExisting(file) {
         val p = pos(file, point)
-        scalaCompiler.askLoadedTyped(p.source)
-        val uses = scalaCompiler.askUsesOfSymAtPoint(p)
+        val uses = scalaCompiler.askUsesOfSymAtPos(p)
         ERangePositions(uses.map(ERangePositionHelper.fromRangePosition))
       }
     case PackageMemberCompletionReq(path: String, prefix: String) =>

--- a/core/src/main/scala/org/ensime/core/Analyzer.scala
+++ b/core/src/main/scala/org/ensime/core/Analyzer.scala
@@ -181,7 +181,7 @@ class Analyzer(
       //consider the case of a project with no modules
       config.modules get (moduleName) foreach {
         module =>
-          val files: List[SourceFileInfo] = module.scalaSourceFiles.map(SourceFileInfo(_, None, None))(breakOut)
+          val files: Set[SourceFileInfo] = module.scalaSourceFiles.map(SourceFileInfo(_, None, None))(breakOut)
           sender ! scalaCompiler.handleReloadFiles(files)
       }
     case UnloadModuleReq(moduleName) =>
@@ -192,9 +192,9 @@ class Analyzer(
           sender ! VoidResponse
       }
     case TypecheckFileReq(fileInfo) =>
-      sender ! scalaCompiler.handleReloadFiles(List(fileInfo))
+      sender ! scalaCompiler.handleReloadFiles(Set(fileInfo))
     case TypecheckFilesReq(files) =>
-      sender ! scalaCompiler.handleReloadFiles(files.map(toSourceFileInfo))
+      sender ! scalaCompiler.handleReloadFiles(files.map(toSourceFileInfo)(breakOut))
     case req: RefactorReq =>
       sender ! handleRefactorRequest(req)
     case CompletionsReq(fileInfo, point, maxResults, caseSens, _reload) =>

--- a/core/src/main/scala/org/ensime/core/Refactoring.scala
+++ b/core/src/main/scala/org/ensime/core/Refactoring.scala
@@ -225,13 +225,13 @@ trait RefactoringImpl { self: RichPresentationCompiler =>
           val pos = if (start == end) new OffsetPosition(sourceFile, start)
           else new RangePosition(sourceFile, start, start, end)
           val symbol = symbolAt(pos)
-          val files = sourceFile :: (symbol match {
+          val files = (symbol match {
             case None => Nil
             case Some(sym) =>
               usesOfSym(sym).map(f => createSourceFile(f.file.getPath))
-          })
+          }).toSet + sourceFile
           reloadAndTypeFiles(files)
-          doRename(procId, tpe, newName, file, start, end, files.map(_.path)(collection.breakOut))
+          doRename(procId, tpe, newName, file, start, end, files.map(_.path))
         case ExtractMethodRefactorDesc(methodName, file, start, end) =>
           reloadAndType(file)
           doExtractMethod(procId, tpe, methodName, file, start, end)

--- a/core/src/main/scala/org/ensime/core/RichPresentationCompiler.scala
+++ b/core/src/main/scala/org/ensime/core/RichPresentationCompiler.scala
@@ -38,7 +38,6 @@
  */
 package org.ensime.core
 
-import java.io.File
 import java.nio.charset.Charset
 
 import scala.collection.mutable
@@ -56,7 +55,7 @@ import org.ensime.api._
 import org.ensime.config._
 import org.ensime.indexer._
 import org.ensime.model._
-import org.ensime.util.file._
+import org.ensime.util.file.{ File, _ }
 import org.ensime.vfs._
 import org.slf4j.LoggerFactory
 
@@ -100,6 +99,7 @@ trait RichCompilerControl extends CompilerControl with RefactoringControl with C
   // exposed for testing
   def askSymbolFqn(p: Position): Option[FullyQualifiedName] =
     askOption(symbolAt(p).map(toFqn)).flatten
+  def askSymbolFqn(s: Symbol): FullyQualifiedName = toFqn(s)
   def askTypeFqn(p: Position): Option[FullyQualifiedName] =
     askOption(typeAt(p).map { tpe => toFqn(tpe.typeSymbol) }).flatten
   def askSymbolByScalaName(name: String, declaredAs: Option[DeclaredAs] = None): Option[Symbol] =
@@ -110,7 +110,6 @@ trait RichCompilerControl extends CompilerControl with RefactoringControl with C
     askOption(symbolAt(p)).flatten
   def askTypeSymbolAt(p: Position): Option[Symbol] =
     askOption(typeAt(p).map { tpe => tpe.typeSymbol }).flatten
-
   ////////////////////////////////////////////////////////////////////////////////
 
   def askSymbolInfoAt(p: Position): Option[SymbolInfo] =
@@ -200,8 +199,63 @@ trait RichCompilerControl extends CompilerControl with RefactoringControl with C
   def askReloadAndTypeFiles(files: Iterable[SourceFile]) =
     askOption(reloadAndTypeFiles(files))
 
-  def askUsesOfSymAtPoint(p: Position): List[RangePosition] =
-    askOption(usesOfSymbolAtPoint(p).toList).getOrElse(List.empty)
+  def askUsesOfSymAtPos(pos: Position): List[RangePosition] = {
+    val symbol = askSymbolAt(pos)
+    symbol match {
+      case None => Nil
+      case Some(sym) =>
+        val source = pos.source
+        val loadedFiles = loadUsesOfSym(sym)
+        askLoadedTyped(source)
+        val files = loadedFiles.map(_.getPath) + source.file.path
+        askUsesOfSym(sym, files)
+    }
+  }
+
+  def askUsesOfSym(sym: Symbol, files: collection.Set[String]): List[RangePosition] =
+    askOption(usesOfSymbol(sym.pos, files).toList).getOrElse(List.empty)
+
+  def handleReloadFiles(files: List[SourceFileInfo]): RpcResponse = {
+    import org.ensime.util.FileUtils
+    val (existing, missingFiles) = files.partition(FileUtils.exists)
+    if (missingFiles.nonEmpty) {
+      val missingFilePaths = missingFiles.map { f => "\"" + f.file + "\"" }.mkString(",")
+      EnsimeServerError(s"file(s): $missingFilePaths do not exist")
+    } else {
+      val (javas, scalas) = existing.partition(_.file.getName.endsWith(".java"))
+      if (scalas.nonEmpty) {
+        val sourceFiles = scalas.map(createSourceFile)
+        askReloadFiles(sourceFiles)
+        askNotifyWhenReady()
+      }
+      VoidResponse
+    }
+  }
+
+  import org.ensime.util.file.File
+  def loadUsesOfSym(sym: Symbol): collection.immutable.Set[File] = {
+    val files = usesOfSym(sym)
+    handleReloadFiles(files)
+    files.map(_.file)(collection.breakOut)
+  }
+
+  def usesOfSym(sym: Symbol): List[SourceFileInfo] = {
+    import scala.concurrent.Await
+    import scala.concurrent.duration.Duration
+
+    val noReverseLookups = search.noReverseLookups
+    if (noReverseLookups) {
+      Nil
+    } else {
+      val fqn = askSymbolFqn(sym)
+      val usages = Await.result(search.findUsages(fqn.fqnString), Duration.Inf)
+      val files: List[SourceFileInfo] = usages.flatMap { usage =>
+        val source = usage.source
+        source.map(s => SourceFileInfo(File(s.replaceFirst("file:", "")), None, None))
+      }(collection.breakOut)
+      files
+    }
+  }
 
   // force the full path of Set because nsc appears to have a conflicting Set....
   def askSymbolDesignationsInRegion(p: RangePosition, tpes: List[SourceSymbol]): SymbolDesignations =
@@ -510,18 +564,19 @@ class RichPresentationCompiler(
     wrapLinkPos(sym, source)
   }
 
-  protected def usesOfSymbolAtPoint(point: Position): Iterable[RangePosition] = {
-    symbolAt(point) match {
+  protected def usesOfSymbol(pos: Position, files: collection.Set[String]): Iterable[RangePosition] = {
+    symbolAt(pos) match {
       case Some(s) =>
         class CompilerGlobalIndexes extends GlobalIndexes {
           val global = RichPresentationCompiler.this
           val sym = s.asInstanceOf[global.Symbol]
-          val cuIndexes = this.global.unitOfFile.values.map { u =>
-            CompilationUnitIndex(u.body)
+          val cuIndexes = this.global.unitOfFile.collect {
+            case (file, unit) if search.noReverseLookups || files.contains(file.file.getPath) =>
+              CompilationUnitIndex(unit.body)
           }
           val index = GlobalIndex(cuIndexes.toList)
-          val result = index.occurences(sym).map {
-            _.pos match {
+          val result = index.occurences(sym).map { r =>
+            r.pos match {
               case p: RangePosition => p
               case p =>
                 new RangePosition(
@@ -532,7 +587,7 @@ class RichPresentationCompiler(
         }
         val gi = new CompilerGlobalIndexes
         gi.result
-      case None => List.empty
+      case None => Nil
     }
   }
 

--- a/core/src/main/scala/org/ensime/core/RichPresentationCompiler.scala
+++ b/core/src/main/scala/org/ensime/core/RichPresentationCompiler.scala
@@ -56,6 +56,7 @@ import org.ensime.config._
 import org.ensime.indexer._
 import org.ensime.model._
 import org.ensime.util.file.{ File, _ }
+import org.ensime.util.sourcefile._
 import org.ensime.vfs._
 import org.slf4j.LoggerFactory
 
@@ -216,8 +217,7 @@ trait RichCompilerControl extends CompilerControl with RefactoringControl with C
     askOption(usesOfSymbol(sym.pos, files).toList).getOrElse(List.empty)
 
   def handleReloadFiles(files: List[SourceFileInfo]): RpcResponse = {
-    import org.ensime.util.FileUtils
-    val (existing, missingFiles) = files.partition(FileUtils.exists)
+    val (existing, missingFiles) = files.partition(_.exists())
     if (missingFiles.nonEmpty) {
       val missingFilePaths = missingFiles.map { f => "\"" + f.file + "\"" }.mkString(",")
       EnsimeServerError(s"file(s): $missingFilePaths do not exist")

--- a/core/src/main/scala/org/ensime/core/RichPresentationCompiler.scala
+++ b/core/src/main/scala/org/ensime/core/RichPresentationCompiler.scala
@@ -252,9 +252,9 @@ trait RichCompilerControl extends CompilerControl with RefactoringControl with C
       val usages = Await.result(search.findUsages(fqn.fqnString), Duration.Inf)
       val files: collection.Set[SourceFileInfo] = usages.flatMap { usage =>
         val source = usage.source
-        source.map(s => SourceFileInfo(File(s.replaceFirst("file:", "")), None, None))
+        source.map(s => SourceFileInfo(File(s.replaceFirst("file:", ""))))
       }(collection.breakOut)
-      files
+      files + SourceFileInfo(sym.sourceFile.file)
     }
   }
 

--- a/core/src/main/scala/org/ensime/indexer/ClassfileIndexer.scala
+++ b/core/src/main/scala/org/ensime/indexer/ClassfileIndexer.scala
@@ -187,6 +187,16 @@ trait ClassfileIndexer {
         case member => FieldName(ClassName.fromInternal(owner), member)
       }
 
+    private def extractClassNames(className: String): Seq[String] = {
+      if (!className.contains("anonfun")) {
+        val parts = className.split("\\$")
+        val baseName = parts.head
+        val classNames = parts.tail.foldLeft(List(baseName))((acc, p) => s"${acc.last}$$$p" :: acc)
+        val objectNames = classNames.map(_ + "$")
+        classNames ++ objectNames
+      } else Nil
+    }
+
     protected def addRefs(refs: Seq[FullyQualifiedName]): Unit = internalRefs = internalRefs ++ refs
 
     protected def addRef(ref: FullyQualifiedName): Unit = addRefs(Seq(ref))
@@ -201,17 +211,21 @@ trait ClassfileIndexer {
     override def visitMultiANewArrayInsn(desc: String, dims: Int): Unit =
       addRef(ClassName.fromDescriptor(desc))
 
-    override def visitTypeInsn(opcode: Int, desc: String): Unit =
-      addRef(ClassName.fromInternal(desc))
+    override def visitTypeInsn(opcode: Int, desc: String): Unit = {
+      val classNames = extractClassNames(desc)
+      addRefs(extractClassNames(desc).map(ClassName.fromInternal))
+    }
 
     override def visitFieldInsn(
       opcode: Int, owner: String, name: String, desc: String
     ): Unit = {
+      addRefs(extractClassNames(owner).map(ClassName.fromInternal))
       addRef(memberOrInit(owner, name))
     }
 
     override def visitTryCatchBlock(start: Label, end: Label, handler: Label, `type`: String): Unit = {
-      Option(`type`).foreach(desc => addRef(ClassName.fromInternal(desc)))
+      Option(`type`).foreach(desc =>
+        addRefs(extractClassNames(desc).map(ClassName.fromInternal)))
     }
 
     override def visitMethodInsn(

--- a/core/src/main/scala/org/ensime/indexer/ClassfileIndexer.scala
+++ b/core/src/main/scala/org/ensime/indexer/ClassfileIndexer.scala
@@ -212,7 +212,6 @@ trait ClassfileIndexer {
       addRef(ClassName.fromDescriptor(desc))
 
     override def visitTypeInsn(opcode: Int, desc: String): Unit = {
-      val classNames = extractClassNames(desc)
       addRefs(extractClassNames(desc).map(ClassName.fromInternal))
     }
 

--- a/core/src/main/scala/org/ensime/indexer/SearchService.scala
+++ b/core/src/main/scala/org/ensime/indexer/SearchService.scala
@@ -86,7 +86,7 @@ class SearchService(
   // poor man's backpressure.
   val semaphore = new Semaphore(Properties.propOrElse("ensime.index.parallel", "10").toInt, true)
 
-  private val noReverseLookups = Properties.propOrFalse("ensime.index.no.reverse.lookups")
+  def noReverseLookups: Boolean = Properties.propOrFalse("ensime.index.no.reverse.lookups")
 
   private[indexer] def getTopLevelClassFile(f: FileObject): FileObject = {
     import scala.reflect.NameTransformer

--- a/core/src/main/scala/org/ensime/indexer/SearchService.scala
+++ b/core/src/main/scala/org/ensime/indexer/SearchService.scala
@@ -86,7 +86,7 @@ class SearchService(
   // poor man's backpressure.
   val semaphore = new Semaphore(Properties.propOrElse("ensime.index.parallel", "10").toInt, true)
 
-  def noReverseLookups: Boolean = Properties.propOrFalse("ensime.index.no.reverse.lookups")
+  val noReverseLookups: Boolean = Properties.propOrFalse("ensime.index.no.reverse.lookups")
 
   private[indexer] def getTopLevelClassFile(f: FileObject): FileObject = {
     import scala.reflect.NameTransformer
@@ -464,9 +464,7 @@ class IndexingQueueActor(searchService: SearchService) extends Actor with ActorL
                 val boost = searchService.isUserFile(file)
                 val persisting = searchService.persist(syms, commitIndex = true, boost = boost)
 
-                persisting.onComplete {
-                  case _ => searchService.semaphore.release()
-                }
+                persisting.onComplete(_ => searchService.semaphore.release())
 
                 persisting.onComplete {
                   case Failure(t) =>

--- a/core/src/test/scala/org/ensime/indexer/ClassfileIndexerSpec.scala
+++ b/core/src/test/scala/org/ensime/indexer/ClassfileIndexerSpec.scala
@@ -54,6 +54,8 @@ class ClassfileIndexerSpec extends EnsimeSpec with IsolatedEnsimeVFSFixture {
         Set(
           ClassName(PackageName(Nil), "void"),
           FieldName(ClassName(PackageName(List("java", "lang")), "System"), "out"),
+          ClassName(PackageName(List("java", "lang")), "System"),
+          ClassName(PackageName(List("java", "lang")), "System$"),
           ClassName(PackageName(List("java", "io")), "PrintStream"),
           ClassName(PackageName(List("java", "lang")), "String"),
           MethodName(
@@ -70,6 +72,8 @@ class ClassfileIndexerSpec extends EnsimeSpec with IsolatedEnsimeVFSFixture {
     refs shouldBe Set(
       ClassName(PackageName(Nil), "void"),
       ClassName(PackageName(List("java", "lang")), "Object"),
+      ClassName(PackageName(List("java", "lang")), "System"),
+      ClassName(PackageName(List("java", "lang")), "System$"),
       FieldName(ClassName(PackageName(List("java", "lang")), "System"), "out"),
       ClassName(PackageName(List("java", "io")), "PrintStream"),
       MethodName(

--- a/project/EnsimeBuild.scala
+++ b/project/EnsimeBuild.scala
@@ -204,7 +204,7 @@ object EnsimeBuild {
 
   lazy val testingSimple = Project("testingSimple", file("testing/simple")) settings (
     scalacOptions in Compile := Seq(),
-    libraryDependencies += "org.scalatest" %% "scalatest" % Sensible.scalatestVersion % "test" intransitive ()
+    libraryDependencies += "org.scalatest" %% "scalatest" % Sensible.scalatestVersion % Test intransitive ()
   )
 
   lazy val testingSimpleJar = Project("testingSimpleJar", file("testing/simpleJar")).settings(
@@ -230,8 +230,8 @@ object EnsimeBuild {
 
   lazy val testingFqns = Project("testingFqns", file("testing/fqns")).settings (
     libraryDependencies ++= Sensible.shapeless(scalaVersion.value) ++ Seq(
-      "org.typelevel" %% "cats-core" % "0.6.1" % Test intransitive(),
-      "org.spire-math" %% "spire" % "0.11.0" % Test intransitive()
+      "org.typelevel" %% "cats-core" % "0.6.1" intransitive(),
+      "org.spire-math" %% "spire" % "0.11.0" intransitive()
     )
   )
 

--- a/testing/simple/src/main/scala/org/example/package.scala
+++ b/testing/simple/src/main/scala/org/example/package.scala
@@ -3,4 +3,6 @@ package org
 package object example {
   case object Blip
   case class Blop()
+
+  new Foo.Foo().testMethod(1, "")
 }


### PR DESCRIPTION
This should make it possible to only load file, which are actually affected by the refactoring, into pres. compiler. It almost works, except sometimes it doesn't (looks like a race condition or some similar error), should be all good when I fix it.