### PR TITLE
Transits to scala-refactoring 0.11.0

### DIFF
--- a/core/src/it/scala/org/ensime/core/RefactoringHandlerSpec.scala
+++ b/core/src/it/scala/org/ensime/core/RefactoringHandlerSpec.scala
@@ -164,7 +164,7 @@ class RefactoringHandlerSpec extends EnsimeSpec
       val relevantExpectedPart = s"""|@@ -1,3 +1,2 @@
                                      |-import java.lang.Integer.{valueOf => vo}
                                      |-import java.lang.Integer.toBinaryString
-                                     |+import java.lang.Integer.{valueOf => vo, toBinaryString}
+                                     |+import java.lang.Integer.{toBinaryString, valueOf => vo}
                                      | import java.lang.String.valueOf
                                      |""".stripMargin
       val expectedContents = expectedDiffContent(file.path, relevantExpectedPart)

--- a/core/src/main/scala/org/ensime/core/Refactoring.scala
+++ b/core/src/main/scala/org/ensime/core/Refactoring.scala
@@ -139,11 +139,13 @@ trait RefactoringImpl { self: RichPresentationCompiler =>
         options = List(
           refactoring.SortImports,
           refactoring.SortImportSelectors,
-          refactoring.CollapseImports,
           refactoring.SimplifyWildcards,
-          refactoring.RemoveDuplicates,
-          refactoring.GroupImports(List("java", "scala"))
-        )
+          refactoring.RemoveDuplicates
+        ),
+        config = Some(OrganizeImports.OrganizeImportsConfig(
+          importsStrategy = Some(OrganizeImports.ImportsStrategy.CollapseImports),
+          groups = List("java", "scala")
+        ))
       ))
     }.result
 

--- a/project/EnsimeBuild.scala
+++ b/project/EnsimeBuild.scala
@@ -174,8 +174,8 @@ object EnsimeBuild {
         "com.typesafe.akka" %% "akka-slf4j" % akkaVersion.value,
         scalaBinaryVersion.value match {
           // see notes in https://github.com/ensime/ensime-server/pull/1446
-          case "2.10" => "org.scala-refactoring" % "org.scala-refactoring.library_2.10.6" % "0.10.0"
-          case "2.11" => "org.scala-refactoring" % "org.scala-refactoring.library_2.11.8" % "0.10.0"
+          case "2.10" => "org.scala-refactoring" % "org.scala-refactoring.library_2.10.6" % "0.11.0-rc2"
+          case "2.11" => "org.scala-refactoring" % "org.scala-refactoring.library_2.11.8" % "0.11.0-rc2"
         },
         "commons-lang" % "commons-lang" % "2.6",
         "com.googlecode.java-diff-utils" % "diffutils" % "1.3.0",


### PR DESCRIPTION
Enables Organize Imports functionality to work with scala-refactoring 0.11.0 family version

