### PR TITLE
upgrade build tooling and workaround graph heap

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -33,12 +33,12 @@ pipeline:
           export ENSIME_ASSEMBLY_JAR=$SBT_VOLATILE_TARGET/$BUILD_DIR/target/*/*-assembly.jar ;
           scp -o StrictHostKeyChecking=no $ENSIME_ASSEMBLY_JAR typelevel@ensime.typelevel.org:ensime.typelevel.org/ ;
         fi
-      - if [ -z "$DRONE_PULL_REQUEST" ] && [ "$SCALA_VERSION" = "2.11.8" ] ; then
+      - if [ -z "$DRONE_PULL_REQUEST" ] && [ "$SCALA_VERSION" = "2.12.1" ] ; then
           curl -H 'Content-Type:application/json' --data '{"docker_tag":"v2.x-cache"}' -X POST "https://registry.hub.docker.com/u/ensime/ensime/trigger/${DOCKER_TRIGGER_TOKEN}/" ;
         fi
 
 matrix:
   SCALA_VERSION:
     - 2.12.1
-    - 2.11.8
+    - 2.11.11
     - 2.10.6

--- a/NOTICE
+++ b/NOTICE
@@ -1,6 +1,9 @@
 ENSIME Server
 Copyright 2010 - 2016 Aemon Cannon
+Copyright 2014 - 2016 Erik Daniel
 Copyright 2014 - 2017 Sam Halliday
+Copyright 2014 - 2016 Rory Graves
+Copyright 2016 - 2017 Andrey Sugak
 Copyright 2010 - 2017 https://github.com/ensime/ensime-server/graphs
 
 The `api` module is licensed under the Apache 2.0 permissive license.

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,12 +1,12 @@
 install:
   - ps: |
       Add-Type -AssemblyName System.IO.Compression.FileSystem
-      if (!(Test-Path -Path "C:\sbt\sbt-launcher-packaging-0.13.13" )) {
+      if (!(Test-Path -Path "C:\sbt\sbt-launcher-packaging-0.13.15" )) {
         (new-object System.Net.WebClient).DownloadFile(
-          'https://dl.bintray.com/sbt/native-packages/sbt/0.13.13/sbt-0.13.13.zip',
-          'C:\sbt-0.13.13.zip'
+          'https://dl.bintray.com/sbt/native-packages/sbt/0.13.15/sbt-0.13.15.zip',
+          'C:\sbt-0.13.15.zip'
         )
-        [System.IO.Compression.ZipFile]::ExtractToDirectory("C:\sbt-0.13.13.zip", "C:\sbt")
+        [System.IO.Compression.ZipFile]::ExtractToDirectory("C:\sbt-0.13.15.zip", "C:\")
       }
   - ps: |
       if (!(Test-Path -Path "C:\Program Files\Java\jdk1.8.0\src.zip")) {
@@ -16,7 +16,7 @@ install:
         )
       }
   - cmd: SET JAVA_HOME=C:\Program Files\Java\jdk1.8.0
-  - cmd: SET PATH=C:\sbt\sbt-launcher-packaging-0.13.13\bin;%JAVA_HOME%\bin;%PATH%
+  - cmd: SET PATH=C:\sbt\bin;%JAVA_HOME%\bin;%PATH%
   - cmd: SET COURSIER_VERBOSITY=-1
   - cmd: SET AKKA_TEST_TIMEFACTOR=5
   - cmd: SET SBT_TASK_LIMIT=4
@@ -30,12 +30,12 @@ build_script:
   - sbt ++%SCALA_VERSION% ";ensimeConfig ;test:compile ;it:compile ;ensime/assembly"
   - cd testing\cache && sbt ++%SCALA_VERSION% ensimeConfig ensimeServerIndex && cd ..\..
 test_script:
-  - sbt ++%SCALA_VERSION% "testOnly -- -l tags.IgnoreOnAppVeyor"
+  - IF DEFINED APPVEYOR_PULL_REQUEST_NUMBER (sbt ++%SCALA_VERSION% "testOnly -- -l tags.IgnoreOnAppVeyor")
   - SET SBT_TASK_LIMIT=2
-  - sbt ++%SCALA_VERSION% "it:testOnly -- -l tags.IgnoreOnAppVeyor"
+  - IF DEFINED APPVEYOR_PULL_REQUEST_NUMBER (sbt ++%SCALA_VERSION% "it:testOnly -- -l tags.IgnoreOnAppVeyor")
 cache:
   - C:\Program Files\Java\jdk1.8.0\src.zip
-  - C:\sbt\sbt-launcher-packaging-0.13.13
+  - C:\sbt
   - C:\Users\appveyor\.ivy2 -> appveyor.yml
   - C:\Users\appveyor\.coursier -> appveyor.yml
 on_finish:

--- a/project/EnsimeBuild.scala
+++ b/project/EnsimeBuild.scala
@@ -25,9 +25,9 @@ object ProjectPlugin extends AutoPlugin {
   override def buildSettings = Seq(
     scalaVersion := "2.12.1",
     organization := "org.ensime",
-    version := "2.0.0-SNAPSHOT",
 
     ensimeIgnoreMissingDirectories := true,
+    ensimeJavaFlags += "-Xmx4g",
 
     sonatypeGithub := ("ensime", "ensime-server"),
     licenses := Seq(GPL3),
@@ -227,7 +227,7 @@ object EnsimeBuild {
   lazy val root = Project(id = "ensime", base = file(".")) settings (commonSettings) aggregate (
     api, monkeys, util, s_express, jerky, swanky, core, server
   ) dependsOn (server) settings (
-      // e.g. `sbt ++2.11.8 ensime/assembly`
+      // e.g. `sbt ++2.11.11 ensime/assembly`
       test in assembly := {},
       sourceDirectories in Compile := Nil,
       resources in Compile := Nil,

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,2 +1,2 @@
-sbt.version=0.13.13
+sbt.version=0.13.15
 

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,11 +1,11 @@
 scalacOptions ++= Seq("-unchecked", "-deprecation")
 ivyLoggingLevel := UpdateLogging.Quiet
 libraryDependencies += "org.scala-sbt" % "scripted-plugin" % sbtVersion.value
-addSbtPlugin("com.fommil" % "sbt-sensible" % "1.1.11")
+addSbtPlugin("com.fommil" % "sbt-sensible" % "1.1.13")
 
 // sbt-ensime is needed for the integration tests
 addSbtPlugin("org.ensime" % "sbt-ensime" % "1.12.9")
 
-addSbtPlugin("de.heikoseeberger" % "sbt-header" % "1.5.1")
+addSbtPlugin("de.heikoseeberger" % "sbt-header" % "1.5.1") // 1.8.0 causes https://github.com/sbt/sbt-header/issues/56
 addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.14.4" exclude("org.apache.maven", "maven-plugin-api"))
 addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.6.1")


### PR DESCRIPTION
some trivial upgrades. No upgrade to scala 2.12.2 yet because of a test failure in the scaladoc resolving (a signature changed) and https://github.com/scala/scala/pull/5402 which causes warnings (errors in CI) **everywhere**.