### PR TITLE
Implement an expand match cases refactoring

### DIFF
--- a/api/src/main/scala/org/ensime/api/common.scala
+++ b/api/src/main/scala/org/ensime/api/common.scala
@@ -88,8 +88,9 @@ object RefactorType {
   case object InlineLocal extends RefactorType('inlineLocal)
   case object OrganizeImports extends RefactorType('organizeImports)
   case object AddImport extends RefactorType('addImport)
+  case object ExpandMatchCases extends RefactorType('expandMatchCases)
 
-  def allTypes = Seq(Rename, ExtractMethod, ExtractLocal, InlineLocal, OrganizeImports, AddImport)
+  def allTypes = Seq(Rename, ExtractMethod, ExtractLocal, InlineLocal, OrganizeImports, AddImport, ExpandMatchCases)
 }
 
 /**

--- a/api/src/main/scala/org/ensime/api/outgoing.scala
+++ b/api/src/main/scala/org/ensime/api/outgoing.scala
@@ -173,6 +173,8 @@ final case class OrganiseImportsRefactorDesc(file: File) extends RefactorDesc(Re
 final case class AddImportRefactorDesc(qualifiedName: String, file: File)
   extends RefactorDesc(RefactorType.AddImport)
 
+final case class ExpandMatchCasesDesc(file: File, start: Int, end: Int) extends RefactorDesc(RefactorType.ExpandMatchCases)
+
 sealed trait PatchOp {
   def start: Int
 }

--- a/protocol-swanky/src/main/scala/org/ensime/server/protocol/swank/SwankFormats.scala
+++ b/protocol-swanky/src/main/scala/org/ensime/server/protocol/swank/SwankFormats.scala
@@ -698,6 +698,10 @@ object SwankProtocolRequest {
     def write(v: RefactorDesc): Sexp = ???
     def read(sexp: Sexp): RefactorDesc = sexp match {
       case SexpList(params) =>
+        val isExpandMatchCases = params.grouped(2).collect {
+          case List(t @ SexpSymbol("tpe"), s @ SexpString("expandMatchCases")) => (t, s)
+        }.nonEmpty
+
         params.grouped(2).collect {
           case List(SexpSymbol("qualifiedName"), value) => (Loc.QualifiedName, value)
           case List(SexpSymbol("file"), value) => (Loc.File, value)
@@ -727,6 +731,12 @@ object SwankProtocolRequest {
             (Loc.Name, SexpString(name)),
             (Loc.Start, SexpNumber(start))
             ) => ExtractLocalRefactorDesc(name, File(f).canon, start.intValue, end.intValue)
+
+          case List(
+            (Loc.End, SexpNumber(end)),
+            (Loc.File, SexpString(f)),
+            (Loc.Start, SexpNumber(start))
+            ) if isExpandMatchCases => ExpandMatchCasesDesc(File(f).canon, start.intValue, end.intValue)
 
           case List(
             (Loc.End, SexpNumber(end)),

--- a/protocol-swanky/src/test/scala/org/ensime/server/protocol/swank/SwankFormatsSpec.scala
+++ b/protocol-swanky/src/test/scala/org/ensime/server/protocol/swank/SwankFormatsSpec.scala
@@ -169,6 +169,16 @@ class SwankFormatsSpec extends EnsimeSpec with EnsimeTestData {
     )
 
     unmarshal(
+      s"""(swank:diff-refactor 1 (end 100 file "$file1" start 1) nil)""",
+      RefactorReq(1, InlineLocalRefactorDesc(file1, 1, 100), false): RpcRequest
+    )
+
+    unmarshal(
+      s"""(swank:diff-refactor 1 (end 100 file "$file1" start 1 tpe "expandMatchCases") nil)""",
+      RefactorReq(1, ExpandMatchCasesDesc(file1, 1, 100), false): RpcRequest
+    )
+
+    unmarshal(
       s"""(swank:symbol-designations "$file1" 1 100 (object val))""",
       SymbolDesignationsReq(
         Left(file1), 1, 100,


### PR DESCRIPTION
This correctly handles case classes, case objects and sealed traits. The indentation handling is so-so.

This will turn this block:
```
val f: Family = ???
f match {
<point>
}
```

To:
```
val f: Family = ???
f match {
  case ctor1(f1, f2, f3) =>
  case ctor2(f1, f2, f3) =>
  ...
}
```
with some permutation of the whitespace.

This is still missing automatic importing of the case constructors, but is useful as it is right now.