### PR TITLE
Use PC instead of scalariform for `ExpandSelectionReq`

### DIFF
--- a/core/src/it/scala/org/ensime/intg/BasicWorkflow.scala
+++ b/core/src/it/scala/org/ensime/intg/BasicWorkflow.scala
@@ -245,13 +245,13 @@ class BasicWorkflow extends EnsimeSpec
           )
 
           // expand selection around 'val foo'
-          project ! ExpandSelectionReq(fooFile, 215, 215)
+          project ! ExpandSelectionReq(fooFile, 290, 290)
           val expandRange1 = expectMsgType[FileRange]
-          expandRange1 shouldBe FileRange(fooFilePath, 214, 217)
+          expandRange1 shouldBe FileRange(fooFilePath, 287, 294)
 
-          project ! ExpandSelectionReq(fooFile, 214, 217)
+          project ! ExpandSelectionReq(fooFile, 287, 294)
           val expandRange2 = expectMsgType[FileRange]
-          expandRange2 shouldBe FileRange(fooFilePath, 210, 229)
+          expandRange2 shouldBe FileRange(fooFilePath, 269, 295)
 
           project ! RefactorReq(1234, RenameRefactorDesc("bar", fooFile, 215, 215), false)
           expectMsgPF() {

--- a/core/src/it/scala/org/ensime/intg/BasicWorkflow.scala
+++ b/core/src/it/scala/org/ensime/intg/BasicWorkflow.scala
@@ -245,13 +245,13 @@ class BasicWorkflow extends EnsimeSpec
           )
 
           // expand selection around "seven" in `foo.testMethod` call
-          project ! ExpandSelectionReq(fooFile, 290, 290)
+          project ! ExpandSelectionReq(fooFile, 215, 215)
           val expandRange1 = expectMsgType[FileRange]
-          expandRange1 shouldBe FileRange(fooFilePath, 287, 294)
+          expandRange1 shouldBe FileRange(fooFilePath, 214, 217)
 
-          project ! ExpandSelectionReq(fooFile, 287, 294)
+          project ! ExpandSelectionReq(fooFile, 214, 217)
           val expandRange2 = expectMsgType[FileRange]
-          expandRange2 shouldBe FileRange(fooFilePath, 269, 295)
+          expandRange2 shouldBe FileRange(fooFilePath, 210, 229)
 
           project ! RefactorReq(1234, RenameRefactorDesc("bar", fooFile, 215, 215), false)
           expectMsgPF() {

--- a/core/src/it/scala/org/ensime/intg/BasicWorkflow.scala
+++ b/core/src/it/scala/org/ensime/intg/BasicWorkflow.scala
@@ -244,7 +244,7 @@ class BasicWorkflow extends EnsimeSpec
             BasicTypeInfo("package", DeclaredAs.Object, "org.example.package")
           )
 
-          // expand selection around 'val foo'
+          // expand selection around "seven" in `foo.testMethod` call
           project ! ExpandSelectionReq(fooFile, 290, 290)
           val expandRange1 = expectMsgType[FileRange]
           expandRange1 shouldBe FileRange(fooFilePath, 287, 294)

--- a/core/src/main/scala/org/ensime/core/Analyzer.scala
+++ b/core/src/main/scala/org/ensime/core/Analyzer.scala
@@ -269,7 +269,6 @@ class Analyzer(
       }
     case ExpandSelectionReq(file, start: Int, stop: Int) =>
       val p = new RangePosition(createSourceFile(file), start, start, stop)
-      scalaCompiler.askLoadedTyped(p.source)
       val enclosingPos = scalaCompiler.askEnclosingTreePosition(p)
       sender ! FileRange(file.getPath, enclosingPos.start, enclosingPos.end)
     case StructureViewReq(fileInfo: SourceFileInfo) =>

--- a/core/src/main/scala/org/ensime/core/Analyzer.scala
+++ b/core/src/main/scala/org/ensime/core/Analyzer.scala
@@ -268,7 +268,10 @@ class Analyzer(
         scalaCompiler.askImplicitInfoInRegion(p)
       }
     case ExpandSelectionReq(file, start: Int, stop: Int) =>
-      sender ! handleExpandselection(file, start, stop)
+      val p = new RangePosition(createSourceFile(file), start, start, stop)
+      scalaCompiler.askLoadedTyped(p.source)
+      val enclosingPos = scalaCompiler.askEnclosingTreePosition(p)
+      sender ! FileRange(file.getPath, enclosingPos.start, enclosingPos.end)
     case StructureViewReq(fileInfo: SourceFileInfo) =>
       sender ! withExisting(fileInfo) {
         val sourceFile = createSourceFile(fileInfo)

--- a/core/src/main/scala/org/ensime/core/PositionLocator.scala
+++ b/core/src/main/scala/org/ensime/core/PositionLocator.scala
@@ -2,15 +2,46 @@
 // License: http://www.gnu.org/licenses/gpl-3.0.en.html
 package org.ensime.core
 
-import scala.tools.nsc.interactive.Global
+import scala.reflect.io.AbstractFile
+import scala.tools.refactoring.common.{ CompilerAccess, EnrichedTrees }
 
-trait PositionLocator {
-  self: Global =>
+class PositionLocator(val global: RichPresentationCompiler) extends CompilerAccess with EnrichedTrees {
+  import global._
 
-  private class ProperlyIncludingLocator(pos: Position) extends Locator(pos) {
-    override protected def isEligible(t: Tree): Boolean = super.isEligible(t) && (t.pos properlyIncludes pos)
+  def compilationUnitOfFile(f: AbstractFile): Option[CompilationUnit] = unitOfFile.get(f)
+
+  private class ProperlyIncludingLocator(pos: Position) extends Traverser {
+    private var last: Position = NoPosition
+
+    protected def isEligible(t: Tree) = !t.pos.isTransparent
+
+    override def traverse(t: Tree): Unit = t match {
+      case tt: TypeTree if tt.original != null && (tt.pos includes tt.original.pos) =>
+        traverse(tt.original)
+      case _ =>
+        if (t.pos properlyIncludes pos) {
+          if (isEligible(t)) {
+            val namePosition = t.namePosition()
+            last = if (namePosition properlyIncludes pos) namePosition else t.pos
+          }
+          super.traverse(t)
+        } else t match {
+          case mdef: MemberDef =>
+            val annTrees = mdef.mods.annotations match {
+              case Nil if mdef.symbol != null =>
+                mdef.symbol.annotations.map(_.original)
+              case anns => anns
+            }
+            traverseTrees(annTrees)
+          case _ =>
+        }
+    }
+
+    def locateIn(root: Tree): Position = {
+      traverse(root)
+      last
+    }
   }
 
-  def enclosingTree(p: Position, root: Tree): Tree = new ProperlyIncludingLocator(p).locateIn(root)
-
+  def enclosingTreePosition(p: Position): Position = new ProperlyIncludingLocator(p).locateIn(parseTree(p.source))
 }

--- a/core/src/main/scala/org/ensime/core/PositionLocator.scala
+++ b/core/src/main/scala/org/ensime/core/PositionLocator.scala
@@ -1,0 +1,33 @@
+// Copyright: 2010 - 2016 https://github.com/ensime/ensime-server/graphs
+// License: http://www.gnu.org/licenses/gpl-3.0.en.html
+package org.ensime.core
+
+import scala.tools.nsc.interactive.Global
+
+trait PositionLocator {
+  self: Global =>
+
+  private class ProperlyIncludingLocator(pos: Position) extends Locator(pos) {
+    override def traverse(t: Tree): Unit = t match {
+      case tt: TypeTree if tt.original != null && (tt.pos includes tt.original.pos) =>
+        traverse(tt.original)
+      case _ =>
+        if (t.pos properlyIncludes pos) {
+          if (isEligible(t)) last = t
+          super.traverse(t)
+        } else t match {
+          case mdef: MemberDef =>
+            val annTrees = mdef.mods.annotations match {
+              case Nil if mdef.symbol != null =>
+                mdef.symbol.annotations.map(_.original)
+              case anns => anns
+            }
+            traverseTrees(annTrees)
+          case _ =>
+        }
+    }
+  }
+
+  def enclosingTree(p: Position, root: Tree): Tree = new ProperlyIncludingLocator(p).locateIn(root)
+
+}

--- a/core/src/main/scala/org/ensime/core/PositionLocator.scala
+++ b/core/src/main/scala/org/ensime/core/PositionLocator.scala
@@ -8,24 +8,7 @@ trait PositionLocator {
   self: Global =>
 
   private class ProperlyIncludingLocator(pos: Position) extends Locator(pos) {
-    override def traverse(t: Tree): Unit = t match {
-      case tt: TypeTree if tt.original != null && (tt.pos includes tt.original.pos) =>
-        traverse(tt.original)
-      case _ =>
-        if (t.pos properlyIncludes pos) {
-          if (isEligible(t)) last = t
-          super.traverse(t)
-        } else t match {
-          case mdef: MemberDef =>
-            val annTrees = mdef.mods.annotations match {
-              case Nil if mdef.symbol != null =>
-                mdef.symbol.annotations.map(_.original)
-              case anns => anns
-            }
-            traverseTrees(annTrees)
-          case _ =>
-        }
-    }
+    override protected def isEligible(t: Tree): Boolean = super.isEligible(t) && (t.pos properlyIncludes pos)
   }
 
   def enclosingTree(p: Position, root: Tree): Tree = new ProperlyIncludingLocator(p).locateIn(root)

--- a/core/src/main/scala/org/ensime/core/Refactoring.scala
+++ b/core/src/main/scala/org/ensime/core/Refactoring.scala
@@ -12,8 +12,6 @@ import scala.tools.refactoring._
 import scala.tools.refactoring.analysis.GlobalIndexes
 import scala.tools.refactoring.common.{ Change, CompilerAccess, RenameSourceFileChange }
 import scala.tools.refactoring.implementations._
-import scalariform.astselect.AstSelector
-import scalariform.utils.Range
 
 abstract class RefactoringEnvironment(file: String, start: Int, end: Int) {
 
@@ -70,20 +68,6 @@ trait RefactoringHandler { self: Analyzer =>
       case Right(success) => success
       case Left(failure) => failure
     }
-
-  def handleExpandselection(file: File, start: Int, stop: Int): FileRange = {
-    readFile(file) match {
-      case Right(contents) =>
-        val selectionRange = Range(start, stop - start)
-        AstSelector.expandSelection(contents, selectionRange) match {
-          case Some(range) => FileRange(file.getPath, range.offset, range.offset + range.length)
-          case _ =>
-            FileRange(file.getPath, start, stop)
-        }
-      case Left(e) => throw e
-    }
-  }
-
 }
 
 trait RefactoringControl { self: RichCompilerControl with RefactoringImpl =>

--- a/core/src/main/scala/org/ensime/core/RichPresentationCompiler.scala
+++ b/core/src/main/scala/org/ensime/core/RichPresentationCompiler.scala
@@ -265,8 +265,7 @@ trait RichCompilerControl extends CompilerControl with RefactoringControl with C
   /**
    * Returns the smallest `Tree`, which position `properlyIncludes` `p`
    */
-  def askEnclosingTreePosition(p: Position): Position =
-    onUnitOf(p.source) { unit => enclosingTree(p, unit.body).pos }
+  def askEnclosingTreePosition(p: Position): Position = enclosingTree(p, parseTree(p.source)).pos
 }
 
 class RichPresentationCompiler(

--- a/core/src/main/scala/org/ensime/core/RichPresentationCompiler.scala
+++ b/core/src/main/scala/org/ensime/core/RichPresentationCompiler.scala
@@ -262,6 +262,11 @@ trait RichCompilerControl extends CompilerControl with RefactoringControl with C
   def askRaw(any: Any): String =
     showRaw(any, printTypes = true, printIds = false, printKinds = true, printMirrors = true)
 
+  /**
+   * Returns the smallest `Tree`, which position `properlyIncludes` `p`
+   */
+  def askEnclosingTreePosition(p: Position): Position =
+    onUnitOf(p.source) { unit => enclosingTree(p, unit.body).pos }
 }
 
 class RichPresentationCompiler(
@@ -281,7 +286,8 @@ class RichPresentationCompiler(
     with StructureViewBuilder
     with SymbolToFqn
     with FqnToSymbol
-    with TypeToScalaName {
+    with TypeToScalaName
+    with PositionLocator {
 
   val logger = LoggerFactory.getLogger(this.getClass)
 

--- a/core/src/main/scala/org/ensime/core/RichPresentationCompiler.scala
+++ b/core/src/main/scala/org/ensime/core/RichPresentationCompiler.scala
@@ -265,7 +265,8 @@ trait RichCompilerControl extends CompilerControl with RefactoringControl with C
   /**
    * Returns the smallest `Tree`, which position `properlyIncludes` `p`
    */
-  def askEnclosingTreePosition(p: Position): Position = enclosingTree(p, parseTree(p.source)).pos
+  def askEnclosingTreePosition(p: Position): Position =
+    new PositionLocator(this).enclosingTreePosition(p)
 }
 
 class RichPresentationCompiler(
@@ -285,8 +286,7 @@ class RichPresentationCompiler(
     with StructureViewBuilder
     with SymbolToFqn
     with FqnToSymbol
-    with TypeToScalaName
-    with PositionLocator {
+    with TypeToScalaName {
 
   val logger = LoggerFactory.getLogger(this.getClass)
 

--- a/project/EnsimeBuild.scala
+++ b/project/EnsimeBuild.scala
@@ -71,9 +71,6 @@ object EnsimeBuild {
   )
 
   lazy val api = Project("api", file("api")) settings (commonSettings) settings (
-    libraryDependencies ++= Seq(
-      "org.scalariform" %% "scalariform" % "0.1.8"
-    ),
     licenses := Seq(Apache2),
     HeaderKey.headers := Copyright.ApacheMap
   )


### PR DESCRIPTION
close #1622 
The most straightforward implementation of `ExpandSelection` feature using pres. compiler `Locator` modified to return smallest tree with a position **strictly** bigger than given. The downside is that we traverse the all the trees every time client asks to expand/contract. Perhaps we can just collect all the trees, which include the initial position, and make client use them for repeating expand/contract commands. 

Also, this will require some `ensime-emacs` adjustments, current implementation copies file contents into a temporary file, which is then loaded into pres. compiler along with the real one, leading to `duplicate definition`s all over the code.