### PR TITLE
Remove commons-lang and introduce HtmlUtil to unescape html

### DIFF
--- a/core/src/main/scala/org/ensime/core/DocUsecaseHandling.scala
+++ b/core/src/main/scala/org/ensime/core/DocUsecaseHandling.scala
@@ -5,7 +5,9 @@ package org.ensime.core
 import java.io.{ File, IOException }
 import java.util.jar.JarFile
 import java.util.regex.Pattern
-import org.apache.commons.lang.StringEscapeUtils
+
+import org.ensime.util.HtmlUtil
+
 import scala.io.Source
 
 // Scaladoc uses @usecase comment annotations to substitute kid-safe signatures
@@ -34,7 +36,9 @@ trait DocUsecaseHandling { self: DocResolver =>
               //              val re = s"""<a id="(${Pattern.quote(prefix)}.+?)"""".r
               val re = s"""<a id="(${Pattern.quote(prefix)}[^a-zA-Z\\d].*?)"""".r
               re.findFirstMatchIn(html).map { m =>
-                sig.copy(member = Some(StringEscapeUtils.unescapeHtml(m.group(1))))
+                {
+                  sig.copy(member = HtmlUtil.unescapeHtml(m.group(1)))
+                }
               }.getOrElse(sig)
             } finally jarFile.close()
           } catch { case e: IOException => sig }
@@ -87,5 +91,4 @@ trait DocUsecaseHandling { self: DocResolver =>
     "zipAll",
     "zipWithIndex"
   )
-
 }

--- a/core/src/main/scala/org/ensime/util/HtmlUtil.scala
+++ b/core/src/main/scala/org/ensime/util/HtmlUtil.scala
@@ -1,0 +1,43 @@
+// Copyright: 2010 - 2017 https://github.com/ensime/ensime-server/graphs
+// License: http://www.gnu.org/licenses/gpl-3.0.en.html
+package org.ensime.util
+
+import scala.util.Try
+
+object HtmlUtil {
+
+  def unescapeHtml(escaped: String): Option[String] = {
+    Try {
+      val result = escaped.foldLeft[(String, Option[String])](("", None)) {
+        case ((acc, escapedElemAcc), c) =>
+          (c, escapedElemAcc) match {
+            case ('&', None) =>
+              (acc, Some(""))
+            case (_, None) =>
+              (acc + c, None)
+            case ('&', Some(_)) =>
+              throw new IllegalArgumentException("nested escape sequences not supported")
+            case (';', Some(escapedElem)) =>
+              (acc + unescapeMap(escapedElem), None)
+            case (_, Some(incompleteEscapedElem)) =>
+              (acc, Some(incompleteEscapedElem + c))
+          }
+      }
+      result match {
+        case (escaped, None) =>
+          escaped
+        case _ =>
+          throw new IllegalArgumentException("unfinished escape sequence not supported")
+      }
+    }.toOption
+  }
+
+  //Minimal unescape map based on scala.xml.Utility.unescape() should be enough for most HTML
+  private val unescapeMap = Map(
+    "lt" -> '<',
+    "gt" -> '>',
+    "amp" -> '&',
+    "quot" -> '"',
+    "apos" -> '\''
+  )
+}

--- a/core/src/test/scala/org/ensime/util/HtmlUtilSpec.scala
+++ b/core/src/test/scala/org/ensime/util/HtmlUtilSpec.scala
@@ -1,0 +1,55 @@
+// Copyright: 2010 - 2017 https://github.com/ensime/ensime-server/graphs
+// License: http://www.gnu.org/licenses/gpl-3.0.en.html
+package org.ensime.util
+
+class HtmlUtilsSpec extends EnsimeSpec {
+
+  "HtmlUtil" should "not unescape plain text" in {
+    val originalEscaped = "plain text"
+    HtmlUtil.unescapeHtml(originalEscaped) should ===(Some(originalEscaped))
+  }
+
+  it should "not unescape empty strings" in {
+    val originalEscaped = ""
+    HtmlUtil.unescapeHtml(originalEscaped) should ===(Some(originalEscaped))
+  }
+
+  it should "unescape ampersands" in {
+    val originalEscaped = "Emacs &amp; Ensime"
+    HtmlUtil.unescapeHtml(originalEscaped) should ===(Some("Emacs & Ensime"))
+
+  }
+
+  it should "unescape quotes" in {
+    val originalEscaped = "&quot;Emacs&quot; &amp; Ensime"
+    HtmlUtil.unescapeHtml(originalEscaped) should ===(Some("\"Emacs\" & Ensime"))
+
+  }
+
+  it should "unescape first character only" in {
+    val originalEscaped = "&lt; less than fun without Ensime"
+    HtmlUtil.unescapeHtml(originalEscaped) should ===(Some("< less than fun without Ensime"))
+  }
+
+  it should "unescape last character only" in {
+    val originalEscaped = "Ensime is greater than all &gt;"
+    HtmlUtil.unescapeHtml(originalEscaped) should ===(Some("Ensime is greater than all >"))
+
+  }
+
+  it should "unescape apostrophes" in {
+    val originalEscaped = "Emacs is Ensime&apos;s friend"
+    HtmlUtil.unescapeHtml(originalEscaped) should ===(Some("Emacs is Ensime's friend"))
+  }
+
+  "HtmlUtil" should "handle unfinished unescape sequences nicely" in {
+    val originalEscaped = "me &amp you"
+    HtmlUtil.unescapeHtml(originalEscaped) should ===(None)
+  }
+
+  "HtmlUtil" should "handle nested unescape sequences nicely" in {
+    val originalEscaped = "me &&amp;; you"
+    HtmlUtil.unescapeHtml(originalEscaped) should ===(None)
+  }
+
+}

--- a/project/EnsimeBuild.scala
+++ b/project/EnsimeBuild.scala
@@ -179,7 +179,6 @@ object EnsimeBuild {
           }
           "org.scala-refactoring" % s"org.scala-refactoring.library_${suffix}" % "0.12.0"
         },
-        "commons-lang" % "commons-lang" % "2.6",
         "com.googlecode.java-diff-utils" % "diffutils" % "1.3.0",
         "org.scala-debugger" %% "scala-debugger-api" % "1.1.0-M3"
       ) ++ shapeless.value


### PR DESCRIPTION
This small PR is a partial fix for #1643 as it only removes commons-lang by introducing a simple HTML unescape utility. It's based on a minimal unescape map that should hopefully be enough for most ScalaDoc/JavaDoc HTML.