### PR TITLE
Disable typechecking when files are changed

### DIFF
--- a/core/src/main/scala/org/ensime/core/Project.scala
+++ b/core/src/main/scala/org/ensime/core/Project.scala
@@ -47,7 +47,7 @@ class Project(
   private val reTypecheck = new FileChangeListener {
     def reTypeCheck(): Unit = self ! AskReTypecheck
     def fileAdded(f: FileObject): Unit = reTypeCheck()
-    def fileChanged(f: FileObject): Unit = reTypeCheck()
+    def fileChanged(f: FileObject): Unit = ()
     def fileRemoved(f: FileObject): Unit = reTypeCheck()
     override def baseReCreated(f: FileObject): Unit = reTypeCheck()
   }


### PR DESCRIPTION
This leaves the `FileChangeListener` unchanged but does not type check on file changes. 

`FileChangeListener` is also being used in `SearchService` to trigger indexing on file changes. If that is also unnecessary then that code can be removed.

Close #1625 