### PR TITLE
CamelCase Completion For Indexed Resources and PC 

### DIFF
--- a/core/src/it/scala/org/ensime/core/RichPresentationCompilerSpec.scala
+++ b/core/src/it/scala/org/ensime/core/RichPresentationCompilerSpec.scala
@@ -212,6 +212,15 @@ class RichPresentationCompilerSpec extends EnsimeSpec
       forAtLeast(1, result.completions) { _.name shouldBe "aMethod" }
     }
 
+  it should "get completions on a member with a camel case prefix" in withPosInCompiledSource(
+    "package com.example",
+    "object A { def camelCaseMethod(a: Int) = a }",
+    "object B { val x = A.caCasMet@@ }"
+  ) { (p, cc) =>
+      val result = cc.completionsAt(p, 10, caseSens = false).futureValue
+      forAtLeast(1, result.completions) { _.name shouldBe "camelCaseMethod" }
+    }
+
   it should "get completions on an object name" in withPosInCompiledSource(
     "package com.example",
     "object Abc { def aMethod(a: Int) = a }",
@@ -219,6 +228,15 @@ class RichPresentationCompilerSpec extends EnsimeSpec
   ) { (p, cc) =>
       val result = cc.completionsAt(p, 10, caseSens = false).futureValue
       forAtLeast(1, result.completions) { _.name shouldBe "Abc" }
+    }
+
+  it should "get completions on an object name with camel case prefix" in withPosInCompiledSource(
+    "package com.example",
+    "object CamelCaseObject { def aMethod(a: Int) = a }",
+    "object B { val x = aCObje@@ }"
+  ) { (p, cc) =>
+      val result = cc.completionsAt(p, 10, caseSens = false).futureValue
+      forAtLeast(1, result.completions) { _.name shouldBe "CamelCaseObject" }
     }
 
   it should "make infix a method with less than 4 letters/numbers name and one parameter" in withPosInCompiledSource(
@@ -388,6 +406,15 @@ class RichPresentationCompilerSpec extends EnsimeSpec
   ) { (p, cc) =>
       val result = cc.completionsAt(p, 10, caseSens = false).futureValue
       forAtLeast(1, result.completions) { _.name shouldBe "aMethod" }
+    }
+
+  it should "complete interpolated variables with camel case in strings" in withPosInCompiledSource(
+    "package com.example",
+    "object Abc { def camelCaseMethod(a: Int) = a }",
+    s"""object B { val x = s"hello there, $${Abc.cCaMet@@}"}"""
+  ) { (p, cc) =>
+      val result = cc.completionsAt(p, 10, caseSens = false).futureValue
+      forAtLeast(1, result.completions) { _.name shouldBe "camelCaseMethod" }
     }
 
   it should "not attempt to complete symbols in strings" in withPosInCompiledSource(

--- a/core/src/it/scala/org/ensime/indexer/SearchServiceSpec.scala
+++ b/core/src/it/scala/org/ensime/indexer/SearchServiceSpec.scala
@@ -77,13 +77,24 @@ class SearchServiceSpec extends EnsimeSpec
       "String", "string",
       "j.l.str", "j l str"
     )
+
+    searchesClasses(
+      "java.lang.StringIndexOutOfBoundsException",
+      "SIndexOOBE",
+      "SIO",
+      "StringIOOBE",
+      "SIndexOuO",
+      "SIOutOBounE",
+      "StInOuOBE"
+    )
   }
 
   it should "return results from dependencies" in withSearchService { implicit service =>
     searchesClasses(
       "org.scalatest.FunSuite",
       "FunSuite", "funsuite", "funsu",
-      "o s Fun"
+      "o s Fun",
+      "FuSu"
     )
   }
 
@@ -102,7 +113,8 @@ class SearchServiceSpec extends EnsimeSpec
       "org.example.CaseClassWithCamelCaseName",
       "CaseClassWith", "caseclasswith",
       "o e Case", "o.e.caseclasswith",
-      "CCWC" // <= CamelCaseAwesomeNess
+      "CCWC", // <= CamelCaseAwesomeNess
+      "CasClWiCCNa" // <= More camel case AwesomnNess
     )
   }
 
@@ -144,14 +156,15 @@ class SearchServiceSpec extends EnsimeSpec
   it should "return results from static methods" in withSearchService { implicit service =>
     searchesMethods(
       "java.lang.Runtime.addShutdownHook(Ljava/lang/Thread;)V",
-      "addShutdownHook"
+      "addShutdownHook",
+      "aSHook"
     )
   }
 
   it should "return results from instance methods" in withSearchService { implicit service =>
     searchesMethods(
       "java.lang.Runtime.availableProcessors()I",
-      "availableProcessors", "availableP"
+      "availableProcessors", "availableP", "aProc", "avaPro"
     )
   }
 

--- a/core/src/main/scala/org/ensime/core/Completion.scala
+++ b/core/src/main/scala/org/ensime/core/Completion.scala
@@ -376,9 +376,12 @@ object CompletionUtil {
     matchEntire: Boolean, caseSens: Boolean): Boolean = {
     val prefixUpper = prefix.toUpperCase
 
+    val prefixRegexp = "[A-Za-z0-9]*" + prefix.replaceAll("(?<!^)([A-Z])", "[A-Za-z0-9]*$1") + "[A-Za-z0-9]*"
+
     (matchEntire && m == prefix) ||
       (!matchEntire && caseSens && m.startsWith(prefix)) ||
-      (!matchEntire && !caseSens && m.toUpperCase.startsWith(prefixUpper))
+      (!matchEntire && !caseSens && m.toUpperCase.startsWith(prefixUpper)) ||
+      (!matchEntire && prefix.exists(_.isUpper) && m.matches(prefixRegexp))
   }
 
   def fetchTypeSearchCompletions(prefix: String, maxResults: Int, indexer: ActorRef): Future[Option[List[CompletionInfo]]] = {


### PR DESCRIPTION
close #1003

Introduce a wildcard query to support camel case completion for indexed resources.
Tweak PC prefix filter to support camel case completion.