### PR TITLE
Adapt SimpleLucene to use a Future-based API

### DIFF
--- a/core/src/it/scala/org/ensime/indexer/SearchServiceSpec.scala
+++ b/core/src/it/scala/org/ensime/indexer/SearchServiceSpec.scala
@@ -215,7 +215,7 @@ class SearchServiceSpec extends EnsimeSpec
     val query = new DisjunctionMaxQuery(
       terms.map(service.index.buildTermClassMethodQuery).asJavaCollection, 0f
     )
-    val fqns = lucene.search(query, 10).map(_.get("fqn"))
+    val fqns = lucene.search(query, 10).futureValue.map(_.get("fqn"))
     fqns.distinct should ===(fqns)
   }
 }

--- a/core/src/main/scala/org/ensime/indexer/IndexService.scala
+++ b/core/src/main/scala/org/ensime/indexer/IndexService.scala
@@ -6,7 +6,6 @@ import java.io.FileNotFoundException
 import java.nio.file.Path
 
 import scala.collection.JavaConverters._
-
 import akka.event.slf4j.SLF4JLogging
 import org.apache.commons.vfs2.FileObject
 import org.apache.lucene.document.{ Document, TextField }
@@ -19,6 +18,8 @@ import org.apache.lucene.analysis.core.KeywordAnalyzer
 import org.ensime.indexer.lucene._
 import org.ensime.util.list._
 import shapeless.Typeable
+
+import scala.concurrent.{ ExecutionContext, Future }
 
 object IndexService extends SLF4JLogging {
 
@@ -79,7 +80,7 @@ object IndexService extends SLF4JLogging {
     build()
 }
 
-class IndexService(path: Path) {
+class IndexService(path: Path)(implicit ec: ExecutionContext) {
   import org.ensime.indexer.IndexService._
 
   private val analyzers = Map(
@@ -94,7 +95,7 @@ class IndexService(path: Path) {
     1 - .25f * nonTrailing$s
   }
 
-  def persist(check: FileCheck, symbols: List[FqnSymbol], commit: Boolean, boost: Boolean): Unit = {
+  def persist(check: FileCheck, symbols: List[FqnSymbol], commit: Boolean, boost: Boolean): Future[Unit] = {
     val f = Some(check)
     val fqns: List[Document] = symbols.map {
       case FqnSymbol(_, _, _, fqn, _, _, _, _) if fqn.contains("(") => MethodIndex(fqn, f).toDocument
@@ -115,35 +116,36 @@ class IndexService(path: Path) {
     lucene.create(fqns, commit)
   }
 
-  def commit(): Unit = {
-    try lucene.commit()
-    catch {
+  def commit(): Future[Unit] = {
+    lucene.commit().recover {
       case e: FileNotFoundException =>
         // one of those useless exceptions that is either harmless
         // (testing, commits are happening after we're interested) or
         // utterly fatal (the user deleted the files on disk)
         log.error("the Lucene database was deleted: " + e.getMessage)
+        ()
     }
   }
 
-  def remove(fs: List[FileObject]): Unit = {
+  def remove(fs: List[FileObject]): Future[Unit] = {
     val terms = fs.map { f => new TermQuery(new Term("file", f.getName.getURI)) }
     lucene.delete(terms, commit = false) // don't commit yet
   }
 
-  def searchClasses(query: String, max: Int): List[ClassIndex] = {
+  def searchClasses(query: String, max: Int): Future[List[ClassIndex]] = {
     val q = new BooleanQuery.Builder().
       add(boostedPrefixQuery(new Term("fqn", query)), Occur.MUST).
       add(ClassIndexT, Occur.MUST).
       build()
-    lucene.search(q, max).map(_.toEntity[ClassIndex]).distinct
+
+    lucene.search(q, max).map(_.map(_.toEntity[ClassIndex]).distinct)
   }
 
-  def searchClassesMethods(terms: List[String], max: Int): List[FqnIndex] = {
+  def searchClassesMethods(terms: List[String], max: Int): Future[List[FqnIndex]] = {
     val query = new DisjunctionMaxQuery(
       terms.map(buildTermClassMethodQuery).asJavaCollection, 0f
     )
-    lucene.search(query, max).map(_.toEntity[ClassIndex]).distinct
+    lucene.search(query, max).map(_.map(_.toEntity[ClassIndex]).distinct)
   }
 
   def buildTermClassMethodQuery(query: String): Query = {
@@ -159,4 +161,6 @@ class IndexService(path: Path) {
       ).
         build()
   }
+
+  def shutdown(): Future[Unit] = lucene.shutdown()
 }

--- a/testutil/src/main/scala/org/ensime/util/EnsimeSpec.scala
+++ b/testutil/src/main/scala/org/ensime/util/EnsimeSpec.scala
@@ -7,11 +7,10 @@ import java.util.concurrent.TimeUnit
 
 import scala.collection.JavaConverters._
 import scala.concurrent.duration._
-
 import com.typesafe.config.ConfigFactory
 import org.scalactic.TypeCheckedTripleEquals
 import org.scalatest._
-import org.scalatest.concurrent.Eventually
+import org.scalatest.concurrent.{ Eventually, ScalaFutures }
 import org.scalatest.time._
 import org.slf4j.LoggerFactory
 import org.slf4j.bridge.SLF4JBridgeHandler
@@ -32,6 +31,7 @@ trait EnsimeSpec extends FlatSpec
     with Retries
     with Eventually
     with TryValues
+    with ScalaFutures
     with Inspectors
     with TypeCheckedTripleEquals
     with BeforeAndAfterAll { self =>


### PR DESCRIPTION
This commit adds an internal `FixedThreadPoolExecutor` to `SimpleLucene`
to be used for executing blocking operations against Lucene. The API is
also converted to return `Future`s.

An implicit `ExecutionContext` was also added to `IndexService`'s
constructor, used for transforming futures returned from `SimpleLucene`.

Resolves #1481.