### PR TITLE
2.12.0 support (not 2.12.1... yet)

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -37,5 +37,6 @@ pipeline:
 
 matrix:
   SCALA_VERSION:
+    - 2.12.0
     - 2.11.8
     - 2.10.6

--- a/core/src/it/scala/org/ensime/core/DocResolverSpec.scala
+++ b/core/src/it/scala/org/ensime/core/DocResolverSpec.scala
@@ -26,17 +26,26 @@ class DocResolverSpec extends EnsimeSpec
       serv.resolve(DocSigPair(
         DocSig(DocFqn("scala", "Some"), Some("map[B](f:A=>B):Option[B]")),
         DocSig(DocFqn("scala", "Some"), Some("map(scala.Function1)"))
-      )) shouldBe Some("docs/scala-library-" + c.scalaVersion + "-javadoc.jar/index.html#scala.Some@map[B](f:A=>B):Option[B]")
+      )) should (
+        equal(Some("docs/scala-library-" + c.scalaVersion + "-javadoc.jar/index.html#scala.Some@map[B](f:A=>B):Option[B]")) or
+        equal(Some("docs/scala-library-" + c.scalaVersion + "-javadoc.jar/scala/Some.html#map[B](f:A=>B):Option[B]"))
+      )
 
       serv.resolve(DocSigPair(
         DocSig(DocFqn("scala", "Some"), None),
         DocSig(DocFqn("scala", "Some"), None)
-      )) shouldBe Some("docs/scala-library-" + c.scalaVersion + "-javadoc.jar/index.html#scala.Some")
+      )) should (
+        equal(Some("docs/scala-library-" + c.scalaVersion + "-javadoc.jar/index.html#scala.Some")) or
+        equal(Some("docs/scala-library-" + c.scalaVersion + "-javadoc.jar/scala/Some.html"))
+      )
 
       serv.resolve(DocSigPair(
         DocSig(DocFqn("scala", "Some$"), None),
         DocSig(DocFqn("scala", "Some"), None)
-      )) shouldBe Some("docs/scala-library-" + c.scalaVersion + "-javadoc.jar/index.html#scala.Some")
+      )) should (
+        equal(Some("docs/scala-library-" + c.scalaVersion + "-javadoc.jar/index.html#scala.Some")) or
+        equal(Some("docs/scala-library-" + c.scalaVersion + "-javadoc.jar/scala/Some.html"))
+      )
 
       serv.resolve(DocSigPair(
         DocSig(DocFqn("com.google.common.io", "Files$"), Some("simplifyPath(x$1:String):String")),
@@ -46,7 +55,10 @@ class DocResolverSpec extends EnsimeSpec
       serv.resolve(DocSigPair(
         DocSig(DocFqn("scala", "Boolean"), None),
         DocSig(DocFqn("", "boolean"), None)
-      )) shouldBe Some("docs/scala-library-" + c.scalaVersion + "-javadoc.jar/index.html#scala.Boolean")
+      )) should (
+        equal(Some("docs/scala-library-" + c.scalaVersion + "-javadoc.jar/index.html#scala.Boolean")) or
+        equal(Some("docs/scala-library-" + c.scalaVersion + "-javadoc.jar/scala/Boolean.html"))
+      )
 
       serv.resolve(DocSigPair(
         DocSig(DocFqn("com.google.common.io", "Files$"), Some("simplifyPath(x$1:String):String")),
@@ -56,7 +68,10 @@ class DocResolverSpec extends EnsimeSpec
       serv.resolve(DocSigPair(
         DocSig(DocFqn("scala", "Option"), Some("isDefined:Boolean")),
         DocSig(DocFqn("scala", "Option"), Some("isDefined"))
-      )) shouldBe Some("docs/scala-library-" + c.scalaVersion + "-javadoc.jar/index.html#scala.Option@isDefined:Boolean")
+      )) should (
+        equal(Some("docs/scala-library-" + c.scalaVersion + "-javadoc.jar/index.html#scala.Option@isDefined:Boolean")) or
+        equal(Some("docs/scala-library-" + c.scalaVersion + "-javadoc.jar/scala/Option.html#isDefined:Boolean"))
+      )
 
       serv.resolve(DocSigPair(
         DocSig(DocFqn("com.google.common.io", "Files$"), Some("simplifyPath(x$1:String):String")),
@@ -66,7 +81,10 @@ class DocResolverSpec extends EnsimeSpec
       serv.resolve(DocSigPair(
         DocSig(DocFqn("scala", "Some"), Some("flatMap[B](f:A=>Option[B]):Option[B]")),
         DocSig(DocFqn("scala", "Some"), Some("flatMap(scala.Function1)"))
-      )) shouldBe Some("docs/scala-library-" + c.scalaVersion + "-javadoc.jar/index.html#scala.Some@flatMap[B](f:A=>Option[B]):Option[B]")
+      )) should (
+        equal(Some("docs/scala-library-" + c.scalaVersion + "-javadoc.jar/index.html#scala.Some@flatMap[B](f:A=>Option[B]):Option[B]")) or
+        equal(Some("docs/scala-library-" + c.scalaVersion + "-javadoc.jar/scala/Some.html#flatMap[B](f:A=>Option[B]):Option[B]"))
+      )
 
       serv.resolve(DocSigPair(
         DocSig(DocFqn("com.google.common.io", "Files$"), Some("simplifyPath(x$1:String):String")),
@@ -76,7 +94,10 @@ class DocResolverSpec extends EnsimeSpec
       serv.resolve(DocSigPair(
         DocSig(DocFqn("scala", "Some"), Some("flatten[B](implicitev:<:<[A,Option[B]]):Option[B]")),
         DocSig(DocFqn("scala", "Some"), Some("flatten(scala.Predef.<:<)"))
-      )) shouldBe Some("docs/scala-library-" + c.scalaVersion + "-javadoc.jar/index.html#scala.Some@flatten[B](implicitev:<:<[A,Option[B]]):Option[B]")
+      )) should (
+        equal(Some("docs/scala-library-" + c.scalaVersion + "-javadoc.jar/index.html#scala.Some@flatten[B](implicitev:<:<[A,Option[B]]):Option[B]")) or
+        equal(Some("docs/scala-library-" + c.scalaVersion + "-javadoc.jar/scala/Some.html#flatten[B](implicitev:<:<[A,Option[B]]):Option[B]"))
+      )
 
       serv.resolve(DocSigPair(
         DocSig(DocFqn("com.google.common.io", "Files$"), Some("simplifyPath(x$1:String):String")),
@@ -86,7 +107,10 @@ class DocResolverSpec extends EnsimeSpec
       serv.resolve(DocSigPair(
         DocSig(DocFqn("scala", "Some"), Some("fold[B](ifEmpty:=>B)(f:A=>B):B")),
         DocSig(DocFqn("scala", "Some"), Some("fold(scala.<byname>, scala.Function1)"))
-      )) shouldBe Some("docs/scala-library-" + c.scalaVersion + "-javadoc.jar/index.html#scala.Some@fold[B](ifEmpty:=>B)(f:A=>B):B")
+      )) should (
+        equal(Some("docs/scala-library-" + c.scalaVersion + "-javadoc.jar/index.html#scala.Some@fold[B](ifEmpty:=>B)(f:A=>B):B")) or
+        equal(Some("docs/scala-library-" + c.scalaVersion + "-javadoc.jar/scala/Some.html#fold[B](ifEmpty:=>B)(f:A=>B):B"))
+      )
 
       serv.resolve(DocSigPair(
         DocSig(DocFqn("com.google.common.io", "Files$"), Some("simplifyPath(x$1:String):String")),
@@ -96,7 +120,10 @@ class DocResolverSpec extends EnsimeSpec
       serv.resolve(DocSigPair(
         DocSig(DocFqn("scala", "Some"), Some("mkString(start:String,sep:String,end:String):String")),
         DocSig(DocFqn("scala", "Some"), Some("mkString(java.lang.String, java.lang.String, java.lang.String)"))
-      )) shouldBe Some("docs/scala-library-" + c.scalaVersion + "-javadoc.jar/index.html#scala.Some@mkString(start:String,sep:String,end:String):String")
+      )) should (
+        equal(Some("docs/scala-library-" + c.scalaVersion + "-javadoc.jar/index.html#scala.Some@mkString(start:String,sep:String,end:String):String")) or
+        equal(Some("docs/scala-library-" + c.scalaVersion + "-javadoc.jar/scala/Some.html#mkString(start:String,sep:String,end:String):String"))
+      )
 
       serv.resolve(DocSigPair(
         DocSig(DocFqn("com.google.common.io", "Files$"), Some("simplifyPath(x$1:String):String")),
@@ -106,7 +133,10 @@ class DocResolverSpec extends EnsimeSpec
       serv.resolve(DocSigPair(
         DocSig(DocFqn("scala", "Some"), Some("mkString:String")),
         DocSig(DocFqn("scala", "Some"), Some("mkString"))
-      )) shouldBe Some("docs/scala-library-" + c.scalaVersion + "-javadoc.jar/index.html#scala.Some@mkString:String")
+      )) should (
+        equal(Some("docs/scala-library-" + c.scalaVersion + "-javadoc.jar/index.html#scala.Some@mkString:String")) or
+        equal(Some("docs/scala-library-" + c.scalaVersion + "-javadoc.jar/scala/Some.html#mkString:String"))
+      )
 
       serv.resolve(DocSigPair(
         DocSig(DocFqn("com.google.common.io", "Files$"), Some("simplifyPath(x$1:String):String")),
@@ -116,7 +146,10 @@ class DocResolverSpec extends EnsimeSpec
       serv.resolve(DocSigPair(
         DocSig(DocFqn("scala", "Some"), Some("mkString(sep:String):String")),
         DocSig(DocFqn("scala", "Some"), Some("mkString(java.lang.String)"))
-      )) shouldBe Some("docs/scala-library-" + c.scalaVersion + "-javadoc.jar/index.html#scala.Some@mkString(sep:String):String")
+      )) should (
+        equal(Some("docs/scala-library-" + c.scalaVersion + "-javadoc.jar/index.html#scala.Some@mkString(sep:String):String")) or
+        equal(Some("docs/scala-library-" + c.scalaVersion + "-javadoc.jar/scala/Some.html#mkString(sep:String):String"))
+      )
 
       serv.resolve(DocSigPair(
         DocSig(DocFqn("com.google.common.io", "Files$"), Some("simplifyPath(x$1:String):String")),
@@ -126,7 +159,10 @@ class DocResolverSpec extends EnsimeSpec
       serv.resolve(DocSigPair(
         DocSig(DocFqn("scala", "Some"), Some("getOrElse[B>:A](default:=>B):B")),
         DocSig(DocFqn("scala", "Some"), Some("getOrElse(scala.<byname>)"))
-      )) shouldBe Some("docs/scala-library-" + c.scalaVersion + "-javadoc.jar/index.html#scala.Some@getOrElse[B>:A](default:=>B):B")
+      )) should (
+        equal(Some("docs/scala-library-" + c.scalaVersion + "-javadoc.jar/index.html#scala.Some@getOrElse[B>:A](default:=>B):B")) or
+        equal(Some("docs/scala-library-" + c.scalaVersion + "-javadoc.jar/scala/Some.html#getOrElse[B>:A](default:=>B):B"))
+      )
 
       serv.resolve(DocSigPair(
         DocSig(DocFqn("com.google.common.io", "Files$"), Some("simplifyPath(x$1:String):String")),
@@ -136,7 +172,10 @@ class DocResolverSpec extends EnsimeSpec
       serv.resolve(DocSigPair(
         DocSig(DocFqn("scala", "Some"), Some("grouped(size:Int):Iterator[Repr]")),
         DocSig(DocFqn("scala", "Some"), Some("grouped(int)"))
-      )) shouldBe Some("docs/scala-library-" + c.scalaVersion + "-javadoc.jar/index.html#scala.Some@grouped(size:Int):Iterator[Repr]")
+      )) should (
+        equal(Some("docs/scala-library-" + c.scalaVersion + "-javadoc.jar/index.html#scala.Some@grouped(size:Int):Iterator[Repr]")) or
+        equal(Some("docs/scala-library-" + c.scalaVersion + "-javadoc.jar/scala/Some.html#grouped(size:Int):Iterator[Repr]"))
+      )
 
       serv.resolve(DocSigPair(
         DocSig(DocFqn("com.google.common.io", "Files$"), Some("simplifyPath(x$1:String):String")),
@@ -146,7 +185,10 @@ class DocResolverSpec extends EnsimeSpec
       serv.resolve(DocSigPair(
         DocSig(DocFqn("scala.collection.immutable", "List$"), Some("empty[A]:List[A]")),
         DocSig(DocFqn("scala.collection.immutable", "List"), Some("empty"))
-      )) shouldBe Some("docs/scala-library-" + c.scalaVersion + "-javadoc.jar/index.html#scala.collection.immutable.List$@empty[A]:List[A]")
+      )) should (
+        equal(Some("docs/scala-library-" + c.scalaVersion + "-javadoc.jar/index.html#scala.collection.immutable.List$@empty[A]:List[A]")) or
+        equal(Some("docs/scala-library-" + c.scalaVersion + "-javadoc.jar/scala/collection/immutable/List$.html#empty[A]:List[A]"))
+      )
 
       serv.resolve(DocSigPair(
         DocSig(DocFqn("com.google.common.io", "Files$"), Some("simplifyPath(x$1:String):String")),
@@ -206,7 +248,10 @@ class DocResolverSpec extends EnsimeSpec
       serv.resolve(DocSigPair(
         DocSig(DocFqn("scala", "Some"), None),
         DocSig(DocFqn("scala", "Some"), None)
-      )) shouldBe Some("docs/scala-library-" + c.scalaVersion + "-javadoc.jar/index.html#scala.Some")
+      )) should (
+        equal(Some("docs/scala-library-" + c.scalaVersion + "-javadoc.jar/index.html#scala.Some")) or
+        equal(Some("docs/scala-library-" + c.scalaVersion + "-javadoc.jar/scala/Some.html"))
+      )
 
       serv.resolve(DocSigPair(
         DocSig(DocFqn("com.google.common.io", "Files$"), Some("simplifyPath(x$1:String):String")),
@@ -221,7 +266,10 @@ class DocResolverSpec extends EnsimeSpec
       serv.resolve(DocSigPair(
         DocSig(DocFqn("scala", "Int"), None),
         DocSig(DocFqn("", "int"), None)
-      )) shouldBe Some("docs/scala-library-" + c.scalaVersion + "-javadoc.jar/index.html#scala.Int")
+      )) should (
+        equal(Some("docs/scala-library-" + c.scalaVersion + "-javadoc.jar/index.html#scala.Int")) or
+        equal(Some("docs/scala-library-" + c.scalaVersion + "-javadoc.jar/scala/Int.html"))
+      )
 
       serv.resolve(DocSigPair(
         DocSig(DocFqn("com.google.common.io", "Files$"), Some("simplifyPath(x$1:String):String")),
@@ -241,7 +289,10 @@ class DocResolverSpec extends EnsimeSpec
       serv.resolve(DocSigPair(
         DocSig(DocFqn("scala", "Predef$$DummyImplicit$"), None),
         DocSig(DocFqn("scala", "Predef.DummyImplicit"), None)
-      )) shouldBe Some("docs/scala-library-" + c.scalaVersion + "-javadoc.jar/index.html#scala.Predef$$DummyImplicit$")
+      )) should (
+        equal(Some("docs/scala-library-" + c.scalaVersion + "-javadoc.jar/index.html#scala.Predef$$DummyImplicit$")) or
+        equal(Some("docs/scala-library-" + c.scalaVersion + "-javadoc.jar/scala/Predef$$DummyImplicit$.html"))
+      )
 
       serv.resolve(DocSigPair(
         DocSig(DocFqn("com.google.common.io", "Files$"), Some("simplifyPath(x$1:String):String")),
@@ -281,7 +332,10 @@ class DocResolverSpec extends EnsimeSpec
       serv.resolve(DocSigPair(
         DocSig(DocFqn("scala", "package"), Some("Exception=Exception")),
         DocSig(DocFqn("scala", "package"), Some("Exception"))
-      )) shouldBe Some("docs/scala-library-" + c.scalaVersion + "-javadoc.jar/index.html#scala.package@Exception=Exception")
+      )) should (
+        equal(Some("docs/scala-library-" + c.scalaVersion + "-javadoc.jar/index.html#scala.package@Exception=Exception")) or
+        equal(Some("docs/scala-library-" + c.scalaVersion + "-javadoc.jar/scala/index.html#Exception=Exception"))
+      )
 
       serv.resolve(DocSigPair(
         DocSig(DocFqn("com.google.common.io", "Files$"), Some("simplifyPath(x$1:String):String")),
@@ -291,7 +345,10 @@ class DocResolverSpec extends EnsimeSpec
       serv.resolve(DocSigPair(
         DocSig(DocFqn("scala", "Some"), Some("++[B>:A,That](that:scala.collection.GenTraversableOnce[B])(implicitbf:scala.collection.generic.CanBuildFrom[Repr,B,That]):That")),
         DocSig(DocFqn("scala", "Some"), Some("++(scala.collection.GenTraversableOnce, scala.collection.generic.CanBuildFrom)"))
-      )) shouldBe Some("docs/scala-library-" + c.scalaVersion + "-javadoc.jar/index.html#scala.Some@++[B](that:scala.collection.GenTraversableOnce[B]):Option[B]")
+      )) should (
+        equal(Some("docs/scala-library-" + c.scalaVersion + "-javadoc.jar/index.html#scala.Some@++[B](that:scala.collection.GenTraversableOnce[B]):Option[B]")) or
+        equal(Some("docs/scala-library-" + c.scalaVersion + "-javadoc.jar/scala/Some.html#++[B](that:scala.collection.GenTraversableOnce[B]):Option[B]"))
+      )
 
       serv.resolve(DocSigPair(
         DocSig(DocFqn("com.google.common.io", "Files$"), Some("simplifyPath(x$1:String):String")),
@@ -301,7 +358,10 @@ class DocResolverSpec extends EnsimeSpec
       serv.resolve(DocSigPair(
         DocSig(DocFqn("scala.collection.immutable", "List"), Some("flatMap[B,That](f:A=>scala.collection.GenTraversableOnce[B])(implicitbf:scala.collection.generic.CanBuildFrom[List[A],B,That]):That")),
         DocSig(DocFqn("scala.collection.immutable", "List"), Some("flatMap(scala.Function1, scala.collection.generic.CanBuildFrom)"))
-      )) shouldBe Some("docs/scala-library-" + c.scalaVersion + "-javadoc.jar/index.html#scala.collection.immutable.List@flatMap[B](f:A=>scala.collection.GenTraversableOnce[B]):List[B]")
+      )) should (
+        equal(Some("docs/scala-library-" + c.scalaVersion + "-javadoc.jar/index.html#scala.collection.immutable.List@flatMap[B](f:A=>scala.collection.GenTraversableOnce[B]):List[B]")) or
+        equal(Some("docs/scala-library-" + c.scalaVersion + "-javadoc.jar/scala/collection/immutable/List.html#flatMap[B](f:A=>scala.collection.GenTraversableOnce[B]):List[B]"))
+      )
 
       serv.resolve(DocSigPair(
         DocSig(DocFqn("com.google.common.io", "Files$"), Some("simplifyPath(x$1:String):String")),
@@ -311,7 +371,10 @@ class DocResolverSpec extends EnsimeSpec
       serv.resolve(DocSigPair(
         DocSig(DocFqn("scala.collection.immutable", "List"), Some("collect[B,That](pf:PartialFunction[A,B])(implicitbf:scala.collection.generic.CanBuildFrom[List[A],B,That]):That")),
         DocSig(DocFqn("scala.collection.immutable", "List"), Some("collect(scala.PartialFunction, scala.collection.generic.CanBuildFrom)"))
-      )) shouldBe Some("docs/scala-library-" + c.scalaVersion + "-javadoc.jar/index.html#scala.collection.immutable.List@collect[B](pf:PartialFunction[A,B]):List[B]")
+      )) should (
+        equal(Some("docs/scala-library-" + c.scalaVersion + "-javadoc.jar/index.html#scala.collection.immutable.List@collect[B](pf:PartialFunction[A,B]):List[B]")) or
+        equal(Some("docs/scala-library-" + c.scalaVersion + "-javadoc.jar/scala/collection/immutable/List.html#collect[B](pf:PartialFunction[A,B]):List[B]"))
+      )
 
       serv.resolve(DocSigPair(
         DocSig(DocFqn("com.google.common.io", "Files$"), Some("simplifyPath(x$1:String):String")),

--- a/core/src/it/scala/org/ensime/core/SemanticHighlightingSpec.scala
+++ b/core/src/it/scala/org/ensime/core/SemanticHighlightingSpec.scala
@@ -457,10 +457,20 @@ class SemanticHighlightingSpec extends EnsimeSpec
           """,
       List(ValFieldSymbol)
     )
-    sds should ===(List(
-      (ValFieldSymbol, "u"),
-      (ValFieldSymbol, "v")
-    ))
+    sds should (
+      // 2.10 & 2.11 case
+      equal(List(
+        (ValFieldSymbol, "u"),
+        (ValFieldSymbol, "v")
+      )) or
+      // 2.12 case
+      equal(List(
+        (ValFieldSymbol, "u"),
+        (ValFieldSymbol, "v"),
+        (ValFieldSymbol, "u"),
+        (ValFieldSymbol, "v")
+      ))
+    )
   }
 
   it should "highlight setter operators" in withPresCompiler { (config, cc) =>

--- a/core/src/it/scala/org/ensime/indexer/SearchServiceSpec.scala
+++ b/core/src/it/scala/org/ensime/indexer/SearchServiceSpec.scala
@@ -152,9 +152,9 @@ class SearchServiceSpec extends EnsimeSpec
   it should "not prioritise noisy inner classes" in withSearchService { implicit service =>
     def nonTrailingDollarSigns(fqn: String): Int = fqn.count(_ == '$') - (if (fqn.endsWith("$")) 1 else 0)
     def isSorted(hits: Seq[String]): Boolean =
-      hits.sliding(2).map {
+      hits.sliding(2).forall {
         case List(x, y) => nonTrailingDollarSigns(x) <= nonTrailingDollarSigns(y)
-      }.forall(identity)
+      }
 
     val sorted = new BeMatcher[Seq[String]] {
       override def apply(left: Seq[String]): MatchResult =
@@ -183,7 +183,7 @@ class SearchServiceSpec extends EnsimeSpec
     )
     matchersHits should be(sorted)
 
-    val regexHits = service.searchClasses("Regex", 10).map(_.fqn)
+    val regexHits = service.searchClasses("Regex", 8).map(_.fqn)
     regexHits.take(2) should contain theSameElementsAs Seq(
       "scala.util.matching.Regex",
       "scala.util.matching.Regex$"

--- a/core/src/it/scala/org/ensime/indexer/SearchServiceSpec.scala
+++ b/core/src/it/scala/org/ensime/indexer/SearchServiceSpec.scala
@@ -209,11 +209,11 @@ class SearchServiceSpec extends EnsimeSpec
   }
 
   "lucene index" should "not contain duplicates" in withSearchService { implicit service =>
-    import scala.collection.JavaConversions._
+    import scala.collection.JavaConverters._
     val lucene = service.index.lucene
     val terms = List("org", "example", "bar")
     val query = new DisjunctionMaxQuery(
-      terms.map(service.index.buildTermClassMethodQuery), 0f
+      terms.map(service.index.buildTermClassMethodQuery).asJavaCollection, 0f
     )
     val fqns = lucene.search(query, 10).map(_.get("fqn"))
     fqns.distinct should ===(fqns)

--- a/core/src/it/scala/org/ensime/intg/BasicWorkflow.scala
+++ b/core/src/it/scala/org/ensime/intg/BasicWorkflow.scala
@@ -280,7 +280,7 @@ class BasicWorkflow extends EnsimeSpec
               else fail(s"Different diff content than expected. \n Actual content: '$diffContents' \n ExpectedRelevantContent: '$relevantExpectedPart'")
           }
 
-          val oldTree1 = """Apply[1](Select[2](Select[1](Apply[3](TypeApply[4](Select[5](Select[6](This[7](newTypeName("immutable")), scala.collection.immutable.List#MOD%M1), newTermName("apply")#METH%M1), List(TypeTree[1]())), List(Literal[8](Constant(1)), Literal[9](Constant(2)), Literal[10](Constant(3)))), newTermName("head")#METH%M1), newTermName("$plus")#METH%M1), List(Literal[9](Constant(2))))
+          val headAst210 = """Apply[1](Select[2](Select[1](Apply[3](TypeApply[4](Select[5](Select[6](This[7](newTypeName("immutable")), scala.collection.immutable.List#MOD%M1), newTermName("apply")#METH%M1), List(TypeTree[1]())), List(Literal[8](Constant(1)), Literal[9](Constant(2)), Literal[10](Constant(3)))), newTermName("head")#METH%M1), newTermName("$plus")#METH%M1), List(Literal[9](Constant(2))))
                            |[1] TypeRef(ThisType(scala#PK%M1), scala.Int#CLS%M1, List())
                            |[2] MethodType(List(newTermName("x")#VAL%M1), TypeRef(ThisType(scala#PK%M1), scala.Int#CLS%M1, List()))
                            |[3] TypeRef(ThisType(scala.collection.immutable#PK%M1), scala.collection.immutable.List#CLS%M1, List(TypeRef(ThisType(scala#PK%M1), scala.Int#CLS%M1, List())))
@@ -293,7 +293,7 @@ class BasicWorkflow extends EnsimeSpec
                            |[10] ConstantType(Constant(3))
                            |[1] compiler mirror""".stripMargin
 
-          val tree1 = """Apply[1](Select[2](Select[1](Apply[3](TypeApply[4](Select[5](Select[6](This[7](TypeName("immutable")), scala.collection.immutable.List#MOD%M1), TermName("apply")#METH%M1), List(TypeTree[1]())), List(Literal[8](Constant(1)), Literal[9](Constant(2)), Literal[10](Constant(3)))), TermName("head")#METH%M1), TermName("$plus")#METH%M1), List(Literal[9](Constant(2))))
+          val headAst211 = """Apply[1](Select[2](Select[1](Apply[3](TypeApply[4](Select[5](Select[6](This[7](TypeName("immutable")), scala.collection.immutable.List#MOD%M1), TermName("apply")#METH%M1), List(TypeTree[1]())), List(Literal[8](Constant(1)), Literal[9](Constant(2)), Literal[10](Constant(3)))), TermName("head")#METH%M1), TermName("$plus")#METH%M1), List(Literal[9](Constant(2))))
                         |[1] TypeRef(ThisType(scala#PKC%M1), scala.Int#CLS%M1, List())
                         |[2] MethodType(List(TermName("x")#VAL%M1), TypeRef(ThisType(scala#PKC%M1), scala.Int#CLS%M1, List()))
                         |[3] TypeRef(ThisType(scala.collection.immutable#PKC%M1), scala.collection.immutable.List#CLS%M1, List(TypeRef(ThisType(scala#PKC%M1), scala.Int#CLS%M1, List())))
@@ -305,42 +305,70 @@ class BasicWorkflow extends EnsimeSpec
                         |[9] ConstantType(Constant(2))
                         |[10] ConstantType(Constant(3))
                         |[1] compiler mirror""".stripMargin
+
+          val headAst212 = """Apply[1](Select[2](Select[1](Apply[3](TypeApply[4](Select[5](Select[6](Select[7](Select[8](Ident[9](scala#PK%M1), scala.collection#PK%M1), scala.collection.immutable#PK%M1), scala.collection.immutable.List#MOD%M1), TermName("apply")#METH%M1), List(TypeTree[1]())), List(Literal[10](Constant(1)), Literal[11](Constant(2)), Literal[12](Constant(3)))), TermName("head")#METH%M1), TermName("$plus")#METH%M1), List(Literal[11](Constant(2))))
+                        |[1] TypeRef(ThisType(scala#PKC%M1), scala.Int#CLS%M1, List())
+                        |[2] MethodType(List(TermName("x")#VAL%M1), TypeRef(ThisType(scala#PKC%M1), scala.Int#CLS%M1, List()))
+                        |[3] TypeRef(ThisType(scala.collection.immutable#PKC%M1), scala.collection.immutable.List#CLS%M1, List(TypeRef(ThisType(scala#PKC%M1), scala.Int#CLS%M1, List())))
+                        |[4] MethodType(List(TermName("xs")#VAL%M1), TypeRef(ThisType(scala.collection.immutable#PKC%M1), scala.collection.immutable.List#CLS%M1, List(TypeRef(ThisType(scala#PKC%M1), scala.Int#CLS%M1, List()))))
+                        |[5] PolyType(List(TypeName("A")#TPE%M1), MethodType(List(TermName("xs")#VAL%M1), TypeRef(ThisType(scala.collection.immutable#PKC%M1), scala.collection.immutable.List#CLS%M1, List(TypeRef(NoPrefix, TypeName("A")#TPE%M1, List())))))
+                        |[6] SingleType(TypeRef(ThisType(scala.collection#PKC%M1), scala.collection.immutable#PKC%M1, List()), scala.collection.immutable.List#MOD%M1)
+                        |[7] TypeRef(ThisType(scala.collection#PKC%M1), scala.collection.immutable#PKC%M1, List())
+                        |[8] TypeRef(ThisType(scala#PKC%M1), scala.collection#PKC%M1, List())
+                        |[9] TypeRef(ThisType(<root>#PKC%M1), scala#PKC%M1, List())
+                        |[10] ConstantType(Constant(1))
+                        |[11] ConstantType(Constant(2))
+                        |[12] ConstantType(Constant(3))
+                        |[1] compiler mirror""".stripMargin
+
           project ! AstAtPointReq(SourceFileInfo(RawFile(fooFile.toPath)), OffsetRange(475, 496))
           expectMsgPF() {
             case AstInfo(ast) if {
               val stripped = ast.replaceAll("[\n\r]", "")
-              stripped == tree1.replaceAll("[\n\r]", "") || stripped == oldTree1.replaceAll("[\n\r]", "")
+              stripped == headAst211.replaceAll("[\n\r]", "") || stripped == headAst210.replaceAll("[\n\r]", "") || stripped == headAst212.replaceAll("[\n\r]", "")
             } =>
           }
 
-          val oldTree2 = """Apply[11](TypeApply[12](Select[13](Select[14](Select[15](This[16](newTypeName("scala")), scala.Predef#MOD%M1), newTermName("Map")#GET%M1), newTermName("apply")#METH%M1), List(TypeTree[17]().setOriginal(Select[17](Select[15](This[16](newTypeName("scala")), scala.Predef#MOD%M1), newTypeName("String")#TPE%M1)), TypeTree[1]().setOriginal(Select[1](Ident[18](scala#PK%M1), scala.Int#CLS%M1)))), List())
-                           |[1] TypeRef(ThisType(scala#PK%M1), scala.Int#CLS%M1, List())
-                           |[11] TypeRef(ThisType(scala.collection.immutable#PK%M1), scala.collection.immutable.Map#TRT%M1, List(TypeRef(SingleType(ThisType(scala#PK%M1), scala.Predef#MOD%M1), newTypeName("String")#TPE%M1, List()), TypeRef(ThisType(scala#PK%M1), scala.Int#CLS%M1, List())))
-                           |[12] MethodType(List(newTermName("elems")#VAL%M1), TypeRef(ThisType(scala.collection.immutable#PK%M1), scala.collection.immutable.Map#TRT%M1, List(TypeRef(SingleType(ThisType(scala#PK%M1), scala.Predef#MOD%M1), newTypeName("String")#TPE%M1, List()), TypeRef(ThisType(scala#PK%M1), scala.Int#CLS%M1, List()))))
-                           |[13] PolyType(List(newTypeName("A")#TPE%M1, newTypeName("B")#TPE%M1), MethodType(List(newTermName("elems")#VAL%M1), TypeRef(ThisType(scala.collection.immutable#PK%M1), scala.collection.immutable.Map#TRT%M1, List(TypeRef(NoPrefix, newTypeName("A")#TPE%M1, List()), TypeRef(NoPrefix, newTypeName("B")#TPE%M1, List())))))
-                           |[14] SingleType(SingleType(ThisType(scala#PK%M1), scala.Predef#MOD%M1), newTermName("Map")#GET%M1)
-                           |[15] SingleType(ThisType(scala#PK%M1), scala.Predef#MOD%M1)
-                           |[16] ThisType(scala#PK%M1)
-                           |[17] TypeRef(SingleType(ThisType(scala#PK%M1), scala.Predef#MOD%M1), newTypeName("String")#TPE%M1, List())
-                           |[18] SingleType(ThisType(<root>#PK%M1), scala#PK%M1)
-                           |[1] compiler mirror""".stripMargin
+          val mapAst210 = """Apply[11](TypeApply[12](Select[13](Select[14](Select[15](This[16](newTypeName("scala")), scala.Predef#MOD%M1), newTermName("Map")#GET%M1), newTermName("apply")#METH%M1), List(TypeTree[17]().setOriginal(Select[17](Select[15](This[16](newTypeName("scala")), scala.Predef#MOD%M1), newTypeName("String")#TPE%M1)), TypeTree[1]().setOriginal(Select[1](Ident[18](scala#PK%M1), scala.Int#CLS%M1)))), List())
+                          |[1] TypeRef(ThisType(scala#PK%M1), scala.Int#CLS%M1, List())
+                          |[11] TypeRef(ThisType(scala.collection.immutable#PK%M1), scala.collection.immutable.Map#TRT%M1, List(TypeRef(SingleType(ThisType(scala#PK%M1), scala.Predef#MOD%M1), newTypeName("String")#TPE%M1, List()), TypeRef(ThisType(scala#PK%M1), scala.Int#CLS%M1, List())))
+                          |[12] MethodType(List(newTermName("elems")#VAL%M1), TypeRef(ThisType(scala.collection.immutable#PK%M1), scala.collection.immutable.Map#TRT%M1, List(TypeRef(SingleType(ThisType(scala#PK%M1), scala.Predef#MOD%M1), newTypeName("String")#TPE%M1, List()), TypeRef(ThisType(scala#PK%M1), scala.Int#CLS%M1, List()))))
+                          |[13] PolyType(List(newTypeName("A")#TPE%M1, newTypeName("B")#TPE%M1), MethodType(List(newTermName("elems")#VAL%M1), TypeRef(ThisType(scala.collection.immutable#PK%M1), scala.collection.immutable.Map#TRT%M1, List(TypeRef(NoPrefix, newTypeName("A")#TPE%M1, List()), TypeRef(NoPrefix, newTypeName("B")#TPE%M1, List())))))
+                          |[14] SingleType(SingleType(ThisType(scala#PK%M1), scala.Predef#MOD%M1), newTermName("Map")#GET%M1)
+                          |[15] SingleType(ThisType(scala#PK%M1), scala.Predef#MOD%M1)
+                          |[16] ThisType(scala#PK%M1)
+                          |[17] TypeRef(SingleType(ThisType(scala#PK%M1), scala.Predef#MOD%M1), newTypeName("String")#TPE%M1, List())
+                          |[18] SingleType(ThisType(<root>#PK%M1), scala#PK%M1)
+                          |[1] compiler mirror""".stripMargin
 
-          val tree2 = """Apply[11](TypeApply[12](Select[13](Select[14](Select[15](This[16](TypeName("scala")), scala.Predef#MOD%M1), TermName("Map")#GET%M1), TermName("apply")#METH%M1), List(TypeTree[17]().setOriginal(Select[17](Select[15](This[16](TypeName("scala")), scala.Predef#MOD%M1), TypeName("String")#TPE%M1)), TypeTree[1]().setOriginal(Select[1](Ident[18](scala#PK%M1), scala.Int#CLS%M1)))), List())
-                        |[1] TypeRef(ThisType(scala#PKC%M1), scala.Int#CLS%M1, List())
-                        |[11] TypeRef(ThisType(scala.collection.immutable#PKC%M1), scala.collection.immutable.Map#TRT%M1, List(TypeRef(SingleType(ThisType(scala#PKC%M1), scala.Predef#MOD%M1), TypeName("String")#TPE%M1, List()), TypeRef(ThisType(scala#PKC%M1), scala.Int#CLS%M1, List())))
-                        |[12] MethodType(List(TermName("elems")#VAL%M1), TypeRef(ThisType(scala.collection.immutable#PKC%M1), scala.collection.immutable.Map#TRT%M1, List(TypeRef(SingleType(ThisType(scala#PKC%M1), scala.Predef#MOD%M1), TypeName("String")#TPE%M1, List()), TypeRef(ThisType(scala#PKC%M1), scala.Int#CLS%M1, List()))))
-                        |[13] PolyType(List(TypeName("A")#TPE%M1, TypeName("B")#TPE%M1), MethodType(List(TermName("elems")#VAL%M1), TypeRef(ThisType(scala.collection.immutable#PKC%M1), scala.collection.immutable.Map#TRT%M1, List(TypeRef(NoPrefix, TypeName("A")#TPE%M1, List()), TypeRef(NoPrefix, TypeName("B")#TPE%M1, List())))))
-                        |[14] SingleType(SingleType(ThisType(scala#PKC%M1), scala.Predef#MOD%M1), TermName("Map")#GET%M1)
-                        |[15] SingleType(ThisType(scala#PKC%M1), scala.Predef#MOD%M1)
-                        |[16] ThisType(scala#PKC%M1)
-                        |[17] TypeRef(SingleType(ThisType(scala#PKC%M1), scala.Predef#MOD%M1), TypeName("String")#TPE%M1, List())
-                        |[18] SingleType(ThisType(<root>#PKC%M1), scala#PK%M1)
-                        |[1] compiler mirror""".stripMargin
+          val mapAst211 = """Apply[11](TypeApply[12](Select[13](Select[14](Select[15](This[16](TypeName("scala")), scala.Predef#MOD%M1), TermName("Map")#GET%M1), TermName("apply")#METH%M1), List(TypeTree[17]().setOriginal(Select[17](Select[15](This[16](TypeName("scala")), scala.Predef#MOD%M1), TypeName("String")#TPE%M1)), TypeTree[1]().setOriginal(Select[1](Ident[18](scala#PK%M1), scala.Int#CLS%M1)))), List())
+                          |[1] TypeRef(ThisType(scala#PKC%M1), scala.Int#CLS%M1, List())
+                          |[11] TypeRef(ThisType(scala.collection.immutable#PKC%M1), scala.collection.immutable.Map#TRT%M1, List(TypeRef(SingleType(ThisType(scala#PKC%M1), scala.Predef#MOD%M1), TypeName("String")#TPE%M1, List()), TypeRef(ThisType(scala#PKC%M1), scala.Int#CLS%M1, List())))
+                          |[12] MethodType(List(TermName("elems")#VAL%M1), TypeRef(ThisType(scala.collection.immutable#PKC%M1), scala.collection.immutable.Map#TRT%M1, List(TypeRef(SingleType(ThisType(scala#PKC%M1), scala.Predef#MOD%M1), TypeName("String")#TPE%M1, List()), TypeRef(ThisType(scala#PKC%M1), scala.Int#CLS%M1, List()))))
+                          |[13] PolyType(List(TypeName("A")#TPE%M1, TypeName("B")#TPE%M1), MethodType(List(TermName("elems")#VAL%M1), TypeRef(ThisType(scala.collection.immutable#PKC%M1), scala.collection.immutable.Map#TRT%M1, List(TypeRef(NoPrefix, TypeName("A")#TPE%M1, List()), TypeRef(NoPrefix, TypeName("B")#TPE%M1, List())))))
+                          |[14] SingleType(SingleType(ThisType(scala#PKC%M1), scala.Predef#MOD%M1), TermName("Map")#GET%M1)
+                          |[15] SingleType(ThisType(scala#PKC%M1), scala.Predef#MOD%M1)
+                          |[16] ThisType(scala#PKC%M1)
+                          |[17] TypeRef(SingleType(ThisType(scala#PKC%M1), scala.Predef#MOD%M1), TypeName("String")#TPE%M1, List())
+                          |[18] SingleType(ThisType(<root>#PKC%M1), scala#PK%M1)
+                          |[1] compiler mirror""".stripMargin
+
+          val mapAst212 = """Apply[1](TypeApply[2](Select[3](Select[4](Select[5](Ident[6](scala#PK%M1), scala.Predef#MOD%M1), TermName("Map")#GET%M1), TermName("apply")#METH%M1), List(TypeTree[7]().setOriginal(Select[7](Select[5](Ident[6](scala#PK%M1), scala.Predef#MOD%M1), TypeName("String")#TPE%M1)), TypeTree[8]().setOriginal(Select[8](Ident[9](scala#PK%M1), scala.Int#CLS%M1)))), List())
+                          |[1] TypeRef(ThisType(scala.collection.immutable#PKC%M1), scala.collection.immutable.Map#TRT%M1, List(TypeRef(SingleType(TypeRef(ThisType(<root>#PKC%M1), scala#PKC%M1, List()), scala.Predef#MOD%M1), TypeName("String")#TPE%M1, List()), TypeRef(ThisType(scala#PKC%M1), scala.Int#CLS%M1, List())))
+                          |[2] MethodType(List(TermName("elems")#VAL%M1), TypeRef(ThisType(scala.collection.immutable#PKC%M1), scala.collection.immutable.Map#TRT%M1, List(TypeRef(SingleType(TypeRef(ThisType(<root>#PKC%M1), scala#PKC%M1, List()), scala.Predef#MOD%M1), TypeName("String")#TPE%M1, List()), TypeRef(ThisType(scala#PKC%M1), scala.Int#CLS%M1, List()))))
+                          |[3] PolyType(List(TypeName("A")#TPE%M1, TypeName("B")#TPE%M1), MethodType(List(TermName("elems")#VAL%M1), TypeRef(ThisType(scala.collection.immutable#PKC%M1), scala.collection.immutable.Map#TRT%M1, List(TypeRef(NoPrefix, TypeName("A")#TPE%M1, List()), TypeRef(NoPrefix, TypeName("B")#TPE%M1, List())))))
+                          |[4] SingleType(SingleType(TypeRef(ThisType(<root>#PKC%M1), scala#PKC%M1, List()), scala.Predef#MOD%M1), TermName("Map")#GET%M1)
+                          |[5] SingleType(TypeRef(ThisType(<root>#PKC%M1), scala#PKC%M1, List()), scala.Predef#MOD%M1)
+                          |[6] TypeRef(ThisType(<root>#PKC%M1), scala#PKC%M1, List())
+                          |[7] TypeRef(SingleType(TypeRef(ThisType(<root>#PKC%M1), scala#PKC%M1, List()), scala.Predef#MOD%M1), TypeName("String")#TPE%M1, List())
+                          |[8] TypeRef(ThisType(scala#PKC%M1), scala.Int#CLS%M1, List())
+                          |[9] SingleType(ThisType(<root>#PKC%M1), scala#PK%M1)
+                          |[1] compiler mirror""".stripMargin
           project ! AstAtPointReq(SourceFileInfo(RawFile(fooFile.toPath)), OffsetRange(189, 206))
           expectMsgPF() {
             case AstInfo(ast) if {
               val stripped = ast.replaceAll("[\n\r]", "")
-              stripped == tree2.replaceAll("[\n\r]", "") || stripped == oldTree2.replaceAll("[\n\r]", "")
+              stripped == mapAst211.replaceAll("[\n\r]", "") || stripped == mapAst210.replaceAll("[\n\r]", "") || stripped == mapAst212.replaceAll("[\n\r]", "")
             } =>
           }
 

--- a/core/src/it/scala/org/ensime/intg/DebugTest.scala
+++ b/core/src/it/scala/org/ensime/intg/DebugTest.scala
@@ -187,7 +187,7 @@ class DebugTest extends EnsimeSpec
         withDebugSession(
           "variables.ReadVariables",
           "variables/ReadVariables.scala",
-          21
+          22
         ) { (threadId, variablesFile) =>
             // boolean local
             getVariableValue(threadId, "a") should matchPattern {
@@ -238,14 +238,11 @@ class DebugTest extends EnsimeSpec
             }
 
             // type local
-            inside(getVariableValue(threadId, "j")) {
-              case DebugObjectInstance(summary, debugFields, "scala.collection.immutable.$colon$colon", _) =>
-                summary should startWith("Instance of scala.collection.immutable.$colon$colon")
+            inside(getVariableValue(threadId, "m")) {
+              case DebugObjectInstance(summary, debugFields, "variables.ReadVariables$SimpleTestClass", _) =>
+                summary should startWith("Instance of variables.ReadVariables$SimpleTestClass")
                 exactly(1, debugFields) should matchPattern {
-                  case DebugClassField(_, head, "java.lang.Object", summary) if (
-                    (head == "head" || head == "hd") &&
-                    summary.startsWith("Instance of java.lang.Integer")
-                  ) =>
+                  case DebugClassField(_, "xs", "scala.collection.immutable.List", summary) if summary.startsWith("Instance of scala.collection.immutable.$colon$colon") =>
                 }
             }
 
@@ -265,7 +262,7 @@ class DebugTest extends EnsimeSpec
         withDebugSession(
           "variables.ReadVariables",
           "variables/ReadVariables.scala",
-          21
+          22
         ) { (threadId, variablesFile) =>
             // boolean local
             getVariableAsString(threadId, "a").text should be("true")

--- a/core/src/main/scala-2.10/org/ensime/core/DocResolverBackCompat.scala
+++ b/core/src/main/scala-2.10/org/ensime/core/DocResolverBackCompat.scala
@@ -1,0 +1,17 @@
+// Copyright: 2010 - 2017 https://github.com/ensime/ensime-server/graphs
+// License: http://www.gnu.org/licenses/gpl-3.0.en.html
+package org.ensime.core
+
+trait DocResolverBackCompat {
+  def scalaSigToLocalUri(prefix: String, jarName: String, scalaSig: DocSig): String = {
+    val anchor = scalaSig.fqn.mkString +
+      scalaSig.member.map("@" + _).getOrElse("")
+    s"$prefix/$jarName/index.html#$anchor"
+  }
+
+  def scalaFqnToPath(fqn: DocFqn): String = {
+    if (fqn.typeName == "package") {
+      fqn.pack.replace(".", "/") + "/package.html"
+    } else fqn.pack.replace(".", "/") + "/" + fqn.typeName + ".html"
+  }
+}

--- a/core/src/main/scala-2.10/org/ensime/core/ScalaRefactoringBackCompat.scala
+++ b/core/src/main/scala-2.10/org/ensime/core/ScalaRefactoringBackCompat.scala
@@ -1,3 +1,5 @@
+// Copyright: 2010 - 2017 https://github.com/ensime/ensime-server/graphs
+// License: http://www.gnu.org/licenses/gpl-3.0.en.html
 package org.ensime.core
 
 import scala.tools.refactoring.implementations.OrganizeImports

--- a/core/src/main/scala-2.10/org/ensime/core/ScalaRefactoringBackCompat.scala
+++ b/core/src/main/scala-2.10/org/ensime/core/ScalaRefactoringBackCompat.scala
@@ -1,0 +1,17 @@
+package org.ensime.core
+
+import scala.tools.refactoring.implementations.OrganizeImports
+
+trait ScalaRefactoringBackCompat {
+
+  def organizeImportOptions(refactoring: OrganizeImports) = {
+    import refactoring._
+    List(
+      SortImports,
+      SimplifyWildcards,
+      SortImportSelectors,
+      RemoveDuplicates
+    )
+  }
+
+}

--- a/core/src/main/scala-2.10/org/ensime/database/SlickBackCompat.scala
+++ b/core/src/main/scala-2.10/org/ensime/database/SlickBackCompat.scala
@@ -1,0 +1,7 @@
+// Copyright: 2010 - 2017 https://github.com/ensime/ensime-server/graphs
+// License: http://www.gnu.org/licenses/gpl-3.0.en.html
+package org.ensime.database
+
+object SlickBackCompat {
+  def h2Api = slick.driver.H2Driver.api
+}

--- a/core/src/main/scala-2.11/org/ensime/core/DocResolverBackCompat.scala
+++ b/core/src/main/scala-2.11/org/ensime/core/DocResolverBackCompat.scala
@@ -1,0 +1,17 @@
+// Copyright: 2010 - 2017 https://github.com/ensime/ensime-server/graphs
+// License: http://www.gnu.org/licenses/gpl-3.0.en.html
+package org.ensime.core
+
+trait DocResolverBackCompat {
+  def scalaSigToLocalUri(prefix: String, jarName: String, scalaSig: DocSig): String = {
+    val anchor = scalaSig.fqn.mkString +
+      scalaSig.member.map("@" + _).getOrElse("")
+    s"$prefix/$jarName/index.html#$anchor"
+  }
+
+  def scalaFqnToPath(fqn: DocFqn): String = {
+    if (fqn.typeName == "package") {
+      fqn.pack.replace(".", "/") + "/package.html"
+    } else fqn.pack.replace(".", "/") + "/" + fqn.typeName + ".html"
+  }
+}

--- a/core/src/main/scala-2.11/org/ensime/core/ScalaRefactoringBackCompat.scala
+++ b/core/src/main/scala-2.11/org/ensime/core/ScalaRefactoringBackCompat.scala
@@ -1,0 +1,19 @@
+// Copyright: 2010 - 2017 https://github.com/ensime/ensime-server/graphs
+// License: http://www.gnu.org/licenses/gpl-3.0.en.html
+package org.ensime.core
+
+import scala.tools.refactoring.implementations.OrganizeImports
+
+trait ScalaRefactoringBackCompat {
+
+  def organizeImportOptions(refactoring: OrganizeImports) = {
+    import refactoring._
+    List(
+      SortImports,
+      SimplifyWildcards,
+      SortImportSelectors,
+      RemoveDuplicates
+    )
+  }
+
+}

--- a/core/src/main/scala-2.11/org/ensime/database/SlickBackCompat.scala
+++ b/core/src/main/scala-2.11/org/ensime/database/SlickBackCompat.scala
@@ -1,0 +1,7 @@
+// Copyright: 2010 - 2017 https://github.com/ensime/ensime-server/graphs
+// License: http://www.gnu.org/licenses/gpl-3.0.en.html
+package org.ensime.database
+
+object SlickBackCompat {
+  val h2Api = slick.jdbc.H2Profile.api
+}

--- a/core/src/main/scala-2.12/org/ensime/core/DocResolverBackCompat.scala
+++ b/core/src/main/scala-2.12/org/ensime/core/DocResolverBackCompat.scala
@@ -1,0 +1,17 @@
+// Copyright: 2010 - 2017 https://github.com/ensime/ensime-server/graphs
+// License: http://www.gnu.org/licenses/gpl-3.0.en.html
+package org.ensime.core
+
+trait DocResolverBackCompat {
+  def scalaSigToLocalUri(prefix: String, jarName: String, scalaSig: DocSig): String = {
+    val anchor = scalaFqnToPath(scalaSig.fqn) +
+      scalaSig.member.map("#" + _).getOrElse("")
+    s"$prefix/$jarName/$anchor"
+  }
+
+  def scalaFqnToPath(fqn: DocFqn): String = {
+    if (fqn.typeName == "package") {
+      fqn.pack.replace(".", "/") + "/index.html"
+    } else fqn.pack.replace(".", "/") + "/" + fqn.typeName + ".html"
+  }
+}

--- a/core/src/main/scala-2.12/org/ensime/core/PresentationCompilerBackCompat.scala
+++ b/core/src/main/scala-2.12/org/ensime/core/PresentationCompilerBackCompat.scala
@@ -1,0 +1,21 @@
+// Copyright: 2010 - 2017 https://github.com/ensime/ensime-server/graphs
+// License: http://www.gnu.org/licenses/gpl-3.0.en.html
+package org.ensime.core
+
+import Predef.{ any2stringadd => _ }
+
+import scala.reflect.internal.util.Position
+
+/**
+ * Simulate methods that were added in later versions of the scalac
+ * API, or to generate fake methods that we can use in both versions.
+ */
+trait PresentationCompilerBackCompat
+
+trait PositionBackCompat {
+  implicit class RichPosition(pos: Position) {
+    // annoyingly, {start, end}OrPoint is deprecated
+    def startOrCursor: Int = if (pos.isRange) pos.start else pos.point
+    def endOrCursor: Int = if (pos.isRange) pos.end else pos.point
+  }
+}

--- a/core/src/main/scala-2.12/org/ensime/core/ScalaRefactoringBackCompat.scala
+++ b/core/src/main/scala-2.12/org/ensime/core/ScalaRefactoringBackCompat.scala
@@ -1,0 +1,18 @@
+// Copyright: 2010 - 2017 https://github.com/ensime/ensime-server/graphs
+// License: http://www.gnu.org/licenses/gpl-3.0.en.html
+package org.ensime.core
+
+import scala.tools.refactoring.implementations.OrganizeImports
+
+trait ScalaRefactoringBackCompat {
+
+  def organizeImportOptions(refactoring: OrganizeImports) = {
+    import refactoring.oiWorker.participants._
+    List(
+      SortImports,
+      SortImportSelectors,
+      RemoveDuplicates
+    )
+  }
+
+}

--- a/core/src/main/scala-2.12/org/ensime/database/SlickBackCompat.scala
+++ b/core/src/main/scala-2.12/org/ensime/database/SlickBackCompat.scala
@@ -3,5 +3,5 @@
 package org.ensime.database
 
 object SlickBackCompat {
-  val h2Api = slick.driver.H2Driver.api
+  val h2Api = slick.jdbc.H2Profile.api
 }

--- a/core/src/main/scala/org/ensime/core/DocResolver.scala
+++ b/core/src/main/scala/org/ensime/core/DocResolver.scala
@@ -9,12 +9,15 @@ import java.util.jar.JarFile
 import org.ensime.api._
 
 class DocResolver(
-    prefix: String,
-    forceJavaVersion: Option[String] // for testing
+  prefix: String,
+  forceJavaVersion: Option[String] // for testing
 )(
-    implicit
-    config: EnsimeConfig
-) extends Actor with ActorLogging with DocUsecaseHandling {
+  implicit
+  config: EnsimeConfig
+) extends Actor
+    with ActorLogging
+    with DocUsecaseHandling
+    with DocResolverBackCompat {
 
   var htmlToJar = Map.empty[String, File]
   var jarNameToJar = Map.empty[String, File]
@@ -79,12 +82,6 @@ class DocResolver(
     }
   }
 
-  def scalaFqnToPath(fqn: DocFqn): String = {
-    if (fqn.typeName == "package") {
-      fqn.pack.replace(".", "/") + "/package.html"
-    } else fqn.pack.replace(".", "/") + "/" + fqn.typeName + ".html"
-  }
-
   private def makeLocalUri(jar: File, sig: DocSigPair): String = {
     val jarName = jar.getName
     val docType = docTypes(jarName)
@@ -97,9 +94,7 @@ class DocResolver(
       s"$prefix/$jarName/$path$anchor"
     } else {
       val scalaSig = maybeReplaceWithUsecase(jar, sig.scala)
-      val anchor = scalaSig.fqn.mkString +
-        scalaSig.member.map("@" + _).getOrElse("")
-      s"$prefix/$jarName/index.html#$anchor"
+      scalaSigToLocalUri(prefix, jarName, scalaSig)
     }
   }
 

--- a/core/src/main/scala/org/ensime/core/DocUsecaseHandling.scala
+++ b/core/src/main/scala/org/ensime/core/DocUsecaseHandling.scala
@@ -31,7 +31,8 @@ trait DocUsecaseHandling { self: DocResolver =>
             try {
               val is = jarFile.getInputStream(jarFile.getEntry(scalaFqnToPath(sig.fqn)))
               val html = Source.fromInputStream(is).mkString
-              val re = s"""<a id="(${Pattern.quote(prefix)}.+?)"""".r
+              //              val re = s"""<a id="(${Pattern.quote(prefix)}.+?)"""".r
+              val re = s"""<a id="(${Pattern.quote(prefix)}[^a-zA-Z\\d].*?)"""".r
               re.findFirstMatchIn(html).map { m =>
                 sig.copy(member = Some(StringEscapeUtils.unescapeHtml(m.group(1))))
               }.getOrElse(sig)

--- a/core/src/main/scala/org/ensime/core/RichPresentationCompiler.scala
+++ b/core/src/main/scala/org/ensime/core/RichPresentationCompiler.scala
@@ -221,7 +221,7 @@ trait RichCompilerControl extends CompilerControl with RefactoringControl with C
       ).getOrElse(List.empty)
     )
 
-  def askNotifyWhenReady(): Unit = ask(setNotifyWhenReady)
+  def askNotifyWhenReady(): Unit = ask(setNotifyWhenReady _)
 
   // WARNING: be really careful when creating BatchSourceFiles. there
   // are multiple constructors which do weird things, best to be very

--- a/core/src/main/scala/org/ensime/core/RichPresentationCompiler.scala
+++ b/core/src/main/scala/org/ensime/core/RichPresentationCompiler.scala
@@ -257,7 +257,7 @@ trait RichCompilerControl extends CompilerControl with RefactoringControl with C
     case SourceFileInfo(ac @ ArchiveFile(a, e), None, Some(contentsIn)) => new BatchSourceFile(
       new VirtualFile(ac.fullPath), contentsIn.readString()(charset).toCharArray
     )
-
+    case _ => throw new IllegalArgumentException(s"Invalid contents of SourceFileInfo parameter: $file.")
   }
 
   def askLinkPos(sym: Symbol, path: EnsimeFile): Option[Position] =

--- a/core/src/main/scala/org/ensime/core/debug/DebugActor.scala
+++ b/core/src/main/scala/org/ensime/core/debug/DebugActor.scala
@@ -202,9 +202,9 @@ class DebugActor private (
           } else {
             val result = t.findVariableByName(name).map(_.cache())
             result.flatMap {
-              case v: IndexedVariableInfoProfile =>
+              case v: IndexedVariableInfo =>
                 Some(DebugStackSlot(DebugThreadId(t.uniqueId), v.frameIndex, v.offsetIndex))
-              case f: FieldVariableInfoProfile => f.parent match {
+              case f: FieldVariableInfo => f.parent match {
                 case Left(o) =>
                   o.cache()
                   Some(DebugObjectField(DebugObjectId(o.uniqueId), f.name))
@@ -337,7 +337,7 @@ class DebugActor private (
    */
   private def withThread[T <: RpcResponse](
     threadId: Long,
-    action: (ScalaVirtualMachine, ThreadInfoProfile) => T
+    action: (ScalaVirtualMachine, ThreadInfo) => T
   ): RpcResponse = withVM(s => {
     val result = s.tryThread(threadId)
       .map(_.cache())
@@ -357,7 +357,7 @@ class DebugActor private (
    * @tparam T The return type of the action
    * @return Success containing the result of the action, otherwise a failure
    */
-  private def suspendAndExecute[T](threadInfo: ThreadInfoProfile, action: => T): Try[T] = {
+  private def suspendAndExecute[T](threadInfo: ThreadInfo, action: => T): Try[T] = {
     Try(threadInfo.suspend())
     val result = Try(action)
     Try(threadInfo.resume())
@@ -378,7 +378,7 @@ class DebugActor private (
     scalaVirtualMachine: ScalaVirtualMachine,
     objectCache: ObjectCache,
     location: DebugLocation
-  ): Option[ValueInfoProfile] = location match {
+  ): Option[ValueInfo] = location match {
     // Retrieves cached object
     case DebugObjectReference(objectId) =>
       log.debug(s"Looking up object from reference $objectId")
@@ -432,8 +432,8 @@ class DebugActor private (
     // Breakpoint Event - capture and broadcast breakpoint information
     scalaVirtualMachine.createEventListener(EventType.BreakpointEventType).foreach(e => {
       val se = e.asInstanceOf[BreakpointEvent]
-      val l: LocationInfoProfile = scalaVirtualMachine.location(se.location())
-      val t: ThreadInfoProfile = scalaVirtualMachine.thread(se.thread())
+      val l: LocationInfo = scalaVirtualMachine.location(se.location())
+      val t: ThreadInfo = scalaVirtualMachine.thread(se.thread())
 
       sourceMap.newLineSourcePosition(l) match {
         case Some(lsp) =>
@@ -453,8 +453,8 @@ class DebugActor private (
     // Step Event - capture and broadcast step information
     scalaVirtualMachine.createEventListener(EventType.StepEventType).foreach(e => {
       val se = e.asInstanceOf[StepEvent]
-      val l: LocationInfoProfile = scalaVirtualMachine.location(se.location())
-      val t: ThreadInfoProfile = scalaVirtualMachine.thread(se.thread())
+      val l: LocationInfo = scalaVirtualMachine.location(se.location())
+      val t: ThreadInfo = scalaVirtualMachine.thread(se.thread())
 
       sourceMap.newLineSourcePosition(l) match {
         case Some(lsp) =>
@@ -476,7 +476,7 @@ class DebugActor private (
       val t = scalaVirtualMachine.thread(ee.thread())
       val ex = scalaVirtualMachine.`object`(ee.exception())
       val lsp = if (ee.catchLocation() != null) {
-        val l: LocationInfoProfile = scalaVirtualMachine.location(ee.catchLocation())
+        val l: LocationInfo = scalaVirtualMachine.location(ee.catchLocation())
         sourceMap.newLineSourcePosition(l)
       } else None
 
@@ -498,13 +498,15 @@ class DebugActor private (
       SuspendPolicyProperty.AllThreads
     ).foreach(e => {
       // Cache the exception object
-      scalaVirtualMachine.`object`(e.exception()).cache()
+      scalaVirtualMachine.`object`(e.exception.toJdiInstance).cache()
 
-      val t = scalaVirtualMachine.thread(e.thread())
-      val ex = scalaVirtualMachine.`object`(e.exception())
-      val lsp = if (e.catchLocation() != null) {
-        val l: LocationInfoProfile = scalaVirtualMachine.location(e.catchLocation())
-        sourceMap.newLineSourcePosition(l)
+      val t = scalaVirtualMachine.thread(e.thread.toJdiInstance)
+      val ex = scalaVirtualMachine.`object`(e.exception.toJdiInstance)
+      val lsp = if (e.catchLocation != null) {
+        e.catchLocation.flatMap { l =>
+          val li = scalaVirtualMachine.location(l.toJdiInstance)
+          sourceMap.newLineSourcePosition(li)
+        }
       } else None
 
       broadcaster ! DebugExceptionEvent(
@@ -518,13 +520,13 @@ class DebugActor private (
 
     // Thread Start Event - capture and broadcast associated thread
     scalaVirtualMachine.onUnsafeThreadStart(SuspendPolicyProperty.NoThread).foreach(t => {
-      val ti = scalaVirtualMachine.thread(t.thread())
+      val ti = scalaVirtualMachine.thread(t.thread.toJdiInstance)
       broadcaster ! DebugThreadStartEvent(DebugThreadId(ti.uniqueId))
     })
 
     // Thread Death Event - capture and broadcast associated thread
     scalaVirtualMachine.onUnsafeThreadDeath(SuspendPolicyProperty.NoThread).foreach(t => {
-      val ti = scalaVirtualMachine.thread(t.thread())
+      val ti = scalaVirtualMachine.thread(t.thread.toJdiInstance)
       broadcaster ! DebugThreadDeathEvent(DebugThreadId(ti.uniqueId))
     })
   }

--- a/core/src/main/scala/org/ensime/core/debug/DebugActor.scala
+++ b/core/src/main/scala/org/ensime/core/debug/DebugActor.scala
@@ -423,17 +423,15 @@ class DebugActor private (
    * @param scalaVirtualMachine The JVM whose events to listen to
    */
   private def bindEventHandlers(scalaVirtualMachine: ScalaVirtualMachine): Unit = {
-    import com.sun.jdi.event._
-
     // Send start event to client when received
     scalaVirtualMachine.onUnsafeVMStart().foreach(_ =>
       broadcaster ! DebugVmStartEvent)
 
     // Breakpoint Event - capture and broadcast breakpoint information
     scalaVirtualMachine.createEventListener(EventType.BreakpointEventType).foreach(e => {
-      val se = e.asInstanceOf[BreakpointEvent]
-      val l: LocationInfo = scalaVirtualMachine.location(se.location())
-      val t: ThreadInfo = scalaVirtualMachine.thread(se.thread())
+      val be = e.toBreakpointEvent
+      val l: LocationInfo = be.location
+      val t: ThreadInfo = be.thread
 
       sourceMap.newLineSourcePosition(l) match {
         case Some(lsp) =>
@@ -452,9 +450,9 @@ class DebugActor private (
 
     // Step Event - capture and broadcast step information
     scalaVirtualMachine.createEventListener(EventType.StepEventType).foreach(e => {
-      val se = e.asInstanceOf[StepEvent]
-      val l: LocationInfo = scalaVirtualMachine.location(se.location())
-      val t: ThreadInfo = scalaVirtualMachine.thread(se.thread())
+      val se = e.toStepEvent
+      val l: LocationInfo = se.location
+      val t: ThreadInfo = se.thread
 
       sourceMap.newLineSourcePosition(l) match {
         case Some(lsp) =>
@@ -472,12 +470,12 @@ class DebugActor private (
     })
 
     scalaVirtualMachine.createEventListener(EventType.ExceptionEventType).foreach(e => {
-      val ee = e.asInstanceOf[ExceptionEvent]
-      val t = scalaVirtualMachine.thread(ee.thread())
-      val ex = scalaVirtualMachine.`object`(ee.exception())
-      val lsp = if (ee.catchLocation() != null) {
-        val l: LocationInfo = scalaVirtualMachine.location(ee.catchLocation())
-        sourceMap.newLineSourcePosition(l)
+      val ee = e.toExceptionEvent
+      val t = ee.thread
+      val ex = ee.exception
+      val ce: Option[LocationInfo] = ee.catchLocation
+      val lsp = if (ce != null) {
+        ce.flatMap(l => sourceMap.newLineSourcePosition(l))
       } else None
 
       broadcaster ! DebugExceptionEvent(
@@ -498,15 +496,12 @@ class DebugActor private (
       SuspendPolicyProperty.AllThreads
     ).foreach(e => {
       // Cache the exception object
-      scalaVirtualMachine.`object`(e.exception.toJdiInstance).cache()
+      e.exception.cache()
 
-      val t = scalaVirtualMachine.thread(e.thread.toJdiInstance)
-      val ex = scalaVirtualMachine.`object`(e.exception.toJdiInstance)
+      val t = e.thread
+      val ex = e.exception
       val lsp = if (e.catchLocation != null) {
-        e.catchLocation.flatMap { l =>
-          val li = scalaVirtualMachine.location(l.toJdiInstance)
-          sourceMap.newLineSourcePosition(li)
-        }
+        e.catchLocation.flatMap(l => sourceMap.newLineSourcePosition(l))
       } else None
 
       broadcaster ! DebugExceptionEvent(
@@ -520,14 +515,12 @@ class DebugActor private (
 
     // Thread Start Event - capture and broadcast associated thread
     scalaVirtualMachine.onUnsafeThreadStart(SuspendPolicyProperty.NoThread).foreach(t => {
-      val ti = scalaVirtualMachine.thread(t.thread.toJdiInstance)
-      broadcaster ! DebugThreadStartEvent(DebugThreadId(ti.uniqueId))
+      broadcaster ! DebugThreadStartEvent(DebugThreadId(t.thread.uniqueId))
     })
 
     // Thread Death Event - capture and broadcast associated thread
     scalaVirtualMachine.onUnsafeThreadDeath(SuspendPolicyProperty.NoThread).foreach(t => {
-      val ti = scalaVirtualMachine.thread(t.thread.toJdiInstance)
-      broadcaster ! DebugThreadDeathEvent(DebugThreadId(ti.uniqueId))
+      broadcaster ! DebugThreadDeathEvent(DebugThreadId(t.thread.uniqueId))
     })
   }
 }

--- a/core/src/main/scala/org/ensime/core/debug/SourceMap.scala
+++ b/core/src/main/scala/org/ensime/core/debug/SourceMap.scala
@@ -10,7 +10,7 @@ import org.ensime.api._
 import org.ensime.config._
 import org.ensime.util.ensimefile._
 import org.ensime.util.file._
-import org.scaladebugger.api.profiles.traits.info.LocationInfoProfile
+import org.scaladebugger.api.profiles.traits.info.LocationInfo
 
 import scala.collection.mutable
 
@@ -45,7 +45,7 @@ class SourceMap(
    *         otherwise None
    */
   def newLineSourcePosition(
-    location: LocationInfoProfile
+    location: LocationInfo
   ): Option[LineSourcePosition] = {
     findFileByLocation(location).map(f =>
       LineSourcePosition(f, location.lineNumber))
@@ -57,8 +57,8 @@ class SourceMap(
    * @param location The location whose source file to find
    * @return Some file representing the local source, otherwise None
    */
-  def findFileByLocation(location: LocationInfoProfile): Option[EnsimeFile] =
-    location.trySourcePath.toOption.flatMap(sourceForFilePath).map(EnsimeFile(_))
+  def findFileByLocation(location: LocationInfo): Option[EnsimeFile] =
+    location.trySourcePath.toOption.flatMap(sourceForFilePath).map(EnsimeFile)
 
   /**
    * Retrieves all current Scala sources available through Ensime with the

--- a/core/src/main/scala/org/ensime/core/debug/StructureConverter.scala
+++ b/core/src/main/scala/org/ensime/core/debug/StructureConverter.scala
@@ -21,7 +21,7 @@ class StructureConverter(private val sourceMap: SourceMap) {
    * @param valueInfo The debugger API value
    * @return The equivalent Ensime message
    */
-  def convertValue(valueInfo: ValueInfoProfile): DebugValue = {
+  def convertValue(valueInfo: ValueInfo): DebugValue = {
     valueInfo.cache() match {
       case v if v.isNull => newDebugNull()
       case v if v.isVoid => convertVoid(v)
@@ -38,7 +38,7 @@ class StructureConverter(private val sourceMap: SourceMap) {
    * @param objInfo The object value to convert
    * @return The new Ensime message
    */
-  private def convertObject(objInfo: ObjectInfoProfile): DebugObjectInstance = {
+  private def convertObject(objInfo: ObjectInfo): DebugObjectInstance = {
     DebugObjectInstance(
       objInfo.toPrettyString,
       extractFields(objInfo.referenceType, objInfo),
@@ -53,7 +53,7 @@ class StructureConverter(private val sourceMap: SourceMap) {
    * @param strInfo The string value to convert
    * @return The new Ensime message
    */
-  private def convertString(strInfo: StringInfoProfile): DebugStringInstance = {
+  private def convertString(strInfo: StringInfo): DebugStringInstance = {
     DebugStringInstance(
       strInfo.toPrettyString,
       extractFields(strInfo.referenceType, strInfo),
@@ -68,7 +68,7 @@ class StructureConverter(private val sourceMap: SourceMap) {
    * @param arrayInfo The array to convert
    * @return The new Ensime message
    */
-  private def convertArray(arrayInfo: ArrayInfoProfile): DebugArrayInstance = {
+  private def convertArray(arrayInfo: ArrayInfo): DebugArrayInstance = {
     DebugArrayInstance(
       arrayInfo.length,
       arrayInfo.referenceType.name,
@@ -84,7 +84,7 @@ class StructureConverter(private val sourceMap: SourceMap) {
    * @return The new Ensime message
    */
   private def convertPrimitive(
-    primitiveInfo: PrimitiveInfoProfile
+    primitiveInfo: PrimitiveInfo
   ): DebugPrimitiveValue = {
     DebugPrimitiveValue(
       primitiveInfo.toPrettyString,
@@ -98,7 +98,7 @@ class StructureConverter(private val sourceMap: SourceMap) {
    * @param void The void value to convert
    * @return The new Ensime message
    */
-  private def convertVoid(void: ValueInfoProfile): DebugPrimitiveValue = {
+  private def convertVoid(void: ValueInfo): DebugPrimitiveValue = {
     DebugPrimitiveValue(
       void.toPrettyString,
       void.typeInfo.name
@@ -123,13 +123,13 @@ class StructureConverter(private val sourceMap: SourceMap) {
    * @return The collection of Ensime messages representing the fields
    */
   private def extractFields(
-    tpeIn: ReferenceTypeInfoProfile,
-    obj: ObjectInfoProfile
+    tpeIn: ReferenceTypeInfo,
+    obj: ObjectInfo
   ): List[DebugClassField] = {
     if (!tpeIn.isClassType) return List.empty
 
     var fields = List[DebugClassField]()
-    var tpe: Option[ClassTypeInfoProfile] = Some(tpeIn.toClassType)
+    var tpe: Option[ClassTypeInfo] = Some(tpeIn.toClassType)
     while (tpe.nonEmpty) {
       fields = tpe.map(_.indexedVisibleFields)
         .map(s => s.map(f => DebugClassField(
@@ -155,7 +155,7 @@ class StructureConverter(private val sourceMap: SourceMap) {
    * @param frame The stack frame to convert
    * @return The resulting Ensime message
    */
-  def convertStackFrame(frame: FrameInfoProfile): DebugStackFrame = {
+  def convertStackFrame(frame: FrameInfo): DebugStackFrame = {
     val locals = ignoreErr(
       frame.indexedLocalVariables.map(_.cache()).map(convertStackLocal).toList,
       List.empty
@@ -182,7 +182,7 @@ class StructureConverter(private val sourceMap: SourceMap) {
    * @return The resulting Ensime message
    */
   private def convertStackLocal(
-    variableInfo: VariableInfoProfile
+    variableInfo: VariableInfo
   ): DebugStackLocal = {
     variableInfo.cache()
     DebugStackLocal(

--- a/core/src/main/scala/org/ensime/indexer/database/DatabaseService.scala
+++ b/core/src/main/scala/org/ensime/indexer/database/DatabaseService.scala
@@ -11,15 +11,15 @@ import akka.event.slf4j.SLF4JLogging
 import com.zaxxer.hikari.HikariDataSource
 import org.apache.commons.vfs2.FileObject
 import org.ensime.api._
+import org.ensime.database.SlickBackCompat.h2Api._
 import org.ensime.indexer.database.DatabaseService._
 import org.ensime.util.file._
 import org.ensime.vfs._
-import slick.driver.H2Driver.api._
 
 class DatabaseService(dir: File) extends SLF4JLogging {
   lazy val (datasource, db) = {
     // MVCC plus connection pooling speeds up the tests ~10%
-    val backend = sys.env.get("ENSIME_EXPERIMENTAL_H2").getOrElse("jdbc:h2:file:")
+    val backend = sys.env.getOrElse("ENSIME_EXPERIMENTAL_H2", "jdbc:h2:file:")
     val url = backend + dir.getAbsolutePath + "/db;MVCC=TRUE"
     val driver = "org.h2.Driver"
 

--- a/core/src/main/scala/org/ensime/indexer/lucene/DynamicSynonymFilter.scala
+++ b/core/src/main/scala/org/ensime/indexer/lucene/DynamicSynonymFilter.scala
@@ -47,13 +47,14 @@ class DynamicSynonymFilter(input: TokenStream, engine: SynonymEngine) extends To
   private val termAtt = addAttribute(classOf[CharTermAttribute])
   private val posIncrAtt = addAttribute(classOf[PositionIncrementAttribute])
 
-  private val stack: mutable.Stack[String] = mutable.Stack()
+  private var stack: List[String] = Nil
   private var current: State = _
 
   // return false when EOL
   override def incrementToken(): Boolean = {
     if (stack.nonEmpty) {
-      val synonym = stack.pop()
+      val synonym = stack.head
+      stack = stack.tail
       restoreState(current) // brings us back to the original token in case of multiple synonyms
       termAtt.setEmpty()
       termAtt.append(synonym)
@@ -69,7 +70,7 @@ class DynamicSynonymFilter(input: TokenStream, engine: SynonymEngine) extends To
     if (synonyms.nonEmpty) {
       synonyms foreach { synonym =>
         if (!synonym.equals(term))
-          stack.push(synonym)
+          stack = synonym :: stack
       }
       current = captureState()
     }

--- a/core/src/main/scala/org/ensime/indexer/lucene/DynamicSynonymFilter.scala
+++ b/core/src/main/scala/org/ensime/indexer/lucene/DynamicSynonymFilter.scala
@@ -9,8 +9,6 @@ import org.apache.lucene.analysis.tokenattributes.{ CharTermAttribute, PositionI
 import org.apache.lucene.util.AttributeSource.State
 import org.ensime.indexer.lucene.DynamicSynonymFilter._
 
-import scala.collection.mutable
-
 /**
  * `Analyzer` that does no additional (not even lowercasing) other than
  * the term itself and its synonyms.

--- a/core/src/test/scala/org/ensime/core/debug/SourceMapSpec.scala
+++ b/core/src/test/scala/org/ensime/core/debug/SourceMapSpec.scala
@@ -11,7 +11,7 @@ import scala.util.Success
 import org.ensime.api._
 import org.ensime.util.EnsimeSpec
 import org.ensime.util.ensimefile._
-import org.scaladebugger.api.profiles.traits.info.LocationInfoProfile
+import org.scaladebugger.api.profiles.traits.info.LocationInfo
 import org.scalamock.scalatest.MockFactory
 import org.scalatest.OneInstancePerTest
 
@@ -37,7 +37,7 @@ class SourceMapSpec extends EnsimeSpec with OneInstancePerTest with MockFactory 
   }
 
   "A SourceMap" should "be able to construct a LineSourcePosition from a location" in {
-    val mockLocationInfo = mock[LocationInfoProfile]
+    val mockLocationInfo = mock[LocationInfo]
     val lineNumber = 999
 
     (mockLocationInfo.trySourcePath _).expects()
@@ -50,7 +50,7 @@ class SourceMapSpec extends EnsimeSpec with OneInstancePerTest with MockFactory 
   }
 
   it should "use the source path of a location to find the associated local file" in {
-    val mockLocationInfo = mock[LocationInfoProfile]
+    val mockLocationInfo = mock[LocationInfo]
 
     (mockLocationInfo.trySourcePath _).expects()
       .returning(Success(testSources.head.getPath)).once()

--- a/core/src/test/scala/org/ensime/indexer/ClassfileDepicklerSpec.scala
+++ b/core/src/test/scala/org/ensime/indexer/ClassfileDepicklerSpec.scala
@@ -6,6 +6,8 @@ import org.ensime.fixture.SharedEnsimeVFSFixture
 import org.ensime.util.EnsimeSpec
 import org.ensime.vfs._
 
+import scala.util.Try
+
 class ClassfileDepicklerSpec extends EnsimeSpec with SharedEnsimeVFSFixture {
 
   "ClassfileDepickler" should "not depickle J2SE classes" in withVFS { vfs =>
@@ -21,7 +23,9 @@ class ClassfileDepicklerSpec extends EnsimeSpec with SharedEnsimeVFSFixture {
   }
 
   it should "not expect anything in closures" in withVFS { vfs =>
-    new ClassfileDepickler(vfs.vres("scala/io/Source$$anonfun$1.class")).scalasig should ===(None)
+    // scala 2.10/2.11 specific, there will be no "scala/io/Source$$anonfun$1.class" generated under 2.12
+    val anonFun = Try { vfs.vres("scala/io/Source$$anonfun$1.class") }
+    anonFun.foreach(fo => new ClassfileDepickler(fo).scalasig should ===(None))
   }
 
   it should "find type aliases" in withVFS { vfs =>

--- a/monkeys/src/main/java/org/apache/commons/vfs2/provider/AbstractFileName.java
+++ b/monkeys/src/main/java/org/apache/commons/vfs2/provider/AbstractFileName.java
@@ -18,11 +18,7 @@
  */
 package org.apache.commons.vfs2.provider;
 
-import org.apache.commons.vfs2.FileName;
-import org.apache.commons.vfs2.FileSystemException;
-import org.apache.commons.vfs2.FileType;
-import org.apache.commons.vfs2.NameScope;
-import org.apache.commons.vfs2.VFS;
+import org.apache.commons.vfs2.*;
 
 /**
  * A default file name implementation.

--- a/monkeys/src/main/java/org/apache/commons/vfs2/provider/AbstractFileName.java
+++ b/monkeys/src/main/java/org/apache/commons/vfs2/provider/AbstractFileName.java
@@ -18,7 +18,11 @@
  */
 package org.apache.commons.vfs2.provider;
 
-import org.apache.commons.vfs2.*;
+import org.apache.commons.vfs2.FileName;
+import org.apache.commons.vfs2.FileSystemException;
+import org.apache.commons.vfs2.FileType;
+import org.apache.commons.vfs2.NameScope;
+import org.apache.commons.vfs2.VFS;
 
 /**
  * A default file name implementation.

--- a/monkeys/src/main/scala-2.12/scala/reflect/io/ZipArchive.scala
+++ b/monkeys/src/main/scala-2.12/scala/reflect/io/ZipArchive.scala
@@ -1,0 +1,331 @@
+// Copyright: 2010 - 2017 https://github.com/ensime/ensime-server/graphs
+// License: http://www.gnu.org/licenses/gpl-3.0.en.html
+/* NSC -- new Scala compiler
+ * Copyright 2005-2013 LAMP/EPFL
+ * @author  Paul Phillips
+ */
+
+package scala
+package reflect
+package io
+
+import java.net.URL
+import java.io.{ IOException, InputStream, ByteArrayInputStream, FilterInputStream }
+import java.io.{ File => JFile }
+import java.util.zip.{ ZipEntry, ZipFile, ZipInputStream }
+import java.util.jar.Manifest
+import scala.collection.mutable
+import scala.collection.JavaConverters._
+import scala.annotation.tailrec
+
+/**
+ * An abstraction for zip files and streams.  Everything is written the way
+ *  it is for performance: we come through here a lot on every run.  Be careful
+ *  about changing it.
+ *
+ *  @author  Philippe Altherr (original version)
+ *  @author  Paul Phillips (this one)
+ *  @version 2.0,
+ *
+ *  ''Note:  This library is considered experimental and should not be used unless you know what you are doing.''
+ */
+object ZipArchive {
+  /**
+   * @param   file  a File
+   * @return  A ZipArchive if `file` is a readable zip file, otherwise null.
+   */
+  def fromFile(file: File): FileZipArchive = fromFile(file.jfile)
+  def fromFile(file: JFile): FileZipArchive =
+    try { new FileZipArchive(file) }
+    catch { case _: IOException => null }
+
+  /**
+   * @param   url  the url of a zip file
+   * @return  A ZipArchive backed by the given url.
+   */
+  def fromURL(url: URL): URLZipArchive = new URLZipArchive(url)
+
+  def fromManifestURL(url: URL): AbstractFile = new ManifestResources(url)
+
+  private def dirName(path: String) = splitPath(path, front = true)
+  private def baseName(path: String) = splitPath(path, front = false)
+  private def splitPath(path0: String, front: Boolean): String = {
+    val isDir = path0.charAt(path0.length - 1) == '/'
+    val path = if (isDir) path0.substring(0, path0.length - 1) else path0
+    val idx = path.lastIndexOf('/')
+
+    if (idx < 0)
+      if (front) "/"
+      else path
+    else if (front) path.substring(0, idx + 1)
+    else path.substring(idx + 1)
+  }
+}
+import ZipArchive._
+/** ''Note:  This library is considered experimental and should not be used unless you know what you are doing.'' */
+abstract class ZipArchive(override val file: JFile) extends AbstractFile with Equals {
+  self =>
+
+  override def underlyingSource = Some(this)
+  def isDirectory = true
+  def lookupName(name: String, directory: Boolean) = unsupported()
+  def lookupNameUnchecked(name: String, directory: Boolean) = unsupported()
+  def create() = unsupported()
+  def delete() = unsupported()
+  def output = unsupported()
+  def container = unsupported()
+  def absolute = unsupported()
+
+  /** ''Note:  This library is considered experimental and should not be used unless you know what you are doing.'' */
+  sealed abstract class Entry(path: String) extends VirtualFile(baseName(path), path) {
+    // have to keep this name for compat with sbt's compiler-interface
+    def getArchive: ZipFile = null
+    override def underlyingSource = Some(self)
+    override def toString = self.path + "(" + path + ")"
+  }
+
+  /** ''Note:  This library is considered experimental and should not be used unless you know what you are doing.'' */
+  class DirEntry(path: String) extends Entry(path) {
+    val entries = mutable.HashMap[String, Entry]()
+
+    override def isDirectory = true
+    override def iterator: Iterator[Entry] = entries.valuesIterator
+    override def lookupName(name: String, directory: Boolean): Entry = {
+      if (directory) entries(name + "/")
+      else entries(name)
+    }
+  }
+
+  private def ensureDir(dirs: mutable.Map[String, DirEntry], path: String, zipEntry: ZipEntry): DirEntry =
+    //OPT inlined from getOrElseUpdate; saves ~50K closures on test run.
+    // was:
+    // dirs.getOrElseUpdate(path, {
+    //   val parent = ensureDir(dirs, dirName(path), null)
+    //   val dir    = new DirEntry(path)
+    //   parent.entries(baseName(path)) = dir
+    //   dir
+    // })
+    dirs get path match {
+      case Some(v) => v
+      case None =>
+        val parent = ensureDir(dirs, dirName(path), null)
+        val dir = new DirEntry(path)
+        parent.entries(baseName(path)) = dir
+        dirs(path) = dir
+        dir
+    }
+
+  protected def getDir(dirs: mutable.Map[String, DirEntry], entry: ZipEntry): DirEntry = {
+    if (entry.isDirectory) ensureDir(dirs, entry.getName, entry)
+    else ensureDir(dirs, dirName(entry.getName), null)
+  }
+}
+/** ''Note:  This library is considered experimental and should not be used unless you know what you are doing.'' */
+final class FileZipArchive(file: JFile) extends ZipArchive(file) {
+  lazy val (root, allDirs) = {
+    val root = new DirEntry("/")
+    val dirs = mutable.HashMap[String, DirEntry]("/" -> root)
+
+    // NOTES on SI-9632
+    //
+    // The original scalac implementation of this class opens the zip
+    // file and retains the file handle, relying on the GC to call the
+    // finalizers (which reliably doesn't happen). On UNIX-like OS the
+    // file handle will refer to the file at the point when it was
+    // created (causing a huge PermGen memory leak), on Windows it is
+    // impossible for any process to delete the file.
+    //
+    // The changes here ensure that zip files are closed immediately
+    // after use: the live version of the file is always accessed.
+    // This can result in runtime exceptions if the file is mutated.
+    //
+    // There is an expected performance penalty, but it is not
+    // significant in practice for ENSIME users. An alternative would
+    // be to eagerly load the zip into memory, but that would have a
+    // significant cost to the heap.
+    def openZipFile(): ZipFile = try {
+      new ZipFile(file)
+    } catch {
+      case ioe: IOException => throw new IOException("Error accessing " + file.getPath, ioe)
+    }
+
+    val zipFile = openZipFile()
+    val enum = zipFile.entries()
+
+    try {
+      while (enum.hasMoreElements) {
+        val zipEntry = enum.nextElement
+        val dir = getDir(dirs, zipEntry)
+        if (zipEntry.isDirectory) dir
+        else {
+          class FileEntry() extends Entry(zipEntry.getName) {
+            // WARNING: provides a newly created archive, which will
+            //          disagree with the FileZipArchive.iterator if
+            //          the file has been mutated. Note that calls to
+            //          this method can leak file handles.
+            override def getArchive = openZipFile
+            override def lastModified = zipEntry.getTime()
+            // WARNING: input will fail if the zip has been mutated
+            //          whereas the scalac implementation will provide
+            //          the old (stale) entry
+            override def input = {
+              val zipFile = getArchive
+              val delegate = zipFile getInputStream zipEntry
+              new FilterInputStream(delegate) {
+                override def close(): Unit = {
+                  delegate.close()
+                  zipFile.close()
+                }
+              }
+            }
+            override def sizeOption = Some(zipEntry.getSize().toInt)
+          }
+          val f = new FileEntry()
+          dir.entries(f.name) = f
+        }
+      }
+    } finally zipFile.close()
+    (root, dirs)
+  }
+
+  def iterator: Iterator[Entry] = root.iterator
+
+  def name = file.getName
+  def path = file.getPath
+  def input = File(file).inputStream()
+  def lastModified = file.lastModified
+
+  override def sizeOption = Some(file.length.toInt)
+  override def canEqual(other: Any) = other.isInstanceOf[FileZipArchive]
+  override def hashCode() = file.hashCode
+  override def equals(that: Any) = that match {
+    case x: FileZipArchive => file.getAbsoluteFile == x.file.getAbsoluteFile
+    case _ => false
+  }
+}
+/** ''Note:  This library is considered experimental and should not be used unless you know what you are doing.'' */
+final class URLZipArchive(val url: URL) extends ZipArchive(null) {
+  def iterator: Iterator[Entry] = {
+    val root = new DirEntry("/")
+    val dirs = mutable.HashMap[String, DirEntry]("/" -> root)
+    val in = new ZipInputStream(new ByteArrayInputStream(Streamable.bytes(input)))
+
+    @tailrec def loop(): Unit = {
+      val zipEntry = in.getNextEntry()
+      class EmptyFileEntry() extends Entry(zipEntry.getName) {
+        override def toByteArray: Array[Byte] = null
+        override def sizeOption = Some(0)
+      }
+      class FileEntry() extends Entry(zipEntry.getName) {
+        override val toByteArray: Array[Byte] = {
+          val len = zipEntry.getSize().toInt
+          val arr = if (len == 0) Array.emptyByteArray else new Array[Byte](len)
+          var offset = 0
+
+          def loop(): Unit = {
+            if (offset < len) {
+              val read = in.read(arr, offset, len - offset)
+              if (read >= 0) {
+                offset += read
+                loop()
+              }
+            }
+          }
+          loop()
+
+          if (offset == arr.length) arr
+          else throw new IOException("Input stream truncated: read %d of %d bytes".format(offset, len))
+        }
+        override def sizeOption = Some(zipEntry.getSize().toInt)
+      }
+
+      if (zipEntry != null) {
+        val dir = getDir(dirs, zipEntry)
+        if (zipEntry.isDirectory)
+          dir
+        else {
+          val f = if (zipEntry.getSize() == 0) new EmptyFileEntry() else new FileEntry()
+          dir.entries(f.name) = f
+        }
+        in.closeEntry()
+        loop()
+      }
+    }
+
+    loop()
+    try root.iterator
+    finally dirs.clear()
+  }
+
+  def name = url.getFile()
+  def path = url.getPath()
+  def input = url.openStream()
+  def lastModified =
+    try url.openConnection().getLastModified()
+    catch { case _: IOException => 0 }
+
+  override def canEqual(other: Any) = other.isInstanceOf[URLZipArchive]
+  override def hashCode() = url.hashCode
+  override def equals(that: Any) = that match {
+    case x: URLZipArchive => url == x.url
+    case _ => false
+  }
+}
+
+final class ManifestResources(val url: URL) extends ZipArchive(null) {
+  def iterator = {
+    val root = new DirEntry("/")
+    val dirs = mutable.HashMap[String, DirEntry]("/" -> root)
+    val manifest = new Manifest(input)
+    val iter = manifest.getEntries().keySet().iterator().asScala.filter(_.endsWith(".class")).map(new ZipEntry(_))
+
+    for (zipEntry <- iter) {
+      val dir = getDir(dirs, zipEntry)
+      if (!zipEntry.isDirectory) {
+        class FileEntry() extends Entry(zipEntry.getName) {
+          override def lastModified = zipEntry.getTime()
+          override def input = resourceInputStream(path)
+          override def sizeOption = None
+        }
+        val f = new FileEntry()
+        dir.entries(f.name) = f
+      }
+    }
+
+    try root.iterator
+    finally dirs.clear()
+  }
+
+  def name = path
+  def path: String = {
+    val s = url.getPath
+    val n = s.lastIndexOf('!')
+    s.substring(0, n)
+  }
+  def input = url.openStream()
+  def lastModified =
+    try url.openConnection().getLastModified()
+    catch { case _: IOException => 0 }
+
+  override def canEqual(other: Any) = other.isInstanceOf[ManifestResources]
+  override def hashCode() = url.hashCode
+  override def equals(that: Any) = that match {
+    case x: ManifestResources => url == x.url
+    case _ => false
+  }
+
+  private def resourceInputStream(path: String): InputStream = {
+    new FilterInputStream(null) {
+      override def read(): Int = {
+        if (in == null) in = Thread.currentThread().getContextClassLoader().getResourceAsStream(path)
+        if (in == null) throw new RuntimeException(path + " not found")
+        super.read()
+      }
+
+      override def close(): Unit = {
+        super.close()
+        in = null
+      }
+    }
+  }
+}

--- a/project/EnsimeBuild.scala
+++ b/project/EnsimeBuild.scala
@@ -154,7 +154,10 @@ object EnsimeBuild {
       ensimeUnmanagedSourceArchives += (baseDirectory in ThisBuild).value / "openjdk-langtools/openjdk8-langtools-src.zip",
       libraryDependencies ++= Seq(
         "com.h2database" % "h2" % "1.4.193",
-        "com.typesafe.slick" %% "slick" % "3.1.1",
+        "com.typesafe.slick" %% "slick" % (scalaBinaryVersion.value match {
+          case "2.10" => "3.1.1"
+          case "2.11" | "2.12" => "3.2.0-M2"
+        }),
         "com.zaxxer" % "HikariCP" % "2.5.1",
         "org.apache.lucene" % "lucene-core" % luceneVersion,
         "org.apache.lucene" % "lucene-analyzers-common" % luceneVersion,
@@ -170,7 +173,7 @@ object EnsimeBuild {
         },
         "commons-lang" % "commons-lang" % "2.6",
         "com.googlecode.java-diff-utils" % "diffutils" % "1.3.0",
-        "org.scala-debugger" %% "scala-debugger-api" % "1.1.0-M2",
+        "org.scala-debugger" %% "scala-debugger-api" % "1.1.0-M3",
         "org.scalamock" %% "scalamock-scalatest-support" % "3.4.2" % Test
       ) ++ shapeless.value
     ) enablePlugins BuildInfoPlugin settings (
@@ -274,8 +277,8 @@ object EnsimeTestingBuild {
 
   lazy val testingFqns = testingProject("testing/fqns").settings (
     libraryDependencies ++= shapeless.value ++ Seq(
-      "org.typelevel" %% "cats" % "0.6.0" % Test intransitive(),
-      "org.spire-math" %% "spire" % "0.11.0" % Test intransitive()
+      "org.typelevel" %% "cats" % "0.8.1" % Test intransitive(),
+      "org.spire-math" %% "spire" % "0.13.0" % Test intransitive()
     )
   )
 

--- a/project/EnsimeBuild.scala
+++ b/project/EnsimeBuild.scala
@@ -69,7 +69,7 @@ object EnsimeBuild {
   // modules
   lazy val monkeys = Project("monkeys", file("monkeys")) settings (commonSettings) settings (
     // WORKAROUND https://issues.scala-lang.org/browse/SI-10157
-    scalacOptions -= "-Xfatal-warnings",
+    scalacOptions in (Compile, doc) -= "-Xfatal-warnings",
     libraryDependencies ++= Seq(
       "org.scala-lang" % "scala-compiler" % scalaVersion.value,
       "org.apache.commons" % "commons-vfs2" % "2.1" exclude ("commons-logging", "commons-logging")

--- a/project/EnsimeBuild.scala
+++ b/project/EnsimeBuild.scala
@@ -55,7 +55,8 @@ object EnsimeBuild {
       "org.apache.lucene" % "lucene-core" % luceneVersion
     ),
 
-    updateOptions := updateOptions.value.withCachedResolution(true)
+    updateOptions := updateOptions.value.withCachedResolution(true),
+    resolvers += Resolver.sonatypeRepo("snapshots")
   )
 
   lazy val commonItSettings = inConfig(It)(
@@ -170,6 +171,7 @@ object EnsimeBuild {
           // see notes in https://github.com/ensime/ensime-server/pull/1446
           case "2.10" => "org.scala-refactoring" % "org.scala-refactoring.library_2.10.6" % "0.11.0"
           case "2.11" => "org.scala-refactoring" % "org.scala-refactoring.library_2.11.8" % "0.11.0"
+          case "2.12" => "org.scala-refactoring" % "org.scala-refactoring.library_2.12.0" % "0.12.0-SNAPSHOT"
         },
         "commons-lang" % "commons-lang" % "2.6",
         "com.googlecode.java-diff-utils" % "diffutils" % "1.3.0",

--- a/project/EnsimeBuild.scala
+++ b/project/EnsimeBuild.scala
@@ -68,7 +68,7 @@ object EnsimeBuild {
   ////////////////////////////////////////////////
   // modules
   lazy val monkeys = Project("monkeys", file("monkeys")) settings (commonSettings) settings (
-    // workaround inability to disable spurious fatal-warnings in scaladoc
+    // WORKAROUND https://issues.scala-lang.org/browse/SI-10157
     scalacOptions -= "-Xfatal-warnings",
     libraryDependencies ++= Seq(
       "org.scala-lang" % "scala-compiler" % scalaVersion.value,

--- a/project/EnsimeBuild.scala
+++ b/project/EnsimeBuild.scala
@@ -68,6 +68,8 @@ object EnsimeBuild {
   ////////////////////////////////////////////////
   // modules
   lazy val monkeys = Project("monkeys", file("monkeys")) settings (commonSettings) settings (
+    // workaround inability to disable spurious fatal-warnings in scaladoc
+    scalacOptions -= "-Xfatal-warnings",
     libraryDependencies ++= Seq(
       "org.scala-lang" % "scala-compiler" % scalaVersion.value,
       "org.apache.commons" % "commons-vfs2" % "2.1" exclude ("commons-logging", "commons-logging")

--- a/project/EnsimeBuild.scala
+++ b/project/EnsimeBuild.scala
@@ -23,7 +23,7 @@ object ProjectPlugin extends AutoPlugin {
   override def trigger = allRequirements
 
   override def buildSettings = Seq(
-    scalaVersion := "2.12.0",
+    scalaVersion := "2.11.8",
     organization := "org.ensime",
     version := "2.0.0-SNAPSHOT",
 

--- a/project/EnsimeBuild.scala
+++ b/project/EnsimeBuild.scala
@@ -23,7 +23,7 @@ object ProjectPlugin extends AutoPlugin {
   override def trigger = allRequirements
 
   override def buildSettings = Seq(
-    scalaVersion := "2.11.8",
+    scalaVersion := "2.12.0",
     organization := "org.ensime",
     version := "2.0.0-SNAPSHOT",
 

--- a/project/EnsimeBuild.scala
+++ b/project/EnsimeBuild.scala
@@ -173,7 +173,7 @@ object EnsimeBuild {
           // see notes in https://github.com/ensime/ensime-server/pull/1446
           case Some((2, 10)) => "org.scala-refactoring" % "org.scala-refactoring.library_2.10.6" % "0.11.0"
           case Some((2, 11)) => "org.scala-refactoring" % "org.scala-refactoring.library_2.11.8" % "0.11.0"
-          case Some((2, 12)) => "org.scala-refactoring" % "org.scala-refactoring.library_2.12.0" % "0.12.0-SNAPSHOT"
+          case _             => "org.scala-refactoring" % "org.scala-refactoring.library_2.12.0" % "0.12.0-SNAPSHOT"
         },
         "commons-lang" % "commons-lang" % "2.6",
         "com.googlecode.java-diff-utils" % "diffutils" % "1.3.0",

--- a/project/EnsimeBuild.scala
+++ b/project/EnsimeBuild.scala
@@ -155,10 +155,12 @@ object EnsimeBuild {
       ensimeUnmanagedSourceArchives += (baseDirectory in ThisBuild).value / "openjdk-langtools/openjdk8-langtools-src.zip",
       libraryDependencies ++= Seq(
         "com.h2database" % "h2" % "1.4.193",
-        "com.typesafe.slick" %% "slick" % (scalaBinaryVersion.value match {
-          case "2.10" => "3.1.1"
-          case "2.11" | "2.12" => "3.2.0-M2"
-        }),
+        "com.typesafe.slick" %% "slick" % {
+          CrossVersion.partialVersion(scalaVersion.value) match {
+            case Some((2, 10)) => "3.1.1"
+            case _             => "3.2.0-M2"
+          }
+        },
         "com.zaxxer" % "HikariCP" % "2.5.1",
         "org.apache.lucene" % "lucene-core" % luceneVersion,
         "org.apache.lucene" % "lucene-analyzers-common" % luceneVersion,
@@ -167,11 +169,11 @@ object EnsimeBuild {
         "org.scala-lang" % "scalap" % scalaVersion.value,
         "com.typesafe.akka" %% "akka-actor" % akkaVersion.value,
         "com.typesafe.akka" %% "akka-slf4j" % akkaVersion.value,
-        scalaBinaryVersion.value match {
+        CrossVersion.partialVersion(scalaVersion.value) match {
           // see notes in https://github.com/ensime/ensime-server/pull/1446
-          case "2.10" => "org.scala-refactoring" % "org.scala-refactoring.library_2.10.6" % "0.11.0"
-          case "2.11" => "org.scala-refactoring" % "org.scala-refactoring.library_2.11.8" % "0.11.0"
-          case "2.12" => "org.scala-refactoring" % "org.scala-refactoring.library_2.12.0" % "0.12.0-SNAPSHOT"
+          case Some((2, 10)) => "org.scala-refactoring" % "org.scala-refactoring.library_2.10.6" % "0.11.0"
+          case Some((2, 11)) => "org.scala-refactoring" % "org.scala-refactoring.library_2.11.8" % "0.11.0"
+          case Some((2, 12)) => "org.scala-refactoring" % "org.scala-refactoring.library_2.12.0" % "0.12.0-SNAPSHOT"
         },
         "commons-lang" % "commons-lang" % "2.6",
         "com.googlecode.java-diff-utils" % "diffutils" % "1.3.0",

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -4,7 +4,7 @@ libraryDependencies += "org.scala-sbt" % "scripted-plugin" % sbtVersion.value
 addSbtPlugin("com.fommil" % "sbt-sensible" % "1.1.5")
 
 // sbt-ensime is needed for the integration tests
-addSbtPlugin("org.ensime" % "sbt-ensime" % "1.12.5")
+addSbtPlugin("org.ensime" % "sbt-ensime" % "1.12.6")
 
 addSbtPlugin("de.heikoseeberger" % "sbt-header" % "1.5.1")
 addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.14.3")

--- a/protocol-swanky/src/main/scala/org/ensime/server/protocol/swank/SwankFormats.scala
+++ b/protocol-swanky/src/main/scala/org/ensime/server/protocol/swank/SwankFormats.scala
@@ -586,6 +586,7 @@ object SwankProtocolResponse {
         SexpList(SexpSymbol(":ok"), payload.toSexp),
         SexpNumber(callId)
       )
+      case _ => throw new IllegalArgumentException(s"Illegal combination of callId and payload content: $o")
     }
   }
 

--- a/s-express/src/test/scala/org/ensime/sexp/formats/BigIntConvertorSpec.scala
+++ b/s-express/src/test/scala/org/ensime/sexp/formats/BigIntConvertorSpec.scala
@@ -53,7 +53,7 @@ class BigIntConvertorCheck extends SexpSpec with GeneratorDrivenPropertyChecks {
     }
   }
 
-  it should "round-trip a troublesome number" in {
+  it should "round-trip a troublesome number" ignore {
     val trouble = BigInt("9223372036854775808")
     fromBitSet(toBitSet(trouble)) shouldBe trouble
   }

--- a/s-express/src/test/scala/org/ensime/sexp/formats/BigIntConvertorSpec.scala
+++ b/s-express/src/test/scala/org/ensime/sexp/formats/BigIntConvertorSpec.scala
@@ -53,6 +53,11 @@ class BigIntConvertorCheck extends SexpSpec with GeneratorDrivenPropertyChecks {
     }
   }
 
+  it should "round-trip a troublesome number" in {
+    val trouble = BigInt("9223372036854775808")
+    fromBitSet(toBitSet(trouble)) shouldBe trouble
+  }
+
   it should "round-trip BitSet <=> BigInt" in {
     forAll { (bitset: BitSet) =>
       toBitSet(fromBitSet(bitset)) should ===(bitset)

--- a/testing/debug/src/main/scala/variables/ReadVariables.scala
+++ b/testing/debug/src/main/scala/variables/ReadVariables.scala
@@ -17,8 +17,11 @@ object ReadVariables {
     val j = List(4, 5, 6)
     val k = Array(One("one"), 1, true)
     val l = NullToString
+    val m = SimpleTestClass(Some("foo"), List(3, 2, 1))
 
     noop(None)
   }
+
+  case class SimpleTestClass(x: Option[String], xs: List[Int])
 
 }

--- a/util/src/main/scala-2.12/org/ensime/AkkaBackCompat.scala
+++ b/util/src/main/scala-2.12/org/ensime/AkkaBackCompat.scala
@@ -1,7 +1,5 @@
 // Copyright: 2010 - 2017 https://github.com/ensime/ensime-server/graphs
 // License: http://www.gnu.org/licenses/gpl-3.0.en.html
-package org.ensime.database
+package org.ensime
 
-object SlickBackCompat {
-  val h2Api = slick.driver.H2Driver.api
-}
+trait AkkaBackCompat

--- a/util/src/main/scala/org/ensime/vfs/EnsimeVFS.scala
+++ b/util/src/main/scala/org/ensime/vfs/EnsimeVFS.scala
@@ -37,7 +37,7 @@ object SourceSelector extends ExtSelector {
 }
 
 @deprecating("https://github.com/ensime/ensime-server/issues/1437")
-object EnsimeVFS {
+object EnsimeVFS0 {
   def apply(): EnsimeVFS = {
     val vfsInst = new StandardFileSystemManager()
     vfsInst.init()
@@ -48,6 +48,9 @@ object EnsimeVFS {
 object `package` {
   @deprecating("https://github.com/ensime/ensime-server/issues/1437")
   type EnsimeVFS = DefaultFileSystemManager
+  // this is a workaround for https://issues.scala-lang.org/browse/SI-7139, to build with 2.12.0
+  // should be removed when we move to 2.12.1
+  val EnsimeVFS: EnsimeVFS0.type = EnsimeVFS0
 
   // the alternative is a monkey patch, count yourself lucky
   private val zipFileField = classOf[ZipFileSystem].getDeclaredField("zipFile")


### PR DESCRIPTION
Been testing it locally, everything but `DocResolverSpec` seems to be working for me on `2.12.0`.

todo:
- [x] fix `DocResolverSpec`
- [ ] blocked on scala-refactoring 2.12.1 release https://github.com/scala-ide/scala-refactoring/issues/178
