### PR TITLE
convert hard coded system properties into configuration classes

### DIFF
--- a/api/src/main/scala/org/ensime/api/config.scala
+++ b/api/src/main/scala/org/ensime/api/config.scala
@@ -3,7 +3,6 @@
 package org.ensime.api
 
 import java.io.File
-import scala.util.Properties._
 
 // there is quite a lot of code in this file, when we clean up the
 // config file format so that a lot of these hacks are no longer
@@ -34,10 +33,6 @@ final case class EnsimeConfig(
   // some marshalling libs (e.g. spray-json) might not like extra vals
   val modules = subprojects.map { module => (module.name, module) }.toMap
 
-  def compileClasspath: Set[File] = modules.values.toSet.flatMap {
-    m: EnsimeModule => m.compileDeps ++ m.testDeps
-  } ++ (if (propOrFalse("ensime.sourceMode")) List.empty else targetClasspath)
-
   def targetClasspath: Set[File] = modules.values.toSet.flatMap {
     m: EnsimeModule => m.targets ++ m.testTargets
   }
@@ -55,7 +50,6 @@ final case class EnsimeConfig(
 
   def scalaLibrary: Option[File] = allJars.find(_.getName.startsWith("scala-library"))
 }
-
 final case class EnsimeModule(
     name: String,
     targets: List[File],
@@ -101,3 +95,5 @@ final case class EnsimeProject(
 ) {
   sources.foreach(f => require(f.exists, "" + f + " is required but does not exist"))
 }
+
+final case class EnsimeServerConfig(shutDownOnDisconnect: Boolean, test: Boolean, exitAfterIndex: Boolean, disableSourceMonitoring: Boolean, disableClassMonitoring: Boolean, sourceMode: Boolean, legacyJarurls: Boolean, protocol: String, ENSIME_EXPERIMENTAL_H2: String = "jdbc:h2:file:", ENSIME_SKIP_JRE_INDEX: Boolean, parallelThread: Int)

--- a/api/src/main/scala/org/ensime/api/config.scala
+++ b/api/src/main/scala/org/ensime/api/config.scala
@@ -96,4 +96,4 @@ final case class EnsimeProject(
   sources.foreach(f => require(f.exists, "" + f + " is required but does not exist"))
 }
 
-final case class EnsimeServerConfig(shutDownOnDisconnect: Boolean, test: Boolean, exitAfterIndex: Boolean, disableSourceMonitoring: Boolean, disableClassMonitoring: Boolean, sourceMode: Boolean, legacyJarurls: Boolean, protocol: String, ENSIME_EXPERIMENTAL_H2: String = "jdbc:h2:file:", ENSIME_SKIP_JRE_INDEX: Boolean, parallelThread: Int)
+final case class EnsimeServerConfig(shutDownOnDisconnect: Boolean, test: Boolean, exitAfterIndex: Boolean, disableSourceMonitoring: Boolean, disableClassMonitoring: Boolean, sourceMode: Boolean, protocol: String, ENSIME_EXPERIMENTAL_H2: String = "jdbc:h2:file:", ENSIME_SKIP_JRE_INDEX: Boolean, parallelThread: Int)

--- a/core/src/it/scala/org/ensime/fixture/AnalyzerFixture.scala
+++ b/core/src/it/scala/org/ensime/fixture/AnalyzerFixture.scala
@@ -5,6 +5,7 @@ package org.ensime.fixture
 import akka.actor._
 import akka.testkit._
 import org.ensime.api._
+import org.ensime.config.EnsimeConfigProtocol
 import org.ensime.core._
 import org.ensime.vfs._
 import org.ensime.indexer.SearchService
@@ -14,7 +15,7 @@ trait AnalyzerFixture {
 }
 
 object AnalyzerFixture {
-  private[fixture] def create(search: SearchService)(implicit system: ActorSystem, config: EnsimeConfig, vfs: EnsimeVFS): TestActorRef[Analyzer] = {
+  private[fixture] def create(search: SearchService)(implicit system: ActorSystem, config: EnsimeConfig, serverConfig: EnsimeServerConfig, vfs: EnsimeVFS): TestActorRef[Analyzer] = {
     val indexer = TestProbe()
     val projectActor = TestProbe()
     TestActorRef(Analyzer(projectActor.ref, indexer.ref, search))
@@ -31,6 +32,7 @@ trait IsolatedAnalyzerFixture
     withVFS { implicit vfs =>
       withTestKit { testkit =>
         import testkit._
+        implicit val s = EnsimeConfigProtocol.parse("")
         withSearchService { (config, search) =>
           implicit val c = config
           testCode(config, AnalyzerFixture.create(search))
@@ -52,6 +54,7 @@ trait SharedAnalyzerFixture
     super.beforeAll()
     implicit val sys = _testkit.system
     implicit val config = _config
+    implicit val serverConfig = _serverConfig
     analyzer = AnalyzerFixture.create(_search)
   }
 

--- a/core/src/it/scala/org/ensime/fixture/EnsimeConfigFixture.scala
+++ b/core/src/it/scala/org/ensime/fixture/EnsimeConfigFixture.scala
@@ -22,7 +22,7 @@ trait EnsimeConfigFixture {
 
   def copyTargets: Boolean = true
 
-  def withEnsimeConfig(testCode: EnsimeConfig => Any): Any
+  def withEnsimeConfig(testCode: (EnsimeConfig) => Any): Any
 
   // convenience method
   def main(lang: String)(implicit config: EnsimeConfig): File =
@@ -51,8 +51,8 @@ object EnsimeConfigFixture {
   lazy val dotEnsimeCache = File("../.ensime_cache")
   dotEnsimeCache.mkdirs()
   private implicit def charset = Charset.defaultCharset()
-  lazy val EnsimeTestProject = EnsimeConfigProtocol.parse(dotEnsime.readString())
-
+  lazy val EnsimeTestProject = EnsimeConfigProtocol.parse(dotEnsime.readString(), "")
+  lazy val EnsimeServerTestProject = EnsimeConfigProtocol.parse("")
   // not completely empty, has a reference to the scala-library jar
   lazy val EmptyTestProject: EnsimeConfig = EnsimeTestProject.copy(
     subprojects = EnsimeTestProject.subprojects.filter(_.name == "testing_empty"),
@@ -168,7 +168,7 @@ trait IsolatedEnsimeConfigFixture extends Suite
   //with ParallelTestExecution {
   import EnsimeConfigFixture._
 
-  override def withEnsimeConfig(testCode: EnsimeConfig => Any): Any = withTempDir {
+  override def withEnsimeConfig(testCode: (EnsimeConfig) => Any): Any = withTempDir {
     dir => testCode(cloneForTesting(original, dir, copyTargets))
   }
 }
@@ -184,6 +184,7 @@ trait SharedEnsimeConfigFixture extends Suite
   private val tmpDir = Files.createTempDir()
 
   private[fixture] var _config: EnsimeConfig = _
+  private[fixture] var _serverConfig: EnsimeServerConfig = _
 
   override def beforeAll(): Unit = {
     super.beforeAll()

--- a/core/src/it/scala/org/ensime/fixture/JavaCompilerFixture.scala
+++ b/core/src/it/scala/org/ensime/fixture/JavaCompilerFixture.scala
@@ -7,11 +7,13 @@ import java.io.File
 import akka.actor.ActorSystem
 import akka.testkit.TestProbe
 import org.ensime.api._
+import org.ensime.config.EnsimeConfigProtocol
 import org.ensime.core.javac.JavaCompiler
 import org.ensime.vfs._
 import org.ensime.indexer._
 import org.ensime.util._
 import org.ensime.util.file._
+
 import scala.collection.immutable.Queue
 
 trait JavaCompilerFixture {
@@ -73,6 +75,7 @@ trait IsolatedJavaCompilerFixture
     withVFS { implicit vfs =>
       withTestKit { testkit =>
         import testkit._
+        implicit val s = EnsimeConfigProtocol.parse("")
         withSearchService { (config, search) =>
           withEnsimeConfig { config =>
             val reportHandler = new JavaStoreReporter

--- a/core/src/it/scala/org/ensime/fixture/RichPresentationCompilerFixture.scala
+++ b/core/src/it/scala/org/ensime/fixture/RichPresentationCompilerFixture.scala
@@ -16,7 +16,7 @@ import org.ensime.indexer._
 import org.ensime.util.{ PresentationReporter, ReportHandler }
 import org.ensime.vfs._
 import org.slf4j.LoggerFactory
-
+import org.ensime.config._
 trait RichPresentationCompilerFixture {
   def withRichPresentationCompiler(
     testCode: (TestKitFix, EnsimeConfig, RichPresentationCompiler) => Any
@@ -59,7 +59,7 @@ object RichPresentationCompilerFixture {
     settings.verbose.value = presCompLog.isDebugEnabled
     //settings.usejavacp.value = true
     settings.bootclasspath.append(scalaLib.getAbsolutePath)
-    settings.classpath.value = config.compileClasspath.mkString(File.pathSeparator)
+    settings.classpath.value = config.compileClasspath(EnsimeConfigProtocol.parse("")).mkString(File.pathSeparator)
 
     val reporter = new TestReporter
     val indexer = TestProbe()
@@ -83,6 +83,7 @@ trait IsolatedRichPresentationCompilerFixture
     withVFS { implicit vfs =>
       withTestKit { testkit =>
         import testkit._
+        implicit val s = EnsimeConfigProtocol.parse("")
         withSearchService { (config, search) =>
           import org.ensime.fixture.RichPresentationCompilerFixture._
           val pc = create(config, search)

--- a/core/src/it/scala/org/ensime/fixture/SearchServiceFixture.scala
+++ b/core/src/it/scala/org/ensime/fixture/SearchServiceFixture.scala
@@ -14,8 +14,8 @@ import org.ensime.vfs._
 
 trait IsolatedSearchServiceFixture extends IsolatedSourceResolverFixture with AkkaBackCompat {
 
-  def withSearchService(testCode: (EnsimeConfig, SearchService) => Any)(implicit actorSystem: ActorSystem, vfs: EnsimeVFS): Any = withSourceResolver { (config, resolver) =>
-    val searchService = new SearchService(config, resolver)
+  def withSearchService(testCode: (EnsimeConfig, SearchService) => Any)(implicit actorSystem: ActorSystem, serverConfig: EnsimeServerConfig, vfs: EnsimeVFS): Any = withSourceResolver { (config, resolver) =>
+    val searchService = new SearchService(config, serverConfig, resolver)
     try {
       testCode(config, searchService)
     } finally {
@@ -36,7 +36,7 @@ trait SharedSearchServiceFixture
   override def beforeAll(): Unit = {
     super.beforeAll()
     implicit val system = _testkit.system
-    _search = new SearchService(_config, _resolver)
+    _search = new SearchService(_config, _serverConfig, _resolver)
   }
 
   override def afterAll(): Unit = {

--- a/core/src/it/scala/org/ensime/fixture/SourceResolverFixture.scala
+++ b/core/src/it/scala/org/ensime/fixture/SourceResolverFixture.scala
@@ -26,7 +26,7 @@ trait IsolatedSourceResolverFixture
       }
     }
   }
-  override def withSourceResolver(testCode: (EnsimeConfig, SourceResolver) => Any): Any = withEnsimeConfig { config =>
+  override def withSourceResolver(testCode: (EnsimeConfig, SourceResolver) => Any): Any = withEnsimeConfig { (config) =>
     withTestKit { testKit ⇒
       import testKit.system
       implicit val vfs = EnsimeVFS()

--- a/core/src/it/scala/org/ensime/intg/DebugTest.scala
+++ b/core/src/it/scala/org/ensime/intg/DebugTest.scala
@@ -18,7 +18,7 @@ import org.ensime.fixture._
 import org.ensime.util._
 import org.ensime.util.file._
 import org.scalatest.Matchers
-
+import org.ensime.config._
 // must be refreshing as the tests don't clean up after themselves properly
 class DebugTest extends EnsimeSpec
     with IsolatedEnsimeConfigFixture
@@ -30,7 +30,7 @@ class DebugTest extends EnsimeSpec
     javaLibs = Nil // no need to index the JRE
   )
 
-  "Debug - stepping" should "be able to step over/in/out" in withEnsimeConfig { implicit config =>
+  "Debug - stepping" should "be able to step over/in/out" in withEnsimeConfig { implicit config: EnsimeConfig =>
     withTestKit { implicit testkit =>
       withProject { (project, asyncHelper) =>
         implicit val p = (project, asyncHelper)
@@ -61,7 +61,7 @@ class DebugTest extends EnsimeSpec
     }
   }
 
-  "Breakpoints" should "trigger/continue" in withEnsimeConfig { implicit config =>
+  "Breakpoints" should "trigger/continue" in withEnsimeConfig { implicit config: EnsimeConfig =>
     withTestKit { implicit testkit =>
       withProject { (project, asyncHelper) =>
         implicit val p = (project, asyncHelper)
@@ -135,7 +135,7 @@ class DebugTest extends EnsimeSpec
     }
   }
 
-  it should "list/clear" in withEnsimeConfig { implicit config =>
+  it should "list/clear" in withEnsimeConfig { implicit config: EnsimeConfig =>
     withTestKit { implicit testkit =>
       withProject { (project, asyncHelper) =>
         implicit val p = (project, asyncHelper)
@@ -180,7 +180,7 @@ class DebugTest extends EnsimeSpec
     }
   }
 
-  "Debug variables" should "inspect variables" in withEnsimeConfig { implicit config =>
+  "Debug variables" should "inspect variables" in withEnsimeConfig { implicit config: EnsimeConfig =>
     withTestKit { implicit testkit =>
       withProject { (project, asyncHelper) =>
         implicit val p = (project, asyncHelper)
@@ -258,7 +258,7 @@ class DebugTest extends EnsimeSpec
     }
   }
 
-  they should "be able to convert variables to string representations" in withEnsimeConfig { implicit config =>
+  they should "be able to convert variables to string representations" in withEnsimeConfig { implicit config: EnsimeConfig =>
     withTestKit { implicit testkit =>
       withProject { (project, asyncHelper) =>
         implicit val p = (project, asyncHelper)
@@ -309,7 +309,7 @@ class DebugTest extends EnsimeSpec
     }
   }
 
-  they should "be retrievable for the BugFromGitter scenario" in withEnsimeConfig { implicit config =>
+  they should "be retrievable for the BugFromGitter scenario" in withEnsimeConfig { implicit config: EnsimeConfig =>
     withTestKit { implicit testkit =>
       withProject { (project, asyncHelper) =>
         implicit val p = (project, asyncHelper)
@@ -336,7 +336,7 @@ class DebugTest extends EnsimeSpec
     }
   }
 
-  they should "set variable values" in withEnsimeConfig { implicit config =>
+  they should "set variable values" in withEnsimeConfig { implicit config: EnsimeConfig =>
     withTestKit { implicit testkit =>
       withProject { (project, asyncHelper) =>
         implicit val p = (project, asyncHelper)
@@ -463,7 +463,7 @@ class DebugTest extends EnsimeSpec
     }
   }
 
-  "Debug backtrace" should "generate backtrace" in withEnsimeConfig { implicit config =>
+  "Debug backtrace" should "generate backtrace" in withEnsimeConfig { implicit config: EnsimeConfig =>
     withTestKit { implicit testkit =>
       withProject { (project, asyncHelper) =>
         implicit val p = (project, asyncHelper)
@@ -625,7 +625,7 @@ object VMStarter extends SLF4JLogging {
     // would be nice to have ephemeral debug ports
     val port = 5000 + scala.util.Random.nextInt(1000)
 
-    val classpath = (config.compileClasspath ++ config.targetClasspath).mkString(File.pathSeparator)
+    val classpath = (config.compileClasspath(EnsimeConfigProtocol.parse("")) ++ config.targetClasspath).mkString(File.pathSeparator)
     val args = Seq(
       java,
       "-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=" + port,

--- a/core/src/main/scala/org/ensime/config/EnsimeConfigProtocol.scala
+++ b/core/src/main/scala/org/ensime/config/EnsimeConfigProtocol.scala
@@ -32,7 +32,7 @@ object EnsimeConfigProtocol {
     val serverConfigRaw = serverConfig.parseSexp.convertTo[EnsimeServerConfig]
     validated(raw).copy(javaLibs = inferJavaLibs(raw.javaHome, serverConfigRaw))
   }
-
+  def parse(serverConfig: String):EnsimeServerConfig = ???
   // there are lots of JRE libs, but most people only care about
   // rt.jar --- this could be parameterised.
   private def inferJavaLibs(javaHome: File, serverConfig: EnsimeServerConfig): List[File] =

--- a/core/src/main/scala/org/ensime/config/EnsimeConfigProtocol.scala
+++ b/core/src/main/scala/org/ensime/config/EnsimeConfigProtocol.scala
@@ -32,7 +32,7 @@ object EnsimeConfigProtocol {
     val serverConfigRaw = serverConfig.parseSexp.convertTo[EnsimeServerConfig]
     validated(raw).copy(javaLibs = inferJavaLibs(raw.javaHome, serverConfigRaw))
   }
-  def parse(serverConfig: String):EnsimeServerConfig = ???
+  def parse(serverConfig: String): EnsimeServerConfig = ???
   // there are lots of JRE libs, but most people only care about
   // rt.jar --- this could be parameterised.
   private def inferJavaLibs(javaHome: File, serverConfig: EnsimeServerConfig): List[File] =

--- a/core/src/main/scala/org/ensime/config/Environment.scala
+++ b/core/src/main/scala/org/ensime/config/Environment.scala
@@ -31,7 +31,4 @@ object Environment {
   private def ensimeVersion: String =
     BuildInfo.version
 
-  def shutdownOnDisconnectFlag: Boolean = {
-    Option(System.getProperty("ensime.explode.on.disconnect")).isDefined
-  }
 }

--- a/core/src/main/scala/org/ensime/config/package.scala
+++ b/core/src/main/scala/org/ensime/config/package.scala
@@ -14,6 +14,10 @@ package object config {
   implicit class RichEnsimeConfig(val c: EnsimeConfig) extends AnyVal {
     def scalaSourceFiles: Set[File] =
       c.modules.values.flatMap((m: EnsimeModule) => m.scalaSourceFiles)(breakOut)
+    def compileClasspath(serverConfig: EnsimeServerConfig): Set[File] = c.modules.values.toSet.flatMap {
+      m: EnsimeModule => m.compileDeps ++ m.testDeps
+    } ++ (if (serverConfig.sourceMode) List.empty else c.targetClasspath)
+
   }
 
   implicit class RichEnsimeModule(val m: EnsimeModule) extends AnyVal {

--- a/core/src/main/scala/org/ensime/core/debug/DebugActor.scala
+++ b/core/src/main/scala/org/ensime/core/debug/DebugActor.scala
@@ -27,8 +27,8 @@ object DebugActor {
    * @param config The Ensime configuration used for source file lookup
    * @return The new Akka props instance
    */
-  def props(broadcaster: ActorRef)(implicit config: EnsimeConfig): Props =
-    Props(new DebugActor(broadcaster, config))
+  def props(broadcaster: ActorRef)(implicit config: EnsimeConfig, serverConfig: EnsimeServerConfig): Props =
+    Props(new DebugActor(broadcaster, config, serverConfig))
 }
 
 /**
@@ -41,9 +41,10 @@ object DebugActor {
  */
 class DebugActor private (
     private val broadcaster: ActorRef,
-    private val config: EnsimeConfig
+    private val config: EnsimeConfig,
+    private val serverConfig: EnsimeServerConfig
 ) extends Actor with ActorLogging {
-  private val sourceMap: SourceMap = new SourceMap(config = config)
+  private val sourceMap: SourceMap = new SourceMap(config = config, serverConfig = serverConfig)
   private val converter: StructureConverter = new StructureConverter(sourceMap)
   private val vmm: VirtualMachineManager = new VirtualMachineManager(
     // Signal to the user that the JVM has disconnected

--- a/core/src/main/scala/org/ensime/core/debug/SourceMap.scala
+++ b/core/src/main/scala/org/ensime/core/debug/SourceMap.scala
@@ -7,11 +7,11 @@ import java.io.File
 import java.util.concurrent.ConcurrentHashMap
 
 import org.ensime.api._
-import org.ensime.config._
+
 import org.ensime.util.ensimefile._
 import org.ensime.util.file._
+import org.ensime.config._
 import org.scaladebugger.api.profiles.traits.info.LocationInfoProfile
-
 import scala.collection.mutable
 
 /**
@@ -25,6 +25,7 @@ import scala.collection.mutable
 @deprecating("this is duplicating the functionality of the indexer and source resolver")
 class SourceMap(
     private val config: EnsimeConfig,
+    private val serverConfig: EnsimeServerConfig,
     private val pathMap: mutable.Map[String, File] = new ConcurrentHashMap[String, File]().asScala
 ) {
   /** Contains a collection of root paths where source files are located */
@@ -139,7 +140,7 @@ class SourceMap(
    * @return The distinct root paths as strings
    */
   protected def retrieveRoots: Seq[String] = (
-    config.compileClasspath.map(_.getCanonicalPath).toSeq ++
+    config.compileClasspath(serverConfig).map(_.getCanonicalPath).toSeq ++
     config.javaSources.map(_.getCanonicalPath) ++
     config.subprojects.flatMap(_.sourceRoots).map(_.getCanonicalPath)
   ).distinct

--- a/core/src/main/scala/org/ensime/indexer/FileWatchers.scala
+++ b/core/src/main/scala/org/ensime/indexer/FileWatchers.scala
@@ -5,7 +5,6 @@ package org.ensime.indexer
 import akka.actor.Actor
 import akka.event.slf4j.SLF4JLogging
 import org.apache.commons.vfs2._
-import scala.util.Properties._
 
 import org.ensime.api._
 import org.ensime.vfs._
@@ -37,6 +36,7 @@ trait Watcher {
  */
 class ClassfileWatcher(
     config: EnsimeConfig,
+    serverConfig: EnsimeServerConfig,
     listeners: Seq[FileChangeListener]
 )(
     implicit
@@ -44,7 +44,7 @@ class ClassfileWatcher(
 ) extends Actor with SLF4JLogging {
 
   private val impls =
-    if (propOrFalse("ensime.disableClassMonitoring")) Nil
+    if (serverConfig.disableClassMonitoring) Nil
     else {
       val jarJava7WatcherBuilder = new JarJava7WatcherBuilder()
       val classJava7WatcherBuilder = new ClassJava7WatcherBuilder()
@@ -72,13 +72,14 @@ class ClassfileWatcher(
 
 class SourceWatcher(
     config: EnsimeConfig,
+    serverConfig: EnsimeServerConfig,
     listeners: Seq[FileChangeListener]
 )(
     implicit
     vfs: EnsimeVFS
 ) extends Watcher with SLF4JLogging {
   private val impls =
-    if (propOrFalse("ensime.disableSourceMonitoring")) Nil
+    if (serverConfig.disableSourceMonitoring) Nil
     else {
       val sourceJava7WatcherBuilder = new SourceJava7WatcherBuilder()
       for {

--- a/core/src/main/scala/org/ensime/indexer/database/DatabaseService.scala
+++ b/core/src/main/scala/org/ensime/indexer/database/DatabaseService.scala
@@ -16,10 +16,10 @@ import org.ensime.util.file._
 import org.ensime.vfs._
 import slick.driver.H2Driver.api._
 
-class DatabaseService(dir: File) extends SLF4JLogging {
+class DatabaseService(dir: File, serverConfig: EnsimeServerConfig) extends SLF4JLogging {
   lazy val (datasource, db) = {
     // MVCC plus connection pooling speeds up the tests ~10%
-    val backend = sys.env.get("ENSIME_EXPERIMENTAL_H2").getOrElse("jdbc:h2:file:")
+    val backend = serverConfig.ENSIME_EXPERIMENTAL_H2
     val url = backend + dir.getAbsolutePath + "/db;MVCC=TRUE"
     val driver = "org.h2.Driver"
 

--- a/core/src/test/scala/org/ensime/config/EnsimeConfigSpec.scala
+++ b/core/src/test/scala/org/ensime/config/EnsimeConfigSpec.scala
@@ -13,8 +13,8 @@ class EnsimeConfigSpec extends EnsimeSpec {
 
   import EscapingStringInterpolation._
 
-  def test(dir: File, contents: String, testFn: (EnsimeConfig) => Unit): Unit = {
-    testFn(EnsimeConfigProtocol.parse(contents))
+  def test(dir: File, contents: String, contents2: String, testFn: (EnsimeConfig) => Unit): Unit = {
+    testFn(EnsimeConfigProtocol.parse(contents, contents2))
   }
 
   "EnsimeConfig" should "parse a simple config" in withTempDir { dir =>
@@ -50,7 +50,7 @@ class EnsimeConfigSpec extends EnsimeSpec {
              :javac-options ()
              :library-jars ()
              :library-sources ()
-             :library-docs ())))""", { implicit config =>
+             :library-docs ())))""", """""", { implicit config =>
       config.name shouldBe "project"
       config.scalaVersion shouldBe "2.10.4"
       val module1 = config.modules("module1")
@@ -76,7 +76,7 @@ class EnsimeConfigSpec extends EnsimeSpec {
  :cache-dir "$cache"
  :subprojects ((:name "module1"
                 :scala-version "2.10.4"
-                :targets ("$abc"))))""", { implicit config =>
+                :targets ("$abc"))))""", """""", { implicit config =>
 
       config.name shouldBe "project"
       config.scalaVersion shouldBe "2.10.4"

--- a/core/src/test/scala/org/ensime/core/debug/SourceMapSpec.scala
+++ b/core/src/test/scala/org/ensime/core/debug/SourceMapSpec.scala
@@ -30,6 +30,7 @@ class SourceMapSpec extends EnsimeSpec with OneInstancePerTest with MockFactory 
   //       overriding protected methods used to retrieve information from config
   private val sourceMap = new SourceMap(
     config = null,
+    serverConfig = null,
     pathMap = testPathMap
   ) {
     override protected def retrieveRoots: Seq[String] = testRoots

--- a/server/src/main/scala/org/ensime/server/Server.scala
+++ b/server/src/main/scala/org/ensime/server/Server.scala
@@ -132,12 +132,12 @@ object Server extends AkkaBackCompat {
     val serverFile = new File(serverFileStr)
     if (!ensimeFile.exists() || !ensimeFile.isFile)
       throw new RuntimeException(s".ensime file ($ensimeFile) not found")
-    val finalServerFile = if (!serverFile.exists() || !serverFile.isFile){
+    val finalServerFile = if (!serverFile.exists() || !serverFile.isFile) {
       new File("~/.ensime-server")
-    }else serverFile
+    } else serverFile
 
-    implicit val serverConfig: EnsimeServerConfig = if(finalServerFile.exists() || !ensimeFile.isFile)
-      EnsimeConfigProtocol.parse(Files.toString(finalServerFile,Charsets.UTF_8))
+    implicit val serverConfig: EnsimeServerConfig = if (finalServerFile.exists() || !ensimeFile.isFile)
+      EnsimeConfigProtocol.parse(Files.toString(finalServerFile, Charsets.UTF_8))
     else {
       val shutDownOnDisconnect = Option(System.getProperty("ensime.explode.on.disconnect")).isDefined
       val test = propIsSet("ensime.server.test")
@@ -146,10 +146,10 @@ object Server extends AkkaBackCompat {
       val disableClassMonitoring = propOrFalse("ensime.disableClassMonitoring")
       val sourceMode = propOrFalse("ensime.sourceMode")
       val parallelThread = Properties.propOrElse("ensime.index.parallel", "10").toInt
-      val ENSIME_EXPERIMENTAL_H2 = sys.env.getOrElse("ENSIME_EXPERIMENTAL_H2","jdbc:h2:file:")
+      val ENSIME_EXPERIMENTAL_H2 = sys.env.getOrElse("ENSIME_EXPERIMENTAL_H2", "jdbc:h2:file:")
       val protocol = propOrElse("ensime.protocol", "swank")
       val ENSIME_SKIP_JRE_INDEX = Properties.envOrNone("ENSIME_SKIP_JRE_INDEX").isDefined
-      EnsimeServerConfig(shutDownOnDisconnect,test,exitAfterIndex,disableSourceMonitoring,disableClassMonitoring,sourceMode,protocol,ENSIME_EXPERIMENTAL_H2,ENSIME_SKIP_JRE_INDEX,parallelThread)
+      EnsimeServerConfig(shutDownOnDisconnect, test, exitAfterIndex, disableSourceMonitoring, disableClassMonitoring, sourceMode, protocol, ENSIME_EXPERIMENTAL_H2, ENSIME_SKIP_JRE_INDEX, parallelThread)
     }
     implicit val config: EnsimeConfig = try {
       EnsimeConfigProtocol.parse(Files.toString(ensimeFile, Charsets.UTF_8), Files.toString(serverFile, Charsets.UTF_8))

--- a/server/src/main/scala/org/ensime/server/Server.scala
+++ b/server/src/main/scala/org/ensime/server/Server.scala
@@ -132,11 +132,25 @@ object Server extends AkkaBackCompat {
     val serverFile = new File(serverFileStr)
     if (!ensimeFile.exists() || !ensimeFile.isFile)
       throw new RuntimeException(s".ensime file ($ensimeFile) not found")
-    if (!serverFile.exists() || !serverFile.isFile){
-      val serverFileNew = new File("~/.ensime-server")
-      if(!serverFileNew.exists() || !serverFileNew.isFile)
+    val finalServerFile = if (!serverFile.exists() || !serverFile.isFile){
+      new File("~/.ensime-server")
+    }else serverFile
+
+    implicit val serverConfig: EnsimeServerConfig = if(finalServerFile.exists() || !ensimeFile.isFile)
+      EnsimeConfigProtocol.parse(Files.toString(finalServerFile,Charsets.UTF_8))
+    else {
+      val shutDownOnDisconnect = Option(System.getProperty("ensime.explode.on.disconnect")).isDefined
+      val test = propIsSet("ensime.server.test")
+      val exitAfterIndex = propOrFalse("ensime.exitAfterIndex")
+      val disableSourceMonitoring = propOrFalse("ensime.disableSourceMonitoring")
+      val disableClassMonitoring = propOrFalse("ensime.disableClassMonitoring")
+      val sourceMode = propOrFalse("ensime.sourceMode")
+      val parallelThread = Properties.propOrElse("ensime.index.parallel", "10").toInt
+      val ENSIME_EXPERIMENTAL_H2 = sys.env.getOrElse("ENSIME_EXPERIMENTAL_H2","jdbc:h2:file:")
+      val protocol = propOrElse("ensime.protocol", "swank")
+      val ENSIME_SKIP_JRE_INDEX = Properties.envOrNone("ENSIME_SKIP_JRE_INDEX").isDefined
+      EnsimeServerConfig(shutDownOnDisconnect,test,exitAfterIndex,disableSourceMonitoring,disableClassMonitoring,sourceMode,protocol,ENSIME_EXPERIMENTAL_H2,ENSIME_SKIP_JRE_INDEX,parallelThread)
     }
-    implicit val serverConfig: EnsimeServerConfig = ???
     implicit val config: EnsimeConfig = try {
       EnsimeConfigProtocol.parse(Files.toString(ensimeFile, Charsets.UTF_8), Files.toString(serverFile, Charsets.UTF_8))
     } catch {

--- a/server/src/main/scala/org/ensime/server/Server.scala
+++ b/server/src/main/scala/org/ensime/server/Server.scala
@@ -125,16 +125,18 @@ object Server extends AkkaBackCompat {
       throw new RuntimeException("ensime.config (the location of the .ensime file) must be set")
     )
     val serverFileStr = propOrNone("server.config").getOrElse(
-      throw new RuntimeException("ensime.config (the location of the .server file) must be set")
+      "~/.config/ensime-server"
     )
 
     val ensimeFile = new File(ensimeFileStr)
     val serverFile = new File(serverFileStr)
     if (!ensimeFile.exists() || !ensimeFile.isFile)
       throw new RuntimeException(s".ensime file ($ensimeFile) not found")
-    if (!serverFile.exists() || !serverFile.isFile)
-      throw new RuntimeException(s".server file ($serverFile) not found")
-
+    if (!serverFile.exists() || !serverFile.isFile){
+      val serverFileNew = new File("~/.ensime-server")
+      if(!serverFileNew.exists() || !serverFileNew.isFile)
+    }
+    implicit val serverConfig: EnsimeServerConfig = ???
     implicit val config: EnsimeConfig = try {
       EnsimeConfigProtocol.parse(Files.toString(ensimeFile, Charsets.UTF_8), Files.toString(serverFile, Charsets.UTF_8))
     } catch {
@@ -142,7 +144,6 @@ object Server extends AkkaBackCompat {
         log.error(s"There was a problem parsing $ensimeFile", e)
         throw e
     }
-    implicit val serverConfig: EnsimeServerConfig = ???
     Canon.config = config
 
     val protocol: Protocol = serverConfig.protocol match {


### PR DESCRIPTION
This is to make .server file mandatory as part of #1346 . Added a new `EnsimeServerConfig` on the lines of `EnsimeConfig` . The `parse` method is left unimplemented and the WIP . @fommil please take a look .