### PR TITLE
Import type at point for objects without companion.

### DIFF
--- a/core/src/it/scala/org/ensime/intg/BasicWorkflow.scala
+++ b/core/src/it/scala/org/ensime/intg/BasicWorkflow.scala
@@ -98,8 +98,7 @@ class BasicWorkflow extends EnsimeSpec
           // public symbol search - scala.util.Random
           project ! PublicSymbolSearchReq(List("scala", "util", "Random"), 2)
           expectMsgPF() {
-            case SymbolSearchResults(res) if res.collectFirst { case TypeSearchResult("scala.util.Random", "Random", DeclaredAs.Class, Some(_)) => true }.isDefined &&
-              res.collectFirst { case TypeSearchResult("scala.util.Random$", "Random$", DeclaredAs.Object, Some(_)) => true }.isDefined =>
+            case SymbolSearchResults(res) if res.collectFirst { case TypeSearchResult("scala.util.Random", "Random", DeclaredAs.Class, Some(_)) => true }.isDefined =>
             // this is a pretty ropey test at the best of times
           }
 

--- a/core/src/main/scala/org/ensime/core/Indexer.scala
+++ b/core/src/main/scala/org/ensime/core/Indexer.scala
@@ -25,10 +25,8 @@ class Indexer(
   )
 
   def oldSearchTypes(query: String, max: Int): List[TypeSearchResult] = {
-    def strip(fqn: String): String =
-      if (fqn.endsWith("$")) fqn.replaceAll("[$]^", "")
-      else if (fqn.endsWith("$class")) fqn.replaceAll("[$class]^", "")
-      else fqn
+    // Remove $/$class from the end.
+    def strip(fqn: String): String = fqn.replaceAll("\\$(class)*$", "")
 
     import org.ensime.util.list._
 


### PR DESCRIPTION
Trying to resolve #1771 . I am not particularly happy with the implementation (mutation, too many ifs, magic numbers, list of suggestions shows $ at the end), but could not come with anything better.

Alternatively, @fommil mentioned that scala names can be looked up via graph, but I could not find any evidence of that in the current project code base. Was it part of so called graphocalypse? Maybe @sugakandrey can help to confirm it is possible. 

Will be happy to hear your comments.