### PR TITLE
Replaced usages of EnsimeModule with EnsimeProject. Deleted EnsimeModule

### DIFF
--- a/api/src/main/scala/org/ensime/api/incoming.scala
+++ b/api/src/main/scala/org/ensime/api/incoming.scala
@@ -53,7 +53,7 @@ final case class TypecheckFileReq(fileInfo: SourceFileInfo) extends RpcAnalyserR
 /**
  * Response with a `VoidResponse`.
  */
-final case class UnloadModuleReq(module: String) extends RpcAnalyserRequest
+final case class UnloadModuleReq(moduleId: EnsimeProjectId) extends RpcAnalyserRequest
 
 /**
  * Responds with a `VoidResponse`
@@ -63,7 +63,7 @@ final case class UnloadFileReq(fileInfo: SourceFileInfo) extends RpcAnalyserRequ
 /**
  * Response with a `VoidResponse`.
  */
-final case class TypecheckModule(module: String) extends RpcAnalyserRequest
+final case class TypecheckModule(moduleId: EnsimeProjectId) extends RpcAnalyserRequest
 
 /**
  * Responds with a `VoidResponse`.

--- a/api/src/main/scala/org/ensime/api/outgoing.scala
+++ b/api/src/main/scala/org/ensime/api/outgoing.scala
@@ -513,7 +513,7 @@ final case class EnsimeImplementation(
 final case class ConnectionInfo(
   pid: Option[Int] = None,
   implementation: EnsimeImplementation = EnsimeImplementation("ENSIME"),
-  version: String = "1.9.1"
+  version: String = "1.9.2"
 ) extends RpcResponse
 
 sealed trait ImplicitInfo

--- a/core/src/it/scala/org/ensime/core/RichPresentationCompilerSpec.scala
+++ b/core/src/it/scala/org/ensime/core/RichPresentationCompilerSpec.scala
@@ -546,7 +546,7 @@ class RichPresentationCompilerSpec extends EnsimeSpec
 
     compileScala(
       List(defsFile.path),
-      config.subprojects.head.targets.head,
+      config.projects.head.targets.head,
       cc.settings.classpath.value
     )
 
@@ -598,7 +598,7 @@ trait RichPresentationCompilerTestUtils {
   }
 
   def srcFile(proj: EnsimeConfig, name: String, content: String, write: Boolean = false, encoding: String = "UTF-8"): BatchSourceFile = {
-    val src = proj.subprojects.head.sourceRoots.head / name
+    val src = proj.projects.head.sources.head / name
     if (write) {
       src.createWithParents()
       scala.tools.nsc.io.File(src)(encoding).writeAll(content)

--- a/core/src/it/scala/org/ensime/fixture/EnsimeConfigFixture.scala
+++ b/core/src/it/scala/org/ensime/fixture/EnsimeConfigFixture.scala
@@ -30,7 +30,7 @@ trait EnsimeConfigFixture {
 
   // convenience method
   def main(lang: String)(implicit config: EnsimeConfig): File =
-    config.subprojects.head.sourceRoots.filter { dir =>
+    config.projects.head.sources.filter { dir =>
       val sep = JFile.separator
       dir.getPath.endsWith(s"${sep}main$sep$lang")
     }.head
@@ -38,7 +38,7 @@ trait EnsimeConfigFixture {
   def javaMain(implicit config: EnsimeConfig): File = main("java")
 
   def mainTarget(implicit config: EnsimeConfig): File =
-    config.subprojects.head.targets.head
+    config.projects.head.targets.head
 }
 
 object EnsimeConfigFixture {
@@ -68,37 +68,37 @@ object EnsimeConfigFixture {
   }
 
   lazy val EmptyTestProject: EnsimeConfig = EnsimeTestProject.copy(
-    subprojects = EnsimeTestProject.subprojects.filter(_.name == "testing_empty")
+    projects = EnsimeTestProject.projects.filter(_.id.project == "testing_empty")
   )
   lazy val SimpleTestProject: EnsimeConfig = EnsimeTestProject.copy(
-    subprojects = EnsimeTestProject.subprojects.filter(_.name == "testing_simple")
+    projects = EnsimeTestProject.projects.filter(_.id.project == "testing_simple")
   )
   lazy val SimpleJarTestProject: EnsimeConfig = EnsimeTestProject.copy(
-    subprojects = EnsimeTestProject.subprojects.filter(_.name == "testing_simpleJar")
+    projects = EnsimeTestProject.projects.filter(_.id.project == "testing_simpleJar")
   )
   lazy val ImplicitsTestProject: EnsimeConfig = EnsimeTestProject.copy(
-    subprojects = EnsimeTestProject.subprojects.filter(_.name == "testing_implicits")
+    projects = EnsimeTestProject.projects.filter(_.id.project == "testing_implicits")
   )
   lazy val TimingTestProject: EnsimeConfig = EnsimeTestProject.copy(
-    subprojects = EnsimeTestProject.subprojects.filter(_.name == "testing_timing")
+    projects = EnsimeTestProject.projects.filter(_.id.project == "testing_timing")
   )
   lazy val MacrosTestProject: EnsimeConfig = EnsimeTestProject.copy(
-    subprojects = EnsimeTestProject.subprojects.filter(_.name == "testing_macros")
+    projects = EnsimeTestProject.projects.filter(_.id.project == "testing_macros")
   )
   lazy val ShapelessTestProject: EnsimeConfig = EnsimeTestProject.copy(
-    subprojects = EnsimeTestProject.subprojects.filter(_.name == "testing_shapeless")
+    projects = EnsimeTestProject.projects.filter(_.id.project == "testing_shapeless")
   )
   lazy val FqnsTestProject: EnsimeConfig = EnsimeTestProject.copy(
-    subprojects = EnsimeTestProject.subprojects.filter(_.name == "testing_fqns")
+    projects = EnsimeTestProject.projects.filter(_.id.project == "testing_fqns")
   )
   lazy val DebugTestProject: EnsimeConfig = EnsimeTestProject.copy(
-    subprojects = EnsimeTestProject.subprojects.filter(_.name == "testing_debug")
+    projects = EnsimeTestProject.projects.filter(_.id.project == "testing_debug")
   )
   lazy val DocsTestProject: EnsimeConfig = EnsimeTestProject.copy(
-    subprojects = EnsimeTestProject.subprojects.filter(_.name == "testing_docs")
+    projects = EnsimeTestProject.projects.filter(_.id.project == "testing_docs")
   )
   lazy val JavaTestProject: EnsimeConfig = EnsimeTestProject.copy(
-    subprojects = EnsimeTestProject.subprojects.filter(_.name == "testing_java")
+    projects = EnsimeTestProject.projects.filter(_.id.project == "testing_java")
   )
 
   // generates an empty single module project in a temporary directory
@@ -141,10 +141,9 @@ object EnsimeConfigFixture {
       if (copyTargets) renameAndCopy(from)
       else rename(from)
 
-    def cloneModule(m: EnsimeModule): EnsimeModule = m.copy(
+    def cloneProject(m: EnsimeProject): EnsimeProject = m.copy(
       targets = m.targets.map(renameAndCopyTarget),
-      testTargets = m.testTargets.map(renameAndCopyTarget),
-      sourceRoots = m.sourceRoots.map(renameAndCopy)
+      sources = m.sources.map(renameAndCopy)
     )
 
     val cacheDir = target / ".ensime_cache"
@@ -152,7 +151,7 @@ object EnsimeConfigFixture {
     val config = EnsimeConfigProtocol.validated(source.copy(
       rootDir = rename(source.rootDir),
       cacheDir = cacheDir,
-      subprojects = source.subprojects.map(cloneModule)
+      projects = source.projects.map(cloneProject)
     ))
 
     // HACK: we must force OS line endings on sources or the tests

--- a/core/src/it/scala/org/ensime/indexer/SearchServiceSpec.scala
+++ b/core/src/it/scala/org/ensime/indexer/SearchServiceSpec.scala
@@ -44,7 +44,7 @@ class SearchServiceSpec extends EnsimeSpec
       val now = System.currentTimeMillis()
       for {
         m <- config.modules.values
-        r <- m.targets ++ m.testTargets
+        r <- m.targets
         f <- r.tree
       } {
         // simulate a full recompile
@@ -60,7 +60,7 @@ class SearchServiceSpec extends EnsimeSpec
   it should "remove classfiles that have been deleted" in {
     withSearchService { (config, service) =>
       implicit val s = service
-      val classfile = config.subprojects.head.targets.head / "org/example/Foo$.class"
+      val classfile = config.projects.head.targets.head / "org/example/Foo$.class"
 
       classfile shouldBe 'exists
       service.findUnique("org.example.Foo$") shouldBe defined

--- a/core/src/it/scala/org/ensime/intg/BasicWorkflow.scala
+++ b/core/src/it/scala/org/ensime/intg/BasicWorkflow.scala
@@ -35,7 +35,7 @@ class BasicWorkflow extends EnsimeSpec
 
           // typeCheck module
 
-          project ! TypecheckModule("testing_simple")
+          project ! TypecheckModule(EnsimeProjectId("testing_simple", "compile"))
           expectMsg(VoidResponse)
           asyncHelper.expectMsgType[NewScalaNotesEvent]
           asyncHelper.expectMsg(FullTypeCheckCompleteEvent)
@@ -43,7 +43,7 @@ class BasicWorkflow extends EnsimeSpec
           project ! TypeByNameReq("org.example.Bloo")
           expectMsgType[api.BasicTypeInfo]
 
-          project ! UnloadModuleReq("testing_simple")
+          project ! UnloadModuleReq(EnsimeProjectId("testing_simple", "compile"))
           expectMsg(VoidResponse)
 
           project ! TypeByNameReq("org.example.Bloo")

--- a/core/src/it/scala/org/ensime/model/SourcePositionSpec.scala
+++ b/core/src/it/scala/org/ensime/model/SourcePositionSpec.scala
@@ -56,7 +56,7 @@ class SourcePositionSpec extends EnsimeSpec
   }
 
   def knownJarEntry(implicit config: EnsimeConfig): String = {
-    val scalatest = config.subprojects.head.referenceSourceJars.find(
+    val scalatest = config.projects.flatMap(_.librarySources).find(
       _.getName.contains("scalatest_")
     ).get.getAbsoluteFile
     "jar:" + scalatest + "!/org/scalatest/FunSpec.scala"

--- a/core/src/main/scala/org/ensime/config/EnsimeConfigProtocol.scala
+++ b/core/src/main/scala/org/ensime/config/EnsimeConfigProtocol.scala
@@ -25,7 +25,6 @@ object EnsimeConfigProtocol {
 
   private implicit val projectIdFormat: SexpFormat[EnsimeProjectId] = cachedImplicit
   private implicit val projectFormat: SexpFormat[EnsimeProject] = cachedImplicit
-  private implicit val moduleFormat: SexpFormat[EnsimeModule] = cachedImplicit
   private implicit val configFormat: SexpFormat[EnsimeConfig] = cachedImplicit
 
   def parse(config: String): EnsimeConfig = {
@@ -42,7 +41,7 @@ object EnsimeConfigProtocol {
     else javaHome.tree.filter(_.getName == "rt.jar").toList
 
   def validated(c: EnsimeConfig): EnsimeConfig = c.copy(
-    subprojects = c.subprojects.map(validated)
+    projects = c.projects.map(validated)
   )
 
   /*
@@ -52,8 +51,8 @@ object EnsimeConfigProtocol {
    directories and then re-canon them, which is - admittedly - a weird
    side-effect.
    */
-  private[config] def validated(m: EnsimeModule): EnsimeModule = {
-    (m.targets ++ m.testTargets ++ m.sourceRoots).foreach { dir =>
+  private[config] def validated(m: EnsimeProject): EnsimeProject = {
+    (m.targets ++ m.sources).foreach { dir =>
       if (!dir.exists() && !dir.isJar) {
         log.warn(s"$dir does not exist, creating")
         dir.mkdirs()

--- a/core/src/main/scala/org/ensime/config/package.scala
+++ b/core/src/main/scala/org/ensime/config/package.scala
@@ -13,13 +13,13 @@ package object config {
 
   implicit class RichEnsimeConfig(val c: EnsimeConfig) extends AnyVal {
     def scalaSourceFiles: Set[File] =
-      c.modules.values.flatMap((m: EnsimeModule) => m.scalaSourceFiles)(breakOut)
+      c.modules.values.flatMap((m: EnsimeProject) => m.scalaSourceFiles)(breakOut)
   }
 
-  implicit class RichEnsimeModule(val m: EnsimeModule) extends AnyVal {
+  implicit class RichEnsimeModule(val m: EnsimeProject) extends AnyVal {
     def scalaSourceFiles: Set[File] = {
       val s = for {
-        root <- m.sourceRoots
+        root <- m.sources
         file <- root.tree
         if file.isFile && file.isScala
       } yield file

--- a/core/src/main/scala/org/ensime/core/Analyzer.scala
+++ b/core/src/main/scala/org/ensime/core/Analyzer.scala
@@ -183,15 +183,15 @@ class Analyzer(
         restartCompiler(keepLoaded = false)
       }
       sender ! VoidResponse
-    case TypecheckModule(moduleName) =>
+    case TypecheckModule(moduleId) =>
       //consider the case of a project with no modules
-      config.modules get (moduleName) foreach {
+      config.modules get (moduleId) foreach {
         module =>
           val files: Set[SourceFileInfo] = module.scalaSourceFiles.map(s => SourceFileInfo(EnsimeFile(s), None, None))(breakOut)
           sender ! scalaCompiler.handleReloadFiles(files)
       }
-    case UnloadModuleReq(moduleName) =>
-      config.modules get (moduleName) foreach {
+    case UnloadModuleReq(moduleId) =>
+      config.modules get (moduleId) foreach {
         module =>
           val files = module.scalaSourceFiles.toList
           files.foreach(scalaCompiler.askRemoveDeleted)

--- a/core/src/main/scala/org/ensime/indexer/FileWatchers.scala
+++ b/core/src/main/scala/org/ensime/indexer/FileWatchers.scala
@@ -83,7 +83,7 @@ class SourceWatcher(
       val sourceJava7WatcherBuilder = new SourceJava7WatcherBuilder()
       for {
         module <- config.modules.values
-        root <- module.sourceRoots
+        root <- module.sources
       } yield {
         if (log.isTraceEnabled())
           log.trace(s"creating a Java 7 source watcher for $root")

--- a/core/src/main/scala/org/ensime/indexer/SearchService.scala
+++ b/core/src/main/scala/org/ensime/indexer/SearchService.scala
@@ -136,8 +136,8 @@ class SearchService(
     // a snapshot of everything that we want to index
     def findBases(): (Set[FileObject], Map[FileName, Set[FileObject]]) = {
       val (jarFiles, dirs) = config.modules.flatMap {
-        case (name, m) =>
-          (m.testTargets ++ m.targets).filter(_.exists()) ::: (m.compileJars ++ m.testJars)
+        case (_, m) =>
+          m.targets.filter(_.exists()).toList ::: m.libraryJars.toList
       }.partition(_.isJar)
       val grouped = dirs.map(d => scanGrouped(vfs.vfile(d))).fold(Map.empty[FileName, Set[FileObject]])(_ merge _)
       val jars: Set[FileObject] = (jarFiles ++ config.javaLibs).map(vfs.vfile)(collection.breakOut)

--- a/core/src/main/scala/org/ensime/indexer/SourceResolver.scala
+++ b/core/src/main/scala/org/ensime/indexer/SourceResolver.scala
@@ -81,7 +81,7 @@ class SourceResolver(
     val srcJars = config.referenceSourceJars.toSet ++ {
       for {
         (_, module) <- config.modules
-        srcArchive <- module.referenceSourceJars
+        srcArchive <- module.librarySources
       } yield srcArchive
     }
     for {
@@ -100,7 +100,7 @@ class SourceResolver(
   private def userSources = {
     for {
       (_, module) <- config.modules.toList
-      root <- module.sourceRoots
+      root <- module.sources
       dir = vfs.vfile(root)
       file <- scan(dir)
     } yield (infer(dir, file), file)

--- a/core/src/test/scala/org/ensime/config/EnsimeConfigSpec.scala
+++ b/core/src/test/scala/org/ensime/config/EnsimeConfigSpec.scala
@@ -53,8 +53,8 @@ class EnsimeConfigSpec extends EnsimeSpec {
              :library-docs ())))""", { implicit config =>
       config.name shouldBe "project"
       config.scalaVersion shouldBe "2.10.4"
-      val module1 = config.modules("module1")
-      module1.name shouldBe "module1"
+      val module1 = config.modules(EnsimeProjectId("module1", "compile"))
+      module1.id.project shouldBe "module1"
       module1.dependencies shouldBe empty
       config.projects.size shouldBe 1
     })
@@ -74,14 +74,14 @@ class EnsimeConfigSpec extends EnsimeSpec {
  :java-home "$javaHome"
  :root-dir "$dir"
  :cache-dir "$cache"
- :subprojects ((:name "module1"
-                :scala-version "2.10.4"
-                :targets ("$abc"))))""", { implicit config =>
+ :projects ((:id (:project "module1" :config "compile")
+             :depends ()
+             :targets ("$abc"))))""", { implicit config =>
 
       config.name shouldBe "project"
       config.scalaVersion shouldBe "2.10.4"
-      val module1 = config.modules("module1")
-      module1.name shouldBe "module1"
+      val module1 = config.modules(EnsimeProjectId("module1", "compile"))
+      module1.id.project shouldBe "module1"
       module1.dependencies shouldBe empty
       module1.targets should have size 1
     })

--- a/core/src/test/scala/org/ensime/core/CanonSpec.scala
+++ b/core/src/test/scala/org/ensime/core/CanonSpec.scala
@@ -57,7 +57,7 @@ class CanonSpec extends EnsimeSpec {
     Canon.config = EnsimeConfig(
       dir, dir, dir,
       "config", "version",
-      Nil, Nil, Nil, Nil, Nil
+      Nil, Nil, Nil, Nil
     )
 
     Canonised(ef) shouldBe expected
@@ -75,7 +75,7 @@ class CanonSpec extends EnsimeSpec {
     Canon.config = EnsimeConfig(
       dir, dir, dir,
       "config", "version",
-      Nil, Nil, Nil, Nil, Nil
+      Nil, Nil, Nil, Nil
     )
 
     Canonised(ef) shouldBe expected

--- a/testing/cache/project/build.properties
+++ b/testing/cache/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version=0.13.15


### PR DESCRIPTION
Deleted `EnsimeModule`.
`modules` in `EnsimeConfig` now correspond to a `List[EnsimeProject]`.

I have assumed the following equivalents :
`compileJars` in EnsimeModule <--> `libraryJars` in EnsimeProject
`referenceSourceJars` in EnsimeModule <--> `librarySources` in EnsimeProject
`docJars` in EnsimeModule <--> `libraryDocs` in EnsimeProject
Others are pretty straightforward.

The hack for handing `TypeCheckModule(moduleName)` and `UnloadModule(moduleName)` in `Analyzer.scala` needs review. Using `EnsimeProject` breaks files that would have been included in one `EnsimeModule` into two EnsimeProjects with `compile` and `test` configurations(probably more).  Hence we now need to filter EnsimeProject with `EnsimeProject.id.project == moduleName`, instead of a simple get.

If there's anything wrong, please let me know and I'll try my best to correct it. :)
