### PR TITLE
Infix flag for methods in auto-completion

### DIFF
--- a/api/src/main/scala/org/ensime/api/outgoing.scala
+++ b/api/src/main/scala/org/ensime/api/outgoing.scala
@@ -309,7 +309,8 @@ final case class CompletionInfo(
   typeInfo: Option[TypeInfo],
   name: String,
   relevance: Int,
-  toInsert: Option[String]
+  toInsert: Option[String],
+  isInfix: Boolean = false
 ) extends RpcResponse
 
 final case class CompletionInfoList(

--- a/api/src/test/scala/org/ensime/api/EnsimeTestData.scala
+++ b/api/src/test/scala/org/ensime/api/EnsimeTestData.scala
@@ -114,7 +114,7 @@ trait EnsimeTestData {
 
   val completionInfo = CompletionInfo(Some(typeInfo), "name", 90, Some("BAZ"))
 
-  val completionInfo2 = CompletionInfo(None, "name2", 91, None)
+  val completionInfo2 = CompletionInfo(None, "nam", 91, None, true)
 
   val completionInfoList = List(completionInfo, completionInfo2)
 

--- a/protocol-jerky/src/test/scala/org/ensime/jerky/JerkyFormatsSpec.scala
+++ b/protocol-jerky/src/test/scala/org/ensime/jerky/JerkyFormatsSpec.scala
@@ -484,17 +484,17 @@ class JerkyFormatsSpec extends EnsimeSpec with SprayJsonTestSupport with EnsimeT
 
     roundtrip(
       completionInfo: EnsimeServerMessage,
-      """{"name":"name","typeInfo":{"name":"type1","fullName":"FOO.type1","typehint":"BasicTypeInfo","typeParams":[],"typeArgs":[],"members":[],"declAs":{"typehint":"Method"}},"typehint":"CompletionInfo","relevance":90,"toInsert":"BAZ"}"""
+      """{"name":"name","typeInfo":{"name":"type1","fullName":"FOO.type1","typehint":"BasicTypeInfo","typeParams":[],"typeArgs":[],"members":[],"declAs":{"typehint":"Method"}},"typehint":"CompletionInfo","relevance":90,"isInfix":false,"toInsert":"BAZ"}"""
     )
 
     roundtrip(
       completionInfo2: EnsimeServerMessage,
-      """{"typehint":"CompletionInfo","name":"name2","relevance":91}"""
+      """{"typehint":"CompletionInfo","name":"nam","relevance":91,"isInfix":true}"""
     )
 
     roundtrip(
       CompletionInfoList("fooBar", List(completionInfo)): EnsimeServerMessage,
-      """{"typehint":"CompletionInfoList","prefix":"fooBar","completions":[{"typeInfo":{"name":"type1","fullName":"FOO.type1","typehint":"BasicTypeInfo","typeParams":[],"typeArgs":[],"members":[],"declAs":{"typehint":"Method"}},"name":"name","relevance":90,"toInsert":"BAZ"}]}"""
+      """{"typehint":"CompletionInfoList","prefix":"fooBar","completions":[{"typeInfo":{"name":"type1","fullName":"FOO.type1","typehint":"BasicTypeInfo","typeParams":[],"typeArgs":[],"members":[],"declAs":{"typehint":"Method"}},"name":"name","relevance":90,"isInfix":false,"toInsert":"BAZ"}]}"""
     )
 
     roundtrip(

--- a/protocol-swanky/src/test/scala/org/ensime/server/protocol/swank/SwankFormatsSpec.scala
+++ b/protocol-swanky/src/test/scala/org/ensime/server/protocol/swank/SwankFormatsSpec.scala
@@ -495,7 +495,7 @@ class SwankFormatsSpec extends EnsimeSpec with EnsimeTestData {
 
     marshal(
       completionInfo2: CompletionInfo,
-      """(:name "name2" :relevance 91)"""
+      """(:name "nam" :relevance 91 :is-infix t)"""
     )
 
     marshal(

--- a/protocol-swanky/src/test/scala/org/ensime/swanky/SwankyFormatsSpec.scala
+++ b/protocol-swanky/src/test/scala/org/ensime/swanky/SwankyFormatsSpec.scala
@@ -492,7 +492,7 @@ class SwankyFormatsSpec extends EnsimeSpec with EnsimeTestData {
 
     roundtrip(
       completionInfo2: CompletionInfo,
-      """(:ensime-api-completion-info (:name "name2" :relevance 91))"""
+      """(:ensime-api-completion-info (:name "nam" :relevance 91 :is-infix t))"""
     )
 
     roundtrip(


### PR DESCRIPTION
Solved ticket number #1475 

The resolution is:
Consider every method that is long 3 character or less to be a infix. I blacklisted `map` method because usually that's not used as infix. The method need also to have only one parameter set, the parameter set has to not be implicit and it has to have arity 1.
I didn't limit the infix flag only to methods made of symbols because there are some nice methods like `and`, `or`, `xor`, `ne`, `eq` that in my opinion should be infix.

@fommil I'd love to have an ensime sticker.
