### PR TITLE
Fix CanonSpec and EnsimeFileSpec for cases where JAVA_HOME is not set.

### DIFF
--- a/core/src/test/scala/org/ensime/core/CanonSpec.scala
+++ b/core/src/test/scala/org/ensime/core/CanonSpec.scala
@@ -3,12 +3,10 @@
 package org.ensime.core
 
 import java.io.File
-import java.nio.file._
-
-import scala.util.Properties.jdkHome
 
 import org.ensime.util.file._
 import org.ensime.util.path._
+import org.ensime.util.TestPaths.src
 import org.ensime.util.ensimefile._
 import org.ensime.util.EnsimeSpec
 import org.ensime.api._
@@ -64,7 +62,6 @@ class CanonSpec extends EnsimeSpec {
   }
 
   it should "canon an ArchiveFile" in withTempDir { dir =>
-    val src = Paths.get(jdkHome) / "src.zip"
 
     val entry = EnsimeFile(s"$src!/java/lang/String.java")
     val extracted = RawFile(dir.toPath / "dep-src/source-jars/java/lang/String.java")

--- a/testutil/src/main/scala/org/ensime/util/TestPaths.scala
+++ b/testutil/src/main/scala/org/ensime/util/TestPaths.scala
@@ -1,0 +1,9 @@
+package org.ensime.util
+
+import java.nio.file._
+import scala.util.Properties.jdkHome
+import org.ensime.util.path._
+
+object TestPaths {
+  lazy val src: Path = Paths.get(jdkHome.stripSuffix("/jre")) / "src.zip"
+}

--- a/util/src/test/scala/org/ensime/util/EnsimeFileSpec.scala
+++ b/util/src/test/scala/org/ensime/util/EnsimeFileSpec.scala
@@ -6,18 +6,15 @@ import java.io.File
 import java.net._
 import java.nio.file._
 
-import scala.util.Properties.jdkHome
-
 import org.ensime.api._
 import org.ensime.util.LegacyArchiveExtraction
 import org.ensime.util.ensimefile.Implicits.DefaultCharset
 import org.ensime.util.file.withTempDir
 import org.ensime.util.path._
+import org.ensime.util.TestPaths.src
 import org.scalatest._
 
 class EnsimeFileSpec extends FlatSpec with Matchers {
-
-  lazy val src: Path = Paths.get(jdkHome) / "src.zip"
 
   "EnsimeFile" should "construct instances from file paths" in {
     val filepath = "/foo/bar/baz.scala"


### PR DESCRIPTION
Fixes #1650 

- Remove (if exists) suffix "/jre" from result of 'Properties.jdkHome'.