### PR TITLE
Recover from extractSymbolsFromClassOrJar method when indexing bases

### DIFF
--- a/core/src/main/scala/org/ensime/indexer/SearchService.scala
+++ b/core/src/main/scala/org/ensime/indexer/SearchService.scala
@@ -133,7 +133,11 @@ class SearchService(
         val check = FileCheck(base)
         val indexed = extractSymbolsFromClassOrJar(base).flatMap(persist(check, _, commitIndex = false, boost = boost))
         indexed.onComplete { _ => semaphore.release() }
-        indexed
+        indexed.recover {
+          case t: Throwable =>
+            log.warn(s"Failed to index ${base.getName()}.", t)
+            0
+        }
       }
     }
 


### PR DESCRIPTION
This PR enables recovering from a possibly failed `Future` in the `extractSymbolsFromClassOrJar` method when indexing bases. A `Future` would fail in this case if the method attempted to open a file that wasn't a jar (`.so`, `.dll` can easily exist in `java.library.path`). Since we're sequencing the `Future`s and only commiting to index on success, the presence of an unindexable file would make the whole process fail.

I think I can create a test that exposes this behaviour, but I would like to know first if you're OK with the general direction on this.