### PR TITLE
Debounce AskReTypecheck

### DIFF
--- a/core/src/main/scala/org/ensime/indexer/SearchService.scala
+++ b/core/src/main/scala/org/ensime/indexer/SearchService.scala
@@ -2,6 +2,7 @@
 // License: http://www.gnu.org/licenses/gpl-3.0.en.html
 package org.ensime.indexer
 
+import org.ensime.util.Debouncer
 import scala.concurrent._
 import scala.concurrent.duration._
 import scala.util.{ Failure, Properties, Success }
@@ -438,8 +439,6 @@ object SearchService {
 final case class IndexFile(f: FileObject)
 
 class IndexingQueueActor(searchService: SearchService) extends Actor with ActorLogging {
-  import context.system
-
   import scala.concurrent.duration._
 
   case object Process
@@ -449,16 +448,9 @@ class IndexingQueueActor(searchService: SearchService) extends Actor with ActorL
   // the URI because FileObject doesn't implement equals
   private val todo = new mutable.HashMap[FileName, mutable.Set[FileObject]] with mutable.MultiMap[FileName, FileObject]
 
-  // debounce and give us a chance to batch (which is *much* faster)
-  private var worker: Cancellable = _
-
   private val advice = "If the problem persists, you may need to restart ensime."
 
-  private def debounce(): Unit = {
-    Option(worker).foreach(_.cancel())
-    import context.dispatcher
-    worker = system.scheduler.scheduleOnce(5 seconds, self, Process)
-  }
+  val processDebounce = Debouncer.forActor(self, Process, delay = 5.seconds, maxDelay = 1.hour)
 
   override def receive: Receive = {
     case IndexFile(f) =>
@@ -467,7 +459,7 @@ class IndexingQueueActor(searchService: SearchService) extends Actor with ActorL
         case classFile => searchService.getTopLevelClassFile(classFile)
       }
       todo.addBinding(topLevelClassFile.getName, topLevelClassFile)
-      debounce()
+      processDebounce.call()
 
     case Process if todo.isEmpty => // nothing to do
 
@@ -475,7 +467,7 @@ class IndexingQueueActor(searchService: SearchService) extends Actor with ActorL
       val batch = todo.take(250)
       batch.keys.foreach(todo.remove)
       if (todo.nonEmpty)
-        debounce()
+        processDebounce.call()
 
       import ExecutionContext.Implicits.global
 

--- a/util/src/main/scala/org/ensime/util/Debouncer.scala
+++ b/util/src/main/scala/org/ensime/util/Debouncer.scala
@@ -1,0 +1,145 @@
+// Copyright: 2010 - 2017 https://github.com/ensime/ensime-server/graphs
+// License: http://www.gnu.org/licenses/gpl-3.0.en.html
+package org.ensime.util
+
+import akka.actor.{ ActorRef, Scheduler, ActorContext }
+import java.time.Clock
+import java.util.concurrent.atomic.{ AtomicBoolean, AtomicInteger }
+import org.slf4j.LoggerFactory
+import scala.concurrent.ExecutionContext
+import scala.concurrent.duration._
+
+/**
+ * Highly performant generic debouncer
+ *
+ * Note: This is not written as an Actor for performance reasons. Debounced calls are filtered synchronously, in the
+ * caller thread, without the need for locks, context switches, or heap allocations. We use AtomicBoolean to resolve
+ * concurrent races; the probability of contending on an AtomicBoolean transition is very low.
+ *
+ * @param name The name of this debouncer
+ * @param scheduler The scheduler implementation to use; Can accept an akka scheduler a la magnet pattern
+ * @param delay The time after which to invoke action; each time [[Debouncer.call]] is invoked, this delay is reset
+ * @param maxDelay The maximum time to delay the invocation of action()
+ * @param action The action to invoke
+ * @param debounceFirst If false, then the first invocation of call() calls action exactly once. Subsequent calls are debounced.
+ * @param Clock The source from which we get the current time. This input should use the same source. Specified for testing purposes
+ */
+class Debouncer(
+    name: String,
+    scheduler: Debouncer.SchedulerLike,
+    delay: FiniteDuration,
+    maxDelay: FiniteDuration,
+    action: () => Unit,
+    debounceFirst: Boolean = true,
+    clock: Clock = Clock.systemUTC
+) {
+  import Debouncer.logger
+  require(delay <= maxDelay, "delay should be <= maxDelay")
+  private[this] val pending = new AtomicBoolean(false)
+  private[this] val calls = new AtomicInteger(0)
+  private[this] val debouncingActive = new AtomicBoolean(debounceFirst)
+  private val delayMs = delay.toMillis
+  private val maxDelayMs = maxDelay.toMillis
+  @volatile private[this] var lastCallAttempt: Long = clock.millis()
+  @volatile private[this] var lastInvocation: Long = clock.millis()
+
+  /**
+   * Register that the provided action should be called according to the debounce logic
+   */
+  def call(): Unit = if (activateDebouncing) {
+    action()
+  } else {
+    lastCallAttempt = clock.millis()
+    calls.incrementAndGet()
+    if (pending.compareAndSet(false, true)) {
+      scheduler.scheduleOnce(delay) { () => tryActionOrPostpone() }
+    }
+  }
+
+  /** Returns true if debouncing was inactive, and we just activated it */
+  private[this] def activateDebouncing =
+    debouncingActive.compareAndSet(false, true)
+
+  /** See if it's time to invoke the debounce action */
+  private[this] def tryActionOrPostpone(): Unit = {
+    val now = clock.millis()
+    val delaySurpassed = ((now - lastCallAttempt) >= delayMs)
+    val maxDelaySurpassed = ((now - lastInvocation) >= maxDelayMs)
+
+    if (delaySurpassed || maxDelaySurpassed) {
+      lastInvocation = now
+      if (pending.compareAndSet(true, false)) {
+        val foldedCalls = calls.getAndSet(0)
+        if (maxDelaySurpassed)
+          logger.info(s"Debouncer action $name invoked after maxDelay $maxDelay surpassed ($foldedCalls calls)")
+        else if (logger.isDebugEnabled)
+          logger.debug(s"Debouncer action $name invoked after delay $delay surpassed ($foldedCalls calls)")
+        try action()
+        catch {
+          case ex: Throwable => logger.error(s"Debouncer ${name} action resulted in error", ex)
+        }
+      } else
+        logger.error(s"Invalid state in debouncer. Should not have reached here!")
+    } else {
+      // reschedule at the earliest of origLastInvocation + delayMs or origLastCallAttempt + maxDelayMs
+      // Note: we use Math.max as there's a _very_ small chance lastCallAttempt could advance in another thread, and
+      // result in a negative calcaulation
+      val delay = Math.max(1, Math.min((lastCallAttempt - now + delayMs), (lastInvocation - now + maxDelayMs)))
+      scheduler.scheduleOnce(delay.millis) { () => tryActionOrPostpone() }
+    }
+  }
+}
+
+object Debouncer {
+  private val logger = LoggerFactory.getLogger(getClass)
+
+  def apply(
+    name: String,
+    scheduler: Debouncer.SchedulerLike,
+    delay: FiniteDuration,
+    maxDelay: FiniteDuration,
+    debounceFirst: Boolean = true,
+    clock: Clock = Clock.systemUTC
+  )(action: () => Unit): Debouncer =
+    new Debouncer(name, scheduler, delay, maxDelay, action, debounceFirst, clock)
+
+  /**
+   * Debouncer which uses sends the specified message to the specified actor.
+   *
+   * Uses scheduler and dispatcher implicitly from the actor context.
+   */
+  def forActor(
+    actorRef: ActorRef,
+    message: Any,
+    delay: FiniteDuration,
+    maxDelay: FiniteDuration,
+    name: String = null,
+    debounceFirst: Boolean = true,
+    clock: Clock = Clock.systemUTC
+  )(implicit context: ActorContext): Debouncer = {
+    import context.dispatcher
+    new Debouncer(
+      Option(name).getOrElse { s"${context.self.path.name} -> ${actorRef.path.name}" },
+      context.system.scheduler,
+      delay,
+      maxDelay, { () => actorRef ! message }, debounceFirst, clock
+    )
+  }
+
+  trait SchedulerLike {
+    /**
+     * Scheduler method which is guaranteed to call body AFTER the provided delay passes
+     */
+    def scheduleOnce(delay: FiniteDuration)(body: () => Unit): Unit
+  }
+
+  object SchedulerLike {
+    implicit def fromAkkaScheduler(scheduler: Scheduler)(
+      implicit
+      ec: ExecutionContext
+    ): SchedulerLike = new SchedulerLike {
+      def scheduleOnce(delay: FiniteDuration)(body: () => Unit): Unit =
+        scheduler.scheduleOnce(delay)(body())
+    }
+  }
+}

--- a/util/src/test/scala/org/ensime/util/DebouncerSpec.scala
+++ b/util/src/test/scala/org/ensime/util/DebouncerSpec.scala
@@ -1,0 +1,98 @@
+// Copyright: 2010 - 2017 https://github.com/ensime/ensime-server/graphs
+// License: http://www.gnu.org/licenses/gpl-3.0.en.html
+package org.ensime.util
+
+import java.time.{ Clock, Instant, ZoneId }
+import org.scalatest._
+import scala.concurrent.duration._
+
+class DebouncerSpec extends FlatSpec with Matchers {
+  class TestScheduler(clock: Clock) extends Debouncer.SchedulerLike {
+    @volatile var action: () => Unit = _
+    @volatile var nextInvocation: Long = Long.MaxValue
+    @volatile var currentTime: Long = 0L
+    override def scheduleOnce(delay: FiniteDuration)(body: () => Unit): Unit = synchronized {
+      require(nextInvocation == Long.MaxValue, "Error! Only one item can be scheduled at a time")
+      action = body
+      nextInvocation = currentTime + delay.toMillis
+    }
+
+    def poll(): Unit = synchronized {
+      currentTime = clock.millis()
+      if (currentTime >= nextInvocation) {
+        nextInvocation = Long.MaxValue
+        action()
+      }
+    }
+  }
+  class TestClock extends Clock {
+    @volatile var currentTime: Long = 0
+    def advanceTime(by: Long): Unit = synchronized {
+      require(by > 0)
+      currentTime += by
+    }
+
+    override def instant(): Instant = Instant.ofEpochMilli(currentTime)
+    override def getZone(): ZoneId = java.time.ZoneOffset.UTC
+    override def withZone(zone: ZoneId) = ???
+  }
+
+  case class DebouncerFixture(debounceFirst: Boolean = true) {
+    val clock = new TestClock
+    val scheduler = new TestScheduler(clock)
+    def advanceTime(amount: FiniteDuration): Unit = {
+      clock.advanceTime(amount.toMillis)
+      scheduler.poll()
+    }
+    var called = false
+    val delay = 5.seconds
+    val maxDelay = 20.seconds
+    lazy val debouncer = Debouncer("test", scheduler, delay, maxDelay, debounceFirst, clock) { () =>
+      called = true
+    }
+  }
+
+  it should "call the action only after the delay has passed" in {
+    val f = DebouncerFixture()
+    f.debouncer.call()
+    f.called.shouldBe(false)
+    f.advanceTime(f.delay)
+    f.called.shouldBe(true)
+  }
+
+  it should "extend the deadline if called before the delay has passed" in {
+    val f = DebouncerFixture()
+    f.debouncer.call()
+    f.called.shouldBe(false)
+    f.advanceTime(2.seconds)
+    f.called.shouldBe(false)
+
+    f.debouncer.call()
+    f.advanceTime(4.seconds)
+    f.called.shouldBe(false)
+
+    f.advanceTime(f.delay)
+    f.called.shouldBe(true)
+  }
+
+  it should "call after maxDelay has passed" in {
+    val f = DebouncerFixture()
+    (1 to 20).foreach { _ =>
+      f.debouncer.call()
+      f.called.shouldBe(false)
+      f.advanceTime(1.second)
+    }
+    f.called.shouldBe(true)
+  }
+
+  it should "call immediately if debounceFirst = false" in {
+    val f = DebouncerFixture(debounceFirst = false)
+    f.debouncer.call()
+    f.called.shouldBe(true)
+    f.called = false
+    f.debouncer.call()
+    f.called.shouldBe(false)
+    f.advanceTime(f.delay)
+    f.called.shouldBe(true)
+  }
+}


### PR DESCRIPTION
Debounce in a way that is efficient (debouncing happens in the same
thread as invoker, and without locks), and in a way that vastly limits
the log output amount. (received handled message AskReTypecheck from
...)

Resolves #1774