### PR TITLE
bump akka version for 2.11+, introduce AkkaBackCompat

### DIFF
--- a/core/src/it/scala/org/ensime/fixture/SearchServiceFixture.scala
+++ b/core/src/it/scala/org/ensime/fixture/SearchServiceFixture.scala
@@ -2,15 +2,17 @@
 // License: http://www.gnu.org/licenses/gpl-3.0.en.html
 package org.ensime.fixture
 
-import akka.actor.ActorSystem
-import org.ensime.api._
-import org.ensime.AkkaBackCompat._
-import org.ensime.vfs._
-import org.ensime.indexer.SearchService
 import scala.concurrent._
 import scala.concurrent.duration._
+import scala.util.Try
 
-trait IsolatedSearchServiceFixture extends IsolatedSourceResolverFixture {
+import akka.actor.ActorSystem
+import org.ensime.api._
+import org.ensime.AkkaBackCompat
+import org.ensime.indexer.SearchService
+import org.ensime.vfs._
+
+trait IsolatedSearchServiceFixture extends IsolatedSourceResolverFixture with AkkaBackCompat {
 
   def withSearchService(testCode: (EnsimeConfig, SearchService) => Any)(implicit actorSystem: ActorSystem, vfs: EnsimeVFS): Any = withSourceResolver { (config, resolver) =>
     val searchService = new SearchService(config, resolver)
@@ -18,8 +20,8 @@ trait IsolatedSearchServiceFixture extends IsolatedSourceResolverFixture {
       testCode(config, searchService)
     } finally {
       Await.ready(searchService.shutdown(), Duration.Inf)
-      actorSystem.close()
-      actorSystem.awaitClosure(10.seconds)
+      Try(actorSystem.terminate())
+      Try(Await.result(actorSystem.whenTerminated, 10.seconds))
     }
   }
 }

--- a/core/src/it/scala/org/ensime/fixture/SearchServiceFixture.scala
+++ b/core/src/it/scala/org/ensime/fixture/SearchServiceFixture.scala
@@ -4,6 +4,7 @@ package org.ensime.fixture
 
 import akka.actor.ActorSystem
 import org.ensime.api._
+import org.ensime.AkkaBackCompat._
 import org.ensime.vfs._
 import org.ensime.indexer.SearchService
 import scala.concurrent._
@@ -17,8 +18,8 @@ trait IsolatedSearchServiceFixture extends IsolatedSourceResolverFixture {
       testCode(config, searchService)
     } finally {
       Await.ready(searchService.shutdown(), Duration.Inf)
-      actorSystem.shutdown()
-      actorSystem.awaitTermination(10.seconds)
+      actorSystem.close()
+      actorSystem.awaitClosure(10.seconds)
     }
   }
 }

--- a/core/src/it/scala/org/ensime/intg/DebugTest.scala
+++ b/core/src/it/scala/org/ensime/intg/DebugTest.scala
@@ -43,17 +43,19 @@ class DebugTest extends EnsimeSpec
         ) { (threadId, breakpointsFile) =>
             import testkit._
 
-            // Should be able to step over a method call
-            project ! DebugNextReq(threadId)
-            expectMsg(remaining, "Failed to step over line!", TrueResponse)
+            within(10.minutes) {
+              // Should be able to step over a method call
+              project ! DebugNextReq(threadId)
+              expectMsg(remaining, "Failed to step over line!", TrueResponse)
 
-            // Should be able to step into a method call
-            project ! DebugStepReq(threadId)
-            expectMsg(remaining, "Failed to step into method call!", TrueResponse)
+              // Should be able to step into a method call
+              project ! DebugStepReq(threadId)
+              expectMsg(remaining, "Failed to step into method call!", TrueResponse)
 
-            // Should be able to step out of a method call
-            project ! DebugStepOutReq(threadId)
-            expectMsg(remaining, "Failed to step out of method call!", TrueResponse)
+              // Should be able to step out of a method call
+              project ! DebugStepOutReq(threadId)
+              expectMsg(remaining, "Failed to step out of method call!", TrueResponse)
+            }
           }
       }
     }
@@ -345,7 +347,7 @@ class DebugTest extends EnsimeSpec
         ) { (threadId, variablesFile) =>
             import testkit._
 
-            /* boolean local */ {
+            /* boolean local */ within(10.minutes) {
               val n = "a"
 
               project ! DebugLocateNameReq(threadId, n)
@@ -359,7 +361,7 @@ class DebugTest extends EnsimeSpec
               }
             }
 
-            /* char local */ {
+            /* char local */ within(10.minutes) {
               val n = "b"
 
               project ! DebugLocateNameReq(threadId, n)
@@ -373,7 +375,7 @@ class DebugTest extends EnsimeSpec
               }
             }
 
-            /* short local */ {
+            /* short local */ within(10.minutes) {
               val n = "c"
 
               project ! DebugLocateNameReq(threadId, n)
@@ -387,7 +389,7 @@ class DebugTest extends EnsimeSpec
               }
             }
 
-            /* int local */ {
+            /* int local */ within(10.minutes) {
               val n = "d"
 
               project ! DebugLocateNameReq(threadId, n)
@@ -401,7 +403,7 @@ class DebugTest extends EnsimeSpec
               }
             }
 
-            /* long local */ {
+            /* long local */ within(10.minutes) {
               val n = "e"
 
               project ! DebugLocateNameReq(threadId, n)
@@ -415,7 +417,7 @@ class DebugTest extends EnsimeSpec
               }
             }
 
-            /* float local */ {
+            /* float local */ within(10.minutes) {
               val n = "f"
 
               project ! DebugLocateNameReq(threadId, n)
@@ -429,7 +431,7 @@ class DebugTest extends EnsimeSpec
               }
             }
 
-            /* double local */ {
+            /* double local */ within(10.minutes) {
               val n = "g"
 
               project ! DebugLocateNameReq(threadId, n)
@@ -443,7 +445,7 @@ class DebugTest extends EnsimeSpec
               }
             }
 
-            /* string local */ {
+            /* string local */ within(10.minutes) {
               val n = "h"
 
               project ! DebugLocateNameReq(threadId, n)

--- a/project/EnsimeBuild.scala
+++ b/project/EnsimeBuild.scala
@@ -27,11 +27,11 @@ object ProjectPlugin extends AutoPlugin {
 
 object EnsimeBuild {
   lazy val commonSettings = Sensible.settings ++ Seq(
-    libraryDependencies ++= Sensible.testLibs() ++ Sensible.logback,
+    libraryDependencies ++= Sensible.testLibs().value ++ Sensible.logback,
 
     dependencyOverrides ++= Set(
-       "com.typesafe.akka" %% "akka-actor" % Sensible.akkaVersion,
-       "com.typesafe.akka" %% "akka-testkit" % Sensible.akkaVersion,
+       "com.typesafe.akka" %% "akka-actor" % Sensible.akkaVersion.value,
+       "com.typesafe.akka" %% "akka-testkit" % Sensible.akkaVersion.value,
        "io.spray" %% "spray-json" % "1.3.2"
     ),
 
@@ -79,6 +79,7 @@ object EnsimeBuild {
     api
   ) settings (
     libraryDependencies ++= List(
+      "com.typesafe.akka" %% "akka-actor" % Sensible.akkaVersion.value,
       "org.scala-lang" % "scala-compiler" % scalaVersion.value,
       "org.apache.commons" % "commons-vfs2" % "2.1" exclude ("commons-logging", "commons-logging")
     ) ++ Sensible.guava
@@ -88,7 +89,7 @@ object EnsimeBuild {
     util, api
   ) settings (
       libraryDependencies += "commons-io" % "commons-io" % "2.5",
-      libraryDependencies ++= Sensible.testLibs("compile")
+      libraryDependencies ++= Sensible.testLibs("compile").value
     )
 
   lazy val s_express = Project("s-express", file("s-express")) settings (commonSettings) settings (
@@ -107,7 +108,7 @@ object EnsimeBuild {
   ) settings (
       libraryDependencies ++= Seq(
         "com.github.fommil" %% "spray-json-shapeless" % "1.3.0",
-        "com.typesafe.akka" %% "akka-slf4j" % Sensible.akkaVersion
+        "com.typesafe.akka" %% "akka-slf4j" % Sensible.akkaVersion.value
       ) ++ Sensible.shapeless(scalaVersion.value)
     )
 
@@ -118,7 +119,7 @@ object EnsimeBuild {
     api % "test->test" // for the test data
   ) settings (
       libraryDependencies ++= Seq(
-        "com.typesafe.akka" %% "akka-slf4j" % Sensible.akkaVersion
+        "com.typesafe.akka" %% "akka-slf4j" % Sensible.akkaVersion.value
       ) ++ Sensible.shapeless(scalaVersion.value)
     )
 
@@ -151,8 +152,8 @@ object EnsimeBuild {
         "org.ow2.asm" % "asm-commons" % "5.1",
         "org.ow2.asm" % "asm-util" % "5.1",
         "org.scala-lang" % "scalap" % scalaVersion.value,
-        "com.typesafe.akka" %% "akka-actor" % Sensible.akkaVersion,
-        "com.typesafe.akka" %% "akka-slf4j" % Sensible.akkaVersion,
+        "com.typesafe.akka" %% "akka-actor" % Sensible.akkaVersion.value,
+        "com.typesafe.akka" %% "akka-slf4j" % Sensible.akkaVersion.value,
         scalaBinaryVersion.value match {
           // see notes in https://github.com/ensime/ensime-server/pull/1446
           case "2.10" => "org.scala-refactoring" % "org.scala-refactoring.library_2.10.6" % "0.10.0"
@@ -161,7 +162,7 @@ object EnsimeBuild {
         "commons-lang" % "commons-lang" % "2.6",
         "com.googlecode.java-diff-utils" % "diffutils" % "1.3.0",
         "org.scala-debugger" %% "scala-debugger-api" % "1.1.0-M2"
-      ) ++ Sensible.testLibs("it,test") ++ Sensible.shapeless(scalaVersion.value)
+      ) ++ Sensible.testLibs("it,test").value ++ Sensible.shapeless(scalaVersion.value)
     ) enablePlugins BuildInfoPlugin settings (
         buildInfoPackage := organization.value,
         buildInfoKeys += BuildInfoKey.action("gitSha")(Try("git rev-parse --verify HEAD".!! dropRight 1) getOrElse "n/a"),
@@ -192,7 +193,7 @@ object EnsimeBuild {
           "io.netty"    %  "netty-transport"  % nettyVersion,
           "io.netty"    %  "netty-handler"    % nettyVersion,
           "io.netty"    %  "netty-codec-http" % nettyVersion
-        ) ++ Sensible.testLibs("it,test") ++ Sensible.shapeless(scalaVersion.value)
+        ) ++ Sensible.testLibs("it,test").value ++ Sensible.shapeless(scalaVersion.value)
       )
 
   // testing modules

--- a/project/SensibleSettings.scala
+++ b/project/SensibleSettings.scala
@@ -119,7 +119,15 @@ object Sensible {
   )
 
   val scalaModulesVersion = "1.0.4"
-  val akkaVersion = "2.3.16"
+  
+  def akkaVersion: Def.Initialize[String] = Def.setting {
+    CrossVersion.partialVersion(scalaVersion.value) match {
+      case Some((2, minor)) if minor >= 11 => "2.4.12"
+      case Some((2, minor)) => "2.3.16"
+      case _ => ???
+    }
+  }
+
   val scalatestVersion = "3.0.0"
   val logbackVersion = "1.7.21"
   val quasiquotesVersion = "2.0.1"
@@ -143,15 +151,15 @@ object Sensible {
     "com.google.code.findbugs" % "jsr305" % "3.0.1" % "provided"
   )
 
-  def testLibs(config: String = "test") = Seq(
+  def testLibs(config: String = "test") = Def.setting(Seq(
     // janino 3.0.6 is not compatible and causes http://www.slf4j.org/codes.html#replay
     "org.codehaus.janino" % "janino" % "2.7.8" % config,
     "org.scalatest" %% "scalatest" % scalatestVersion % config,
     "org.scalamock" %% "scalamock-scalatest-support" % "3.3.0" % config,
     "org.scalacheck" %% "scalacheck" % "1.13.4" % config,
-    "com.typesafe.akka" %% "akka-testkit" % akkaVersion % config,
-    "com.typesafe.akka" %% "akka-slf4j" % akkaVersion % config
-  ) ++ logback.map(_ % config)
+    "com.typesafe.akka" %% "akka-testkit" % akkaVersion.value % config,
+    "com.typesafe.akka" %% "akka-slf4j" % akkaVersion.value % config
+  ) ++ logback.map(_ % config))
 
   // e.g. YOURKIT_AGENT=/opt/yourkit/bin/linux-x86-64/libyjpagent.so
   val yourkitAgent = Properties.envOrNone("YOURKIT_AGENT").map { name =>

--- a/server/src/it/scala/org/ensime/server/ServerStartupSpec.scala
+++ b/server/src/it/scala/org/ensime/server/ServerStartupSpec.scala
@@ -4,11 +4,12 @@ package org.ensime.server
 
 import java.net._
 
+import scala.concurrent.Await
 import scala.concurrent.duration._
 import scala.util.{ Properties, Try }
 
 import akka.actor.Props
-import org.ensime.AkkaBackCompat._
+import org.ensime.AkkaBackCompat
 import org.ensime.fixture._
 import org.ensime.util.EnsimeSpec
 import org.ensime.util.ensimefile.Implicits.DefaultCharset
@@ -16,7 +17,8 @@ import org.ensime.util.file._
 
 class ServerStartupSpec extends EnsimeSpec
     with IsolatedEnsimeConfigFixture
-    with IsolatedTestKitFixture {
+    with IsolatedTestKitFixture
+    with AkkaBackCompat {
 
   val original = EnsimeConfigFixture.EmptyTestProject
 
@@ -83,7 +85,7 @@ class ServerStartupSpec extends EnsimeSpec
         val protocol = new SwankProtocol
         system.actorOf(Props(new ServerActor(config, protocol)), "ensime-main")
 
-        system.awaitClosure(30.seconds).get
+        Await.result(system.whenTerminated, 30.seconds)
       }
     }
   }
@@ -101,7 +103,7 @@ class ServerStartupSpec extends EnsimeSpec
         val protocol = new SwankProtocol
         system.actorOf(Props(new ServerActor(config, protocol)), "ensime-main")
 
-        system.awaitClosure(30.seconds).get
+        Await.result(system.whenTerminated, 30.seconds)
       }
     }
   }

--- a/server/src/it/scala/org/ensime/server/ServerStartupSpec.scala
+++ b/server/src/it/scala/org/ensime/server/ServerStartupSpec.scala
@@ -85,7 +85,7 @@ class ServerStartupSpec extends EnsimeSpec
         val protocol = new SwankProtocol
         system.actorOf(Props(new ServerActor(config, protocol)), "ensime-main")
 
-        Await.result(system.whenTerminated, 30.seconds)
+        Await.result(system.whenTerminated, 40.seconds)
       }
     }
   }
@@ -103,7 +103,7 @@ class ServerStartupSpec extends EnsimeSpec
         val protocol = new SwankProtocol
         system.actorOf(Props(new ServerActor(config, protocol)), "ensime-main")
 
-        Await.result(system.whenTerminated, 30.seconds)
+        Await.result(system.whenTerminated, 40.seconds)
       }
     }
   }

--- a/server/src/it/scala/org/ensime/server/ServerStartupSpec.scala
+++ b/server/src/it/scala/org/ensime/server/ServerStartupSpec.scala
@@ -8,6 +8,7 @@ import scala.concurrent.duration._
 import scala.util.{ Properties, Try }
 
 import akka.actor.Props
+import org.ensime.AkkaBackCompat._
 import org.ensime.fixture._
 import org.ensime.util.EnsimeSpec
 import org.ensime.util.ensimefile.Implicits.DefaultCharset
@@ -82,9 +83,7 @@ class ServerStartupSpec extends EnsimeSpec
         val protocol = new SwankProtocol
         system.actorOf(Props(new ServerActor(config, protocol)), "ensime-main")
 
-        eventually(timeout(30 seconds), interval(1 second)) {
-          system.isTerminated
-        }
+        system.awaitClosure(30.seconds).get
       }
     }
   }
@@ -102,9 +101,7 @@ class ServerStartupSpec extends EnsimeSpec
         val protocol = new SwankProtocol
         system.actorOf(Props(new ServerActor(config, protocol)), "ensime-main")
 
-        eventually(timeout(30 seconds), interval(1 second)) {
-          system.isTerminated
-        }
+        system.awaitClosure(30.seconds).get
       }
     }
   }

--- a/server/src/it/scala/org/ensime/server/ServerStartupSpec.scala
+++ b/server/src/it/scala/org/ensime/server/ServerStartupSpec.scala
@@ -85,7 +85,7 @@ class ServerStartupSpec extends EnsimeSpec
         val protocol = new SwankProtocol
         system.actorOf(Props(new ServerActor(config, protocol)), "ensime-main")
 
-        Await.result(system.whenTerminated, 40.seconds)
+        Await.result(system.whenTerminated, akkaTimeout.duration)
       }
     }
   }
@@ -103,7 +103,7 @@ class ServerStartupSpec extends EnsimeSpec
         val protocol = new SwankProtocol
         system.actorOf(Props(new ServerActor(config, protocol)), "ensime-main")
 
-        Await.result(system.whenTerminated, 40.seconds)
+        Await.result(system.whenTerminated, akkaTimeout.duration)
       }
     }
   }

--- a/server/src/main/scala/org/ensime/server/Server.scala
+++ b/server/src/main/scala/org/ensime/server/Server.scala
@@ -4,6 +4,7 @@ package org.ensime.server
 
 import java.io._
 import java.net.InetSocketAddress
+import scala.concurrent.Await
 import scala.concurrent.duration._
 import scala.util._
 import scala.util.Properties._
@@ -14,14 +15,14 @@ import akka.util.Timeout
 import com.google.common.base.Charsets
 import com.google.common.io.Files
 import io.netty.channel.Channel
-import org.slf4j._
 
 import org.ensime.api._
 import org.ensime.config._
 import org.ensime.core._
-import org.ensime.AkkaBackCompat._
+import org.ensime.AkkaBackCompat
 import org.ensime.server.tcp.TCPServer
 import org.ensime.util.Slf4jSetup
+import org.slf4j._
 
 class ServerActor(
     config: EnsimeConfig,
@@ -113,7 +114,7 @@ class ServerActor(
 
 }
 
-object Server {
+object Server extends AkkaBackCompat {
   Slf4jSetup.init()
 
   val log = LoggerFactory.getLogger("Server")
@@ -154,10 +155,10 @@ object Server {
           log.info(s"Shutdown requested: ${request.reason}")
 
         log.info("Shutting down the ActorSystem")
-        system.close()
+        Try(system.terminate())
 
         log.info("Awaiting actor system termination")
-        system.awaitClosure()
+        Try(Await.result(system.whenTerminated, Duration.Inf))
 
         log.info("Shutting down the Netty channel")
         Try(channel.close().sync())

--- a/server/src/main/scala/org/ensime/server/Server.scala
+++ b/server/src/main/scala/org/ensime/server/Server.scala
@@ -19,6 +19,7 @@ import org.slf4j._
 import org.ensime.api._
 import org.ensime.config._
 import org.ensime.core._
+import org.ensime.AkkaBackCompat._
 import org.ensime.server.tcp.TCPServer
 import org.ensime.util.Slf4jSetup
 
@@ -153,10 +154,10 @@ object Server {
           log.info(s"Shutdown requested: ${request.reason}")
 
         log.info("Shutting down the ActorSystem")
-        Try(system.shutdown())
+        system.close()
 
         log.info("Awaiting actor system termination")
-        Try(system.awaitTermination())
+        system.awaitClosure()
 
         log.info("Shutting down the Netty channel")
         Try(channel.close().sync())

--- a/testutil/src/main/scala/org/ensime/fixture/TestKitFixture.scala
+++ b/testutil/src/main/scala/org/ensime/fixture/TestKitFixture.scala
@@ -2,15 +2,18 @@
 // License: http://www.gnu.org/licenses/gpl-3.0.en.html
 package org.ensime.fixture
 
-import akka.util.Timeout
-import com.typesafe.config.ConfigFactory
 import java.util.concurrent.TimeUnit
-import org.scalatest._
-import org.ensime.AkkaBackCompat._
+
+import scala.concurrent.Await
 import scala.concurrent.duration._
+import scala.util.Try
 
 import akka.actor.ActorSystem
 import akka.testkit._
+import akka.util.Timeout
+import com.typesafe.config.ConfigFactory
+import org.ensime.AkkaBackCompat
+import org.scalatest._
 
 /**
  * Normally a TestKit will reuse the same actor system for all tests
@@ -35,21 +38,23 @@ trait TestKitFixture {
 
 class TestKitFix extends TestKit(ActorSystem()) with ImplicitSender
 
-trait IsolatedTestKitFixture extends TestKitFixture {
+trait IsolatedTestKitFixture extends TestKitFixture with AkkaBackCompat {
   override def withTestKit(testCode: TestKitFix => Any): Any = {
     val sys = new TestKitFix
     try {
       testCode(sys)
     } finally {
-      sys.system.close()
-      sys.system.awaitClosure()
+      Try(sys.system.terminate())
+      Try(Await.result(sys.system.whenTerminated, Duration.Inf))
     }
   }
 }
 
 // this seems redundant, because it mimics "extends TestKit" behaviour,
 // but it allows for easy swapping with the refreshing implementation
-trait SharedTestKitFixture extends TestKitFixture with BeforeAndAfterAll {
+trait SharedTestKitFixture extends TestKitFixture
+    with BeforeAndAfterAll
+    with AkkaBackCompat {
   this: Suite =>
 
   var _testkit: TestKitFix = _
@@ -61,8 +66,8 @@ trait SharedTestKitFixture extends TestKitFixture with BeforeAndAfterAll {
 
   override def afterAll(): Unit = {
     super.afterAll()
-    _testkit.system.close()
-    _testkit.system.awaitClosure()
+    Try(_testkit.system.terminate())
+    Try(Await.result(_testkit.system.whenTerminated, Duration.Inf))
   }
 
   override def withTestKit(testCode: TestKitFix => Any): Any = testCode(_testkit)

--- a/testutil/src/main/scala/org/ensime/fixture/TestKitFixture.scala
+++ b/testutil/src/main/scala/org/ensime/fixture/TestKitFixture.scala
@@ -6,6 +6,7 @@ import akka.util.Timeout
 import com.typesafe.config.ConfigFactory
 import java.util.concurrent.TimeUnit
 import org.scalatest._
+import org.ensime.AkkaBackCompat._
 import scala.concurrent.duration._
 
 import akka.actor.ActorSystem
@@ -40,8 +41,8 @@ trait IsolatedTestKitFixture extends TestKitFixture {
     try {
       testCode(sys)
     } finally {
-      sys.system.shutdown()
-      sys.system.awaitTermination()
+      sys.system.close()
+      sys.system.awaitClosure()
     }
   }
 }
@@ -60,8 +61,8 @@ trait SharedTestKitFixture extends TestKitFixture with BeforeAndAfterAll {
 
   override def afterAll(): Unit = {
     super.afterAll()
-    _testkit.system.shutdown()
-    _testkit.system.awaitTermination()
+    _testkit.system.close()
+    _testkit.system.awaitClosure()
   }
 
   override def withTestKit(testCode: TestKitFix => Any): Any = testCode(_testkit)

--- a/util/src/main/scala-2.10/org/ensime/AkkaBackCompat.scala
+++ b/util/src/main/scala-2.10/org/ensime/AkkaBackCompat.scala
@@ -1,0 +1,17 @@
+// Copyright: 2010 - 2016 https://github.com/ensime/ensime-server/graphs
+// License: http://www.gnu.org/licenses/gpl-3.0.en.html
+package org.ensime
+
+import akka.actor.ActorSystem
+
+import scala.concurrent.Await
+import scala.concurrent.duration._
+import scala.util.Try
+
+object AkkaBackCompat {
+  implicit class ActorSystemShutdownBackCompat(val actorSystem: ActorSystem) {
+    def close(): Try[Unit] = Try(actorSystem.shutdown())
+
+    def awaitClosure(d: Duration = Duration.Inf): Try[Unit] = Try(actorSystem.awaitTermination(d))
+  }
+}

--- a/util/src/main/scala-2.10/org/ensime/AkkaBackCompat.scala
+++ b/util/src/main/scala-2.10/org/ensime/AkkaBackCompat.scala
@@ -4,6 +4,7 @@ package org.ensime
 
 import akka.actor.ActorSystem
 
+import scala.concurrent.blocking
 import scala.concurrent.Future
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.duration.Duration
@@ -12,6 +13,8 @@ trait AkkaBackCompat {
   implicit class ActorSystemShutdownBackCompat(val actorSystem: ActorSystem) {
     def terminate(): Future[Unit] = Future.successful(actorSystem.shutdown())
 
-    def whenTerminated: Future[Unit] = Future(actorSystem.awaitTermination(Duration.Inf))(global)
+    def whenTerminated: Future[Unit] = Future {
+      blocking { actorSystem.awaitTermination(Duration.Inf) }
+    }(global)
   }
 }

--- a/util/src/main/scala-2.10/org/ensime/AkkaBackCompat.scala
+++ b/util/src/main/scala-2.10/org/ensime/AkkaBackCompat.scala
@@ -4,14 +4,14 @@ package org.ensime
 
 import akka.actor.ActorSystem
 
-import scala.concurrent.Await
-import scala.concurrent.duration._
-import scala.util.Try
+import scala.concurrent.Future
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.duration.Duration
 
-object AkkaBackCompat {
+trait AkkaBackCompat {
   implicit class ActorSystemShutdownBackCompat(val actorSystem: ActorSystem) {
-    def close(): Try[Unit] = Try(actorSystem.shutdown())
+    def terminate(): Future[Unit] = Future.successful(actorSystem.shutdown())
 
-    def awaitClosure(d: Duration = Duration.Inf): Try[Unit] = Try(actorSystem.awaitTermination(d))
+    def whenTerminated: Future[Unit] = Future(actorSystem.awaitTermination(Duration.Inf))(global)
   }
 }

--- a/util/src/main/scala-2.11/org/ensime/AkkaBackCompat.scala
+++ b/util/src/main/scala-2.11/org/ensime/AkkaBackCompat.scala
@@ -1,0 +1,17 @@
+// Copyright: 2010 - 2016 https://github.com/ensime/ensime-server/graphs
+// License: http://www.gnu.org/licenses/gpl-3.0.en.html
+package org.ensime
+
+import akka.actor.{ ActorSystem, Terminated }
+
+import scala.concurrent.Await
+import scala.concurrent.duration._
+import scala.util.Try
+
+object AkkaBackCompat {
+  implicit class ActorSystemShutdownBackCompat(val actorSystem: ActorSystem) {
+    def close(): Try[Unit] = Try(actorSystem.terminate)
+
+    def awaitClosure(d: Duration = Duration.Inf): Try[Terminated] = Try(Await.result(actorSystem.whenTerminated, d))
+  }
+}

--- a/util/src/main/scala-2.11/org/ensime/AkkaBackCompat.scala
+++ b/util/src/main/scala-2.11/org/ensime/AkkaBackCompat.scala
@@ -2,16 +2,4 @@
 // License: http://www.gnu.org/licenses/gpl-3.0.en.html
 package org.ensime
 
-import akka.actor.{ ActorSystem, Terminated }
-
-import scala.concurrent.Await
-import scala.concurrent.duration._
-import scala.util.Try
-
-object AkkaBackCompat {
-  implicit class ActorSystemShutdownBackCompat(val actorSystem: ActorSystem) {
-    def close(): Try[Unit] = Try(actorSystem.terminate)
-
-    def awaitClosure(d: Duration = Duration.Inf): Try[Terminated] = Try(Await.result(actorSystem.whenTerminated, d))
-  }
-}
+trait AkkaBackCompat


### PR DESCRIPTION
Akka keeps writing to `STDOUT` on shutdown in 2.4.12. We may want to wait until we find a way to fix this before merging.