### PR TITLE
Remove flags for watch disabling and source mode from EnsimeConfig

### DIFF
--- a/api/src/main/scala/org/ensime/api/config.scala
+++ b/api/src/main/scala/org/ensime/api/config.scala
@@ -3,6 +3,7 @@
 package org.ensime.api
 
 import java.io.File
+import scala.util.Properties._
 
 // there is quite a lot of code in this file, when we clean up the
 // config file format so that a lot of these hacks are no longer
@@ -18,11 +19,7 @@ final case class EnsimeConfig(
     compilerArgs: List[String],
     referenceSourceRoots: List[File],
     subprojects: List[EnsimeModule],
-    sourceMode: Boolean,
-    javaLibs: List[File],
-    // WORKAROUND: https://github.com/ensime/ensime-server/issues/1042
-    disableSourceMonitoring: Boolean = false,
-    disableClassMonitoring: Boolean = false
+    javaLibs: List[File]
 ) {
   (rootDir :: cacheDir :: javaHome :: referenceSourceRoots ::: javaLibs).foreach { f =>
     require(f.exists, "" + f + " is required but does not exist")
@@ -38,7 +35,7 @@ final case class EnsimeConfig(
 
   def compileClasspath: Set[File] = modules.values.toSet.flatMap {
     m: EnsimeModule => m.compileDeps ++ m.testDeps
-  } ++ (if (sourceMode) List.empty else targetClasspath)
+  } ++ (if (propOrFalse("ensime.sourceMode")) List.empty else targetClasspath)
 
   def targetClasspath: Set[File] = modules.values.toSet.flatMap {
     m: EnsimeModule => m.targets ++ m.testTargets

--- a/core/src/main/scala/org/ensime/core/Analyzer.scala
+++ b/core/src/main/scala/org/ensime/core/Analyzer.scala
@@ -22,6 +22,7 @@ import scala.reflect.internal.util.{ OffsetPosition, RangePosition, SourceFile }
 import scala.tools.nsc.Settings
 import scala.tools.nsc.interactive.Global
 import scala.util.Try
+import scala.util.Properties._
 
 final case class CompilerFatalError(e: Throwable)
 
@@ -96,7 +97,7 @@ class Analyzer(
     broadcaster ! SendBackgroundMessageEvent("Initializing Analyzer. Please wait...")
 
     scalaCompiler.askNotifyWhenReady()
-    if (config.sourceMode) scalaCompiler.askReloadAllFiles()
+    if (propOrFalse("ensime.sourceMode")) scalaCompiler.askReloadAllFiles()
   }
 
   protected def makeScalaCompiler() = new RichPresentationCompiler(
@@ -168,7 +169,7 @@ class Analyzer(
       scalaCompiler.askNotifyWhenReady()
       sender ! VoidResponse
     case UnloadAllReq =>
-      if (config.sourceMode) {
+      if (propOrFalse("ensime.sourceMode")) {
         log.info("in source mode, will reload all files")
         scalaCompiler.askRemoveAllDeleted()
         restartCompiler(keepLoaded = true)

--- a/core/src/main/scala/org/ensime/indexer/FileWatchers.scala
+++ b/core/src/main/scala/org/ensime/indexer/FileWatchers.scala
@@ -5,6 +5,7 @@ package org.ensime.indexer
 import akka.actor.Actor
 import akka.event.slf4j.SLF4JLogging
 import org.apache.commons.vfs2._
+import scala.util.Properties._
 
 import org.ensime.api._
 import org.ensime.vfs._
@@ -43,7 +44,7 @@ class ClassfileWatcher(
 ) extends Actor with SLF4JLogging {
 
   private val impls =
-    if (config.disableClassMonitoring) Nil
+    if (propOrFalse("ensime.disableClassMonitoring")) Nil
     else {
       val jarJava7WatcherBuilder = new JarJava7WatcherBuilder()
       val classJava7WatcherBuilder = new ClassJava7WatcherBuilder()
@@ -77,7 +78,7 @@ class SourceWatcher(
     vfs: EnsimeVFS
 ) extends Watcher with SLF4JLogging {
   private val impls =
-    if (config.disableSourceMonitoring) Nil
+    if (propOrFalse("ensime.disableSourceMonitoring")) Nil
     else {
       val sourceJava7WatcherBuilder = new SourceJava7WatcherBuilder()
       for {

--- a/core/src/test/scala/org/ensime/config/EnsimeConfigSpec.scala
+++ b/core/src/test/scala/org/ensime/config/EnsimeConfigSpec.scala
@@ -78,28 +78,4 @@ class EnsimeConfigSpec extends EnsimeSpec {
     })
   }
 
-  it should "base class paths on ensime.sourceMode value" in withTempDir { dir =>
-    val abc = dir / "abc"
-    val cache = dir / ".ensime_cache"
-    val javaHome = File(Properties.javaHome)
-
-    abc.mkdirs()
-    cache.mkdirs()
-
-    test(dir, s"""
-(:name "project"
- :scala-version "2.10.4"
- :java-home "$javaHome"
- :root-dir "$dir"
- :cache-dir "$cache"
- :source-mode ${if (Properties.propOrFalse("ensime.sourceMode")) "t" else "nil"}
- :subprojects ((:name "module1"
-                :scala-version "2.10.4"
-                :targets ("$abc"))))""", { implicit config =>
-      config.compileClasspath shouldBe (
-        if (Properties.propOrFalse("ensime.sourceMode")) Set.empty else Set(abc)
-      )
-    })
-  }
-
 }

--- a/core/src/test/scala/org/ensime/config/EnsimeConfigSpec.scala
+++ b/core/src/test/scala/org/ensime/config/EnsimeConfigSpec.scala
@@ -48,7 +48,6 @@ class EnsimeConfigSpec extends EnsimeSpec {
       val module1 = config.modules("module1")
       module1.name shouldBe "module1"
       module1.dependencies shouldBe empty
-      config.sourceMode shouldBe false
     })
   }
 
@@ -79,33 +78,28 @@ class EnsimeConfigSpec extends EnsimeSpec {
     })
   }
 
-  it should "base class paths on source-mode value" in {
-    List(true, false) foreach { (sourceMode: Boolean) =>
-      withTempDir { dir =>
-        val abc = dir / "abc"
-        val cache = dir / ".ensime_cache"
-        val javaHome = File(Properties.javaHome)
+  it should "base class paths on ensime.sourceMode value" in withTempDir { dir =>
+    val abc = dir / "abc"
+    val cache = dir / ".ensime_cache"
+    val javaHome = File(Properties.javaHome)
 
-        abc.mkdirs()
-        cache.mkdirs()
+    abc.mkdirs()
+    cache.mkdirs()
 
-        test(dir, s"""
+    test(dir, s"""
 (:name "project"
  :scala-version "2.10.4"
  :java-home "$javaHome"
  :root-dir "$dir"
  :cache-dir "$cache"
- :source-mode ${if (sourceMode) "t" else "nil"}
+ :source-mode ${if (Properties.propOrFalse("ensime.sourceMode")) "t" else "nil"}
  :subprojects ((:name "module1"
                 :scala-version "2.10.4"
                 :targets ("$abc"))))""", { implicit config =>
-          config.sourceMode shouldBe sourceMode
-          config.compileClasspath shouldBe (
-            if (sourceMode) Set.empty else Set(abc)
-          )
-        })
-      }
-    }
+      config.compileClasspath shouldBe (
+        if (Properties.propOrFalse("ensime.sourceMode")) Set.empty else Set(abc)
+      )
+    })
   }
 
 }


### PR DESCRIPTION
Use system properties instead of `.ensime` flags

I'm not sure regarding the unit test, I don't think it is of any use now

Close #1617 