### PR TITLE
Analyser per Module : Stage 1

### DIFF
--- a/api/src/main/scala/org/ensime/api/config.scala
+++ b/api/src/main/scala/org/ensime/api/config.scala
@@ -47,9 +47,6 @@ final case class EnsimeConfig(
     }.toSet
   } ++ javaLibs
 
-  val allTargets: Set[File] =
-    projects.flatMap(_.targets).toSet
-
   def allDocJars: Set[File] = modules.values.flatMap(_.libraryDocs).toSet
 
   def scalaLibrary: Option[File] = allJars.find(_.getName.startsWith("scala-library"))
@@ -75,4 +72,20 @@ final case class EnsimeProject(
 
   def dependencies(implicit config: EnsimeConfig): List[EnsimeProject] =
     depends.toList.map(config.modules)
+
+  def compileClasspath: Set[File] = libraryJars ++ (if (propOrFalse("ensime.sourceMode")) List.empty else targets)
+
+}
+object EnsimeProject {
+  def wholeProject(implicit config: EnsimeConfig): EnsimeProject = new EnsimeProject(
+    EnsimeProjectId("wholeProject", "compile"),
+    Seq(),
+    config.projects.flatMap(_.sources).toSet,
+    config.projects.flatMap(_.targets).toSet,
+    config.projects.flatMap(_.scalacOptions).distinct,
+    config.projects.flatMap(_.javacOptions).distinct,
+    config.projects.flatMap(_.libraryJars).toSet,
+    config.projects.flatMap(_.librarySources).toSet,
+    config.projects.flatMap(_.libraryDocs).toSet
+  )
 }

--- a/api/src/main/scala/org/ensime/api/config.scala
+++ b/api/src/main/scala/org/ensime/api/config.scala
@@ -18,7 +18,6 @@ final case class EnsimeConfig(
     javaHome: File,
     name: String,
     scalaVersion: String,
-    compilerArgs: List[String],
     javaSources: List[File],
     projects: List[EnsimeProject],
     javaLibs: List[File]
@@ -39,7 +38,7 @@ final case class EnsimeConfig(
   // FIXME: move these
   val targets: Set[File] = modules.values.flatMap(_.targets)(breakOut)
   // can't be a val because of the implicit
-  def classpath: Set[File] = modules.values.flatMap(m => m.classpath(this))(breakOut)
+//  def classpath: Set[File] = modules.values.flatMap(m => m.classpath(this))(breakOut)
 
   val allDocJars: Set[File] = modules.values.flatMap(_.libraryDocs)(breakOut)
   val scalaLibrary: Option[File] = modules.values.flatMap(_.libraryJars).find { f =>
@@ -68,7 +67,7 @@ final case class EnsimeProject(
 
   sources.foreach(f => require(f.exists, "" + f + " is required but does not exist"))
 
-  // TODO: definitely move these, they can't be cached
+  // FIXME: definitely move these, they can't be cached
   def dependencies(implicit config: EnsimeConfig): List[EnsimeProject] =
     depends.toList.map(config.modules)
 
@@ -77,17 +76,4 @@ final case class EnsimeProject(
     libraryJars ++ target ++ dependencies.flatMap(_.classpath)
   }
 
-}
-object EnsimeProject {
-  def wholeProject(implicit config: EnsimeConfig): EnsimeProject = new EnsimeProject(
-    EnsimeProjectId("wholeProject", "compile"),
-    Seq(),
-    config.projects.flatMap(_.sources).toSet,
-    config.projects.flatMap(_.targets).toSet,
-    config.projects.flatMap(_.scalacOptions).distinct,
-    config.projects.flatMap(_.javacOptions).distinct,
-    config.projects.flatMap(_.libraryJars).toSet,
-    config.projects.flatMap(_.librarySources).toSet,
-    config.projects.flatMap(_.libraryDocs).toSet
-  )
 }

--- a/api/src/main/scala/org/ensime/api/config.scala
+++ b/api/src/main/scala/org/ensime/api/config.scala
@@ -3,7 +3,9 @@
 package org.ensime.api
 
 import java.io.File
+
 import scala.util.Properties._
+import scala.collection.breakOut
 
 // there is quite a lot of code in this file, when we clean up the
 // config file format so that a lot of these hacks are no longer
@@ -21,35 +23,29 @@ final case class EnsimeConfig(
     projects: List[EnsimeProject],
     javaLibs: List[File]
 ) {
+  // it would be good if this was implemented as a Validator
   (rootDir :: javaHome :: javaSources ::: javaLibs).foreach { f =>
     require(f.exists, "" + f + " is required but does not exist")
   }
 
-  /* Proposed alternatives to the legacy wire format field names */
-  def root = rootDir
-  val referenceSourceJars =
+  // it would be good if all the rest of this functionality was moved
+  // into typeclasses, instead of polluting the otherwise clean api
+
+  val referenceSourceJars: Set[File] =
     (javaSources ++ projects.flatMap(_.librarySources)).toSet
 
-  // some marshalling libs (e.g. spray-json) might not like extra vals
-  val modules = projects.map { module => (module.id, module) }.toMap
+  val modules: Map[EnsimeProjectId, EnsimeProject] = projects.map { module => (module.id, module) }.toMap
 
-  def compileClasspath: Set[File] = modules.values.toSet.flatMap {
-    m: EnsimeProject => m.libraryJars
-  } ++ (if (propOrFalse("ensime.sourceMode")) List.empty else targetClasspath)
+  // FIXME: move these
+  val targets: Set[File] = modules.values.flatMap(_.targets)(breakOut)
+  // can't be a val because of the implicit
+  def classpath: Set[File] = modules.values.flatMap(m => m.classpath(this))(breakOut)
 
-  def targetClasspath: Set[File] = modules.values.toSet.flatMap {
-    m: EnsimeProject => m.targets
+  val allDocJars: Set[File] = modules.values.flatMap(_.libraryDocs)(breakOut)
+  val scalaLibrary: Option[File] = modules.values.flatMap(_.libraryJars).find { f =>
+    val name = f.getName
+    name.startsWith("scala-library") && name.endsWith(".jar")
   }
-
-  def allJars: Set[File] = {
-    modules.values.flatMap { m =>
-      m.libraryJars
-    }.toSet
-  } ++ javaLibs
-
-  def allDocJars: Set[File] = modules.values.flatMap(_.libraryDocs).toSet
-
-  def scalaLibrary: Option[File] = allJars.find(_.getName.startsWith("scala-library"))
 }
 
 final case class EnsimeProjectId(
@@ -68,12 +64,18 @@ final case class EnsimeProject(
     librarySources: Set[File],
     libraryDocs: Set[File]
 ) {
+  // see typeclass wishlist in EnsimeConfig
+
   sources.foreach(f => require(f.exists, "" + f + " is required but does not exist"))
 
+  // TODO: definitely move these, they can't be cached
   def dependencies(implicit config: EnsimeConfig): List[EnsimeProject] =
     depends.toList.map(config.modules)
 
-  def compileClasspath: Set[File] = libraryJars ++ (if (propOrFalse("ensime.sourceMode")) List.empty else targets)
+  def classpath(implicit config: EnsimeConfig): Set[File] = {
+    val target = if (propOrFalse("ensime.sourceMode")) Set.empty else targets
+    libraryJars ++ target ++ dependencies.flatMap(_.classpath)
+  }
 
 }
 object EnsimeProject {

--- a/api/src/main/scala/org/ensime/api/config.scala
+++ b/api/src/main/scala/org/ensime/api/config.scala
@@ -38,7 +38,7 @@ final case class EnsimeConfig(
   // FIXME: move these
   val targets: Set[File] = modules.values.flatMap(_.targets)(breakOut)
   // can't be a val because of the implicit
-//  def classpath: Set[File] = modules.values.flatMap(m => m.classpath(this))(breakOut)
+  //  def classpath: Set[File] = modules.values.flatMap(m => m.classpath(this))(breakOut)
 
   val allDocJars: Set[File] = modules.values.flatMap(_.libraryDocs)(breakOut)
   val scalaLibrary: Option[File] = modules.values.flatMap(_.libraryJars).find { f =>

--- a/api/src/main/scala/org/ensime/api/incoming.scala
+++ b/api/src/main/scala/org/ensime/api/incoming.scala
@@ -41,24 +41,18 @@ final case class ImplicitInfoReq(
 ) extends RpcAnalyserRequest
 
 /**
+ * Tell the Analyzer that this file has been deleted. This is
+ * different to simply unloading the file (which can keeps symbols
+ * around).
+ *
  * Responds with a `VoidResponse`.
  */
 final case class RemoveFileReq(file: File) extends RpcAnalyserRequest
 
 /**
- * Responds with a `VoidResponse`
- */
-final case class RemoveFilesReq(files: List[File]) extends RpcAnalyserRequest
-
-/**
  * Responds with a `VoidResponse`.
  */
 final case class TypecheckFileReq(fileInfo: SourceFileInfo) extends RpcAnalyserRequest
-
-/**
- * Response with a `VoidResponse`.
- */
-final case class UnloadModuleReq(moduleId: EnsimeProjectId) extends RpcAnalyserRequest
 
 /**
  * Responds with a `VoidResponse`
@@ -127,7 +121,7 @@ final case class DocUriAtPointReq(
  * Responds with a `StringResponse` for the URL of the documentation if valid,
  * or `FalseResponse`.
  */
-@deprecating
+@deprecating("https://github.com/ensime/ensime-server/issues/1787")
 final case class DocUriForSymbolReq(
   typeFullName: String,
   memberName: Option[String],
@@ -148,7 +142,7 @@ final case class CompletionsReq(
 /**
  * Responds with a `List[CompletionInfo]`.
  */
-@deprecating
+@deprecating("https://github.com/ensime/ensime-server/issues/1787")
 final case class PackageMemberCompletionReq(
   path: String,
   prefix: String
@@ -157,7 +151,7 @@ final case class PackageMemberCompletionReq(
 /**
  * Responds with `TypeInfo` if valid, or `FalseResponse`.
  */
-@deprecating
+@deprecating("https://github.com/ensime/ensime-server/issues/1787")
 final case class TypeByNameReq(name: String) extends RpcAnalyserRequest
 
 /**
@@ -194,7 +188,7 @@ final case class InspectTypeAtPointReq(file: Either[File, SourceFileInfo], range
  *
  * @param name fully qualified type name to inspect
  */
-@deprecating
+@deprecating("https://github.com/ensime/ensime-server/issues/1787")
 final case class InspectTypeByNameReq(name: String) extends RpcAnalyserRequest
 
 /**
@@ -211,7 +205,7 @@ final case class SymbolAtPointReq(file: Either[File, SourceFileInfo], point: Int
  * @param memberName short name of a member symbol of the qualified symbol.
  * @param signatureString to disambiguate overloaded methods.
  */
-@deprecating
+@deprecating("https://github.com/ensime/ensime-server/issues/1787")
 final case class SymbolByNameReq(
   typeFullName: String,
   memberName: Option[String],
@@ -221,7 +215,7 @@ final case class SymbolByNameReq(
 /**
  * Responds with `PackageInfo`.
  */
-@deprecating
+@deprecating("https://github.com/ensime/ensime-server/issues/1787")
 final case class InspectPackageByPathReq(path: String) extends RpcAnalyserRequest
 
 /**

--- a/api/src/main/scala/org/ensime/api/incoming.scala
+++ b/api/src/main/scala/org/ensime/api/incoming.scala
@@ -67,6 +67,11 @@ final case class TypecheckModule(moduleId: EnsimeProjectId) extends RpcAnalyserR
 /**
  * Responds with a `VoidResponse`.
  */
+case object UnloadAllReq extends RpcAnalyserRequest
+
+/**
+ * Responds with a `VoidResponse`.
+ */
 final case class TypecheckFilesReq(files: List[Either[File, SourceFileInfo]]) extends RpcAnalyserRequest
 
 // related to searching the indexer

--- a/api/src/main/scala/org/ensime/api/incoming.scala
+++ b/api/src/main/scala/org/ensime/api/incoming.scala
@@ -67,16 +67,6 @@ final case class TypecheckModule(moduleId: EnsimeProjectId) extends RpcAnalyserR
 /**
  * Responds with a `VoidResponse`.
  */
-case object UnloadAllReq extends RpcAnalyserRequest
-
-/**
- * Responds with a `VoidResponse`.
- */
-case object TypecheckAllReq extends RpcAnalyserRequest
-
-/**
- * Responds with a `VoidResponse`.
- */
 final case class TypecheckFilesReq(files: List[Either[File, SourceFileInfo]]) extends RpcAnalyserRequest
 
 // related to searching the indexer

--- a/api/src/main/scala/org/ensime/api/incoming.scala
+++ b/api/src/main/scala/org/ensime/api/incoming.scala
@@ -46,6 +46,11 @@ final case class ImplicitInfoReq(
 final case class RemoveFileReq(file: File) extends RpcAnalyserRequest
 
 /**
+ * Responds with a `VoidResponse`
+ */
+final case class RemoveFilesReq(files: List[File]) extends RpcAnalyserRequest
+
+/**
  * Responds with a `VoidResponse`.
  */
 final case class TypecheckFileReq(fileInfo: SourceFileInfo) extends RpcAnalyserRequest
@@ -122,6 +127,7 @@ final case class DocUriAtPointReq(
  * Responds with a `StringResponse` for the URL of the documentation if valid,
  * or `FalseResponse`.
  */
+@deprecating
 final case class DocUriForSymbolReq(
   typeFullName: String,
   memberName: Option[String],
@@ -142,6 +148,7 @@ final case class CompletionsReq(
 /**
  * Responds with a `List[CompletionInfo]`.
  */
+@deprecating
 final case class PackageMemberCompletionReq(
   path: String,
   prefix: String
@@ -150,6 +157,7 @@ final case class PackageMemberCompletionReq(
 /**
  * Responds with `TypeInfo` if valid, or `FalseResponse`.
  */
+@deprecating
 final case class TypeByNameReq(name: String) extends RpcAnalyserRequest
 
 /**
@@ -186,6 +194,7 @@ final case class InspectTypeAtPointReq(file: Either[File, SourceFileInfo], range
  *
  * @param name fully qualified type name to inspect
  */
+@deprecating
 final case class InspectTypeByNameReq(name: String) extends RpcAnalyserRequest
 
 /**
@@ -202,6 +211,7 @@ final case class SymbolAtPointReq(file: Either[File, SourceFileInfo], point: Int
  * @param memberName short name of a member symbol of the qualified symbol.
  * @param signatureString to disambiguate overloaded methods.
  */
+@deprecating
 final case class SymbolByNameReq(
   typeFullName: String,
   memberName: Option[String],
@@ -211,6 +221,7 @@ final case class SymbolByNameReq(
 /**
  * Responds with `PackageInfo`.
  */
+@deprecating
 final case class InspectPackageByPathReq(path: String) extends RpcAnalyserRequest
 
 /**

--- a/api/src/main/scala/org/ensime/api/incoming.scala
+++ b/api/src/main/scala/org/ensime/api/incoming.scala
@@ -52,6 +52,7 @@ final case class RemoveFileReq(file: File) extends RpcAnalyserRequest
 /**
  * Responds with a `VoidResponse`.
  */
+@deprecating("redundant query, use TypecheckFilesReq")
 final case class TypecheckFileReq(fileInfo: SourceFileInfo) extends RpcAnalyserRequest
 
 /**
@@ -72,6 +73,7 @@ case object UnloadAllReq extends RpcAnalyserRequest
 /**
  * Responds with a `VoidResponse`.
  */
+@deprecating("should only support SourceFileInfo")
 final case class TypecheckFilesReq(files: List[Either[File, SourceFileInfo]]) extends RpcAnalyserRequest
 
 // related to searching the indexer
@@ -152,6 +154,7 @@ final case class TypeByNameReq(name: String) extends RpcAnalyserRequest
 /**
  * Responds with `TypeInfo` if valid, or `FalseResponse`.
  */
+@deprecating("https://github.com/ensime/ensime-server/issues/1787")
 final case class TypeByNameAtPointReq(
   name: String, file: Either[File, SourceFileInfo], range: OffsetRange
 ) extends RpcAnalyserRequest

--- a/api/src/main/scala/org/ensime/api/outgoing.scala
+++ b/api/src/main/scala/org/ensime/api/outgoing.scala
@@ -54,13 +54,13 @@ final case class SendBackgroundMessageEvent(
   code: Int = 105
 ) extends GeneralSwankEvent
 
-/** The presentation compiler is ready to accept requests. */
+@deprecating("https://github.com/ensime/ensime-server/issues/1789")
 case object AnalyzerReadyEvent extends GeneralSwankEvent
 
-/** The presentation compiler has finished analysing the entire project. */
+@deprecating("https://github.com/ensime/ensime-server/issues/1789")
 case object FullTypeCheckCompleteEvent extends GeneralSwankEvent
 
-/** The search engine has finished indexing the classpath. */
+@deprecating("https://github.com/ensime/ensime-server/issues/1789")
 case object IndexerReadyEvent extends GeneralSwankEvent
 
 /** The presentation compiler was restarted. Existing `:type-id`s are invalid. */

--- a/api/src/main/scala/org/ensime/api/outgoing.scala
+++ b/api/src/main/scala/org/ensime/api/outgoing.scala
@@ -134,9 +134,6 @@ final case class DebugThreadDeathEvent(threadId: DebugThreadId) extends DebugEve
 /** Communicates stdout/stderr of debugged VM to client. */
 final case class DebugOutputEvent(body: String) extends DebugEvent
 
-case object ReloadExistingFilesEvent
-case object AskReTypecheck
-
 case object VoidResponse extends RpcResponse
 
 final case class RefactorFailure(

--- a/core/src/it/scala-2.11/org/ensime/core/TypelevelLibrariesSymbolToFqnSpec.scala
+++ b/core/src/it/scala-2.11/org/ensime/core/TypelevelLibrariesSymbolToFqnSpec.scala
@@ -29,7 +29,9 @@ class TypelevelLibrariesSymbolToFqnSpec extends EnsimeSpec
 
   it should "index all class file in typelevel libraries" in withPresCompiler { (config, cc) =>
     val vfs = cc.vfs
-    val jars = config.allJars.filter(!_.getName.contains("macro-compat"))
+    val jars = config.compileClasspath
+      .filter(_.getName.endsWith(".jar"))
+      .filter(!_.getName.contains("macro-compat"))
     jars.foreach { file =>
       val jar = vfs.vjar(file)
       val classes = (jar.findFiles(ClassfileSelector) match {

--- a/core/src/it/scala/org/ensime/core/RefactoringHandlerSpec.scala
+++ b/core/src/it/scala/org/ensime/core/RefactoringHandlerSpec.scala
@@ -7,10 +7,13 @@ import java.nio.charset.Charset
 import java.text.SimpleDateFormat
 import java.util.Date
 
-import org.ensime.api._
+import org.ensime.api.{ AddImportRefactorDesc, ExpandMatchCasesDesc, OrganiseImportsRefactorDesc, RawFile, RefactorDiffEffect, RefactorReq, RenameRefactorDesc, RpcResponse, SourceFileInfo }
+
+//import org.ensime.api._
 import org.ensime.fixture._
 import org.ensime.util.EnsimeSpec
 import org.scalatest.Assertions
+
 import scala.concurrent.ExecutionContext.Implicits.global
 
 class RefactoringHandlerSpec extends EnsimeSpec
@@ -22,7 +25,6 @@ class RefactoringHandlerSpec extends EnsimeSpec
   def original = EnsimeConfigFixture.EmptyTestProject.copy(
     compilerArgs = List("-encoding", encoding)
   )
-
   // transitionary methods
   def ContentsSourceFileInfo(file: File, contents: String) =
     SourceFileInfo(RawFile(file.toPath), Some(contents))

--- a/core/src/it/scala/org/ensime/core/RefactoringHandlerSpec.scala
+++ b/core/src/it/scala/org/ensime/core/RefactoringHandlerSpec.scala
@@ -7,13 +7,10 @@ import java.nio.charset.Charset
 import java.text.SimpleDateFormat
 import java.util.Date
 
-import org.ensime.api.{ AddImportRefactorDesc, ExpandMatchCasesDesc, OrganiseImportsRefactorDesc, RawFile, RefactorDiffEffect, RefactorReq, RenameRefactorDesc, RpcResponse, SourceFileInfo }
-
-//import org.ensime.api._
+import org.ensime.api._
 import org.ensime.fixture._
 import org.ensime.util.EnsimeSpec
 import org.scalatest.Assertions
-
 import scala.concurrent.ExecutionContext.Implicits.global
 
 class RefactoringHandlerSpec extends EnsimeSpec
@@ -25,6 +22,7 @@ class RefactoringHandlerSpec extends EnsimeSpec
   def original = EnsimeConfigFixture.EmptyTestProject.copy(
     compilerArgs = List("-encoding", encoding)
   )
+
   // transitionary methods
   def ContentsSourceFileInfo(file: File, contents: String) =
     SourceFileInfo(RawFile(file.toPath), Some(contents))

--- a/core/src/it/scala/org/ensime/fixture/AnalyzerFixture.scala
+++ b/core/src/it/scala/org/ensime/fixture/AnalyzerFixture.scala
@@ -17,7 +17,17 @@ object AnalyzerFixture {
   private[fixture] def create(search: SearchService)(implicit system: ActorSystem, config: EnsimeConfig, vfs: EnsimeVFS): TestActorRef[Analyzer] = {
     val indexer = TestProbe()
     val projectActor = TestProbe()
-    TestActorRef(Analyzer(projectActor.ref, indexer.ref, search))
+    TestActorRef(Analyzer(projectActor.ref, indexer.ref, search, EnsimeProject(
+      EnsimeProjectId("testProject", "compile"),
+      Seq(),
+      config.projects.flatMap(_.sources).toSet,
+      config.projects.flatMap(_.targets).toSet,
+      config.compilerArgs,
+      config.projects.flatMap(_.javacOptions).distinct,
+      config.projects.flatMap(_.libraryJars).toSet,
+      config.projects.flatMap(_.librarySources).toSet,
+      config.projects.flatMap(_.libraryDocs).toSet
+    )))
   }
 }
 

--- a/core/src/it/scala/org/ensime/fixture/AnalyzerFixture.scala
+++ b/core/src/it/scala/org/ensime/fixture/AnalyzerFixture.scala
@@ -14,20 +14,10 @@ trait AnalyzerFixture {
 }
 
 object AnalyzerFixture {
-  private[fixture] def create(search: SearchService)(implicit system: ActorSystem, config: EnsimeConfig, vfs: EnsimeVFS): TestActorRef[Analyzer] = {
+  private[fixture] def create(search: SearchService, id: EnsimeProjectId)(implicit system: ActorSystem, config: EnsimeConfig, vfs: EnsimeVFS): TestActorRef[Analyzer] = {
     val indexer = TestProbe()
     val projectActor = TestProbe()
-    TestActorRef(Analyzer(projectActor.ref, indexer.ref, search, EnsimeProject(
-      EnsimeProjectId("testProject", "compile"),
-      Seq(),
-      config.projects.flatMap(_.sources).toSet,
-      config.projects.flatMap(_.targets).toSet,
-      config.compilerArgs,
-      config.projects.flatMap(_.javacOptions).distinct,
-      config.projects.flatMap(_.libraryJars).toSet,
-      config.projects.flatMap(_.librarySources).toSet,
-      config.projects.flatMap(_.libraryDocs).toSet
-    )))
+    TestActorRef(Analyzer(projectActor.ref, indexer.ref, search, config.modules(id)))
   }
 }
 

--- a/core/src/it/scala/org/ensime/fixture/EnsimeConfigFixture.scala
+++ b/core/src/it/scala/org/ensime/fixture/EnsimeConfigFixture.scala
@@ -114,10 +114,10 @@ object EnsimeConfigFixture {
 
     def rename(from: File): File = {
       val toPath = from.getAbsolutePath.replace(
-        source.root.getAbsolutePath,
+        source.rootDir.getAbsolutePath,
         target.getAbsolutePath
       )
-      require(toPath != from.getAbsolutePath, s"${source.root.getAbsolutePath} ${target.getAbsolutePath} in ${from.getAbsolutePath}")
+      require(toPath != from.getAbsolutePath, s"${source.rootDir.getAbsolutePath} ${target.getAbsolutePath} in ${from.getAbsolutePath}")
       File(toPath)
     }
 
@@ -160,7 +160,7 @@ object EnsimeConfigFixture {
       file.writeLines(file.readLines())
     }
 
-    if (preWarm && (config.compileClasspath ++ config.javaLibs).nonEmpty)
+    if (preWarm && (config.classpath ++ config.javaLibs).nonEmpty)
       EnsimeCacheProject.foreach { cacheProject =>
         log.info(s"copying ${cacheProject.cacheDir}")
         cacheProject.cacheDir.toPath.copyDirTo(config.cacheDir.toPath)

--- a/core/src/it/scala/org/ensime/fixture/RichPresentationCompilerFixture.scala
+++ b/core/src/it/scala/org/ensime/fixture/RichPresentationCompilerFixture.scala
@@ -51,7 +51,7 @@ object RichPresentationCompilerFixture {
     vfs: EnsimeVFS
   ): RichPresentationCompiler = {
     import system.dispatcher
-    val scalaLib = config.allJars.find(_.getName.contains("scala-library")).get
+    val scalaLib = config.scalaLibrary.get
 
     val presCompLog = LoggerFactory.getLogger(classOf[Global])
     val settings = new Settings(presCompLog.error)
@@ -60,7 +60,7 @@ object RichPresentationCompilerFixture {
     settings.verbose.value = presCompLog.isDebugEnabled
     //settings.usejavacp.value = true
     settings.bootclasspath.append(scalaLib.getAbsolutePath)
-    settings.classpath.value = config.compileClasspath.mkString(File.pathSeparator)
+    settings.classpath.value = config.classpath.mkString(File.pathSeparator)
 
     val reporter = new TestReporter
     val indexer = TestProbe()

--- a/core/src/it/scala/org/ensime/intg/DebugTest.scala
+++ b/core/src/it/scala/org/ensime/intg/DebugTest.scala
@@ -627,7 +627,7 @@ object VMStarter extends SLF4JLogging {
     // would be nice to have ephemeral debug ports
     val port = 5000 + scala.util.Random.nextInt(1000)
 
-    val classpath = (config.compileClasspath ++ config.targetClasspath).mkString(File.pathSeparator)
+    val classpath = config.classpath.mkString(File.pathSeparator)
     val args = Seq(
       java,
       "-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=" + port,

--- a/core/src/it/scala/org/ensime/intg/JarTargetTest.scala
+++ b/core/src/it/scala/org/ensime/intg/JarTargetTest.scala
@@ -88,7 +88,7 @@ class MissingJarTargetTest extends EnsimeSpec
           mainTarget should be a 'file
 
           // means the file addition was detected
-          asyncHelper.expectMsg(10 seconds, CompilerRestartedEvent)
+          asyncHelper.expectMsg(10 seconds, AnalyzerReadyEvent)
 
           eventually(timeout(scaled(10 seconds)), interval(scaled(1 second))) {
             project ! PublicSymbolSearchReq(List("Foo"), 5)

--- a/core/src/main/scala/org/ensime/config/package.scala
+++ b/core/src/main/scala/org/ensime/config/package.scala
@@ -7,11 +7,23 @@ import Predef.{ any2stringadd => _, _ => _ }
 import org.ensime.api._
 import org.ensime.util.file._
 
-import scala.collection.breakOut
-
 package object config {
 
   implicit class RichEnsimeConfig(val c: EnsimeConfig) extends AnyVal {
+    // we should really be using NIO instead of strings...
+    def find(path: String): Option[EnsimeProject] =
+      c.projects.find(_.sources.exists(f => path.startsWith(f.getPath)))
+    def find(file: File): Option[EnsimeProject] = find(file.getPath)
+    def find(file: EnsimeFile): Option[EnsimeProject] = file match {
+      case RawFile(file) => find(file.toFile)
+      case ArchiveFile(jar, _) => find(jar.toFile)
+    }
+    def find(file: SourceFileInfo): Option[EnsimeProject] = find(file.file)
+
+    // def find(file: Either[File, SourceFileInfo]): Option[EnsimeProject] = file match {
+    //   case Left(f) => find(f)
+    //   case Right(sourceFileInfo) => find(sourceFileInfo)
+    // }
   }
 
   implicit class RichEnsimeModule(val m: EnsimeProject) extends AnyVal {

--- a/core/src/main/scala/org/ensime/config/package.scala
+++ b/core/src/main/scala/org/ensime/config/package.scala
@@ -24,7 +24,8 @@ package object config {
         if file.isFile && file.isScala
       } yield file
 
-      s.toSet
+      s
     }
   }
+
 }

--- a/core/src/main/scala/org/ensime/config/package.scala
+++ b/core/src/main/scala/org/ensime/config/package.scala
@@ -12,20 +12,15 @@ import scala.collection.breakOut
 package object config {
 
   implicit class RichEnsimeConfig(val c: EnsimeConfig) extends AnyVal {
-    def scalaSourceFiles: Set[File] =
-      c.modules.values.flatMap((m: EnsimeProject) => m.scalaSourceFiles)(breakOut)
   }
 
   implicit class RichEnsimeModule(val m: EnsimeProject) extends AnyVal {
-    def scalaSourceFiles: Set[File] = {
-      val s = for {
-        root <- m.sources
-        file <- root.tree
-        if file.isFile && file.isScala
-      } yield file
+    def scalaSourceFiles: Set[File] = for {
+      root <- m.sources
+      file <- root.tree
+      if file.isFile && file.isScala
+    } yield file
 
-      s
-    }
   }
 
 }

--- a/core/src/main/scala/org/ensime/core/Analyzer.scala
+++ b/core/src/main/scala/org/ensime/core/Analyzer.scala
@@ -160,9 +160,9 @@ class Analyzer(
   }
 
   def ready: Receive = withLabel("ready") {
-    case ReloadExistingFilesEvent if allFilesMode =>
+    case AskReTypecheck if allFilesMode =>
       log.info("Skipping reload, in all-files mode")
-    case ReloadExistingFilesEvent =>
+    case AskReTypecheck =>
       restartCompiler(keepLoaded = true)
 
     case FullTypeCheckCompleteEvent =>
@@ -207,13 +207,6 @@ class Analyzer(
         module =>
           val files: Set[SourceFileInfo] = module.scalaSourceFiles.map(s => SourceFileInfo(EnsimeFile(s), None, None))(breakOut)
           sender ! scalaCompiler.handleReloadFiles(files)
-      }
-    case UnloadModuleReq(moduleId) =>
-      config.modules get (moduleId) foreach {
-        module =>
-          val files = module.scalaSourceFiles.toList
-          files.foreach(scalaCompiler.askRemoveDeleted)
-          sender ! VoidResponse
       }
     case TypecheckFileReq(fileInfo) =>
       sender ! scalaCompiler.handleReloadFiles(Set(fileInfo))

--- a/core/src/main/scala/org/ensime/core/Analyzer.scala
+++ b/core/src/main/scala/org/ensime/core/Analyzer.scala
@@ -185,6 +185,16 @@ class Analyzer(
     case RemoveFileReq(file: File) =>
       scalaCompiler.askRemoveDeleted(file)
       sender ! VoidResponse
+    case UnloadAllReq =>
+      if (propOrFalse("ensime.sourceMode")) {
+        log.info("in source mode, will reload all files")
+        scalaCompiler.askRemoveAllDeleted()
+        restartCompiler(keepLoaded = true)
+      } else {
+        allFilesMode = false
+        restartCompiler(keepLoaded = false)
+      }
+      sender ! VoidResponse
     case TypecheckModule(moduleId) =>
       //consider the case of a project with no modules
       config.modules get (moduleId) foreach {

--- a/core/src/main/scala/org/ensime/core/Analyzer.scala
+++ b/core/src/main/scala/org/ensime/core/Analyzer.scala
@@ -54,7 +54,7 @@ class Analyzer(
     broadcaster: ActorRef,
     indexer: ActorRef,
     search: SearchService,
-    module: EnsimeProject,
+    project: EnsimeProject,
     implicit val config: EnsimeConfig,
     implicit val vfs: EnsimeVFS
 ) extends Actor with Stash with ActorLogging with RefactoringHandler {
@@ -63,7 +63,6 @@ class Analyzer(
   import FileUtils._
 
   private var allFilesMode = false
-
   private var settings: Settings = _
   private var reporter: PresentationReporter = _
 
@@ -81,8 +80,8 @@ class Analyzer(
       case Some(scalaLib) => settings.bootclasspath.value = scalaLib.getAbsolutePath
       case None => log.warning("scala-library.jar not present, enabling Odersky mode")
     }
-    settings.classpath.value = module.compileClasspath.mkString(JFile.pathSeparator)
-    settings.processArguments(module.scalacOptions, processAll = false)
+    settings.classpath.value = project.classpath.mkString(JFile.pathSeparator)
+    settings.processArguments(project.scalacOptions, processAll = false)
     presCompLog.debug("Presentation Compiler settings:\n" + settings)
 
     reporter = new PresentationReporter(new ReportHandler {
@@ -105,7 +104,7 @@ class Analyzer(
 
     // each analyzer must load files  of its module
     if (propOrFalse("ensime.sourceMode"))
-      scalaCompiler.askReloadAllFiles(module)
+      scalaCompiler.askReloadAllFiles(project)
 
   }
 

--- a/core/src/main/scala/org/ensime/core/AnalyzerManager.scala
+++ b/core/src/main/scala/org/ensime/core/AnalyzerManager.scala
@@ -1,0 +1,339 @@
+package org.ensime.core
+
+import akka.actor.{ Actor, ActorLogging, ActorRef, Props, Stash }
+import akka.event.LoggingReceive.withLabel
+import org.ensime.api.{ AnalyzerReadyEvent, ArchiveFile, AstAtPointReq, CompletionsReq, DocUriAtPointReq, DocUriForSymbolReq, EnsimeConfig, EnsimeFile, EnsimeProject, EnsimeProjectId, EnsimeServerError, ExpandSelectionReq, FullTypeCheckCompleteEvent, ImplicitInfoReq, InspectPackageByPathReq, InspectTypeAtPointReq, InspectTypeByNameReq, OffsetRange, PackageMemberCompletionReq, RawFile, RefactorReq, ReloadExistingFilesEvent, RemoveFileReq, RemoveFilesReq, RpcAnalyserRequest, RpcResponse, SourceFileInfo, StructureViewReq, SymbolAtPointReq, SymbolByNameReq, SymbolDesignationsReq, TypeAtPointReq, TypeByNameAtPointReq, TypeByNameReq, TypecheckAllReq, TypecheckFileReq, TypecheckFilesReq, TypecheckModule, UnloadAllReq, UnloadFileReq, UnloadModuleReq, UsesOfSymbolAtPointReq, VoidResponse }
+import org.ensime.config.RichEnsimeModule
+import org.ensime.util.FileUtils.toSourceFileInfo
+import org.ensime.util.ensimefile.{ RichArchiveFile, richEnsimeFile }
+import org.ensime.util.file.File
+
+import scala.collection.breakOut
+
+trait ModuleFinder {
+  implicit val config: EnsimeConfig
+
+  def getModule(path: String): Option[EnsimeProject] =
+    config.projects.find(_.sources.exists(f => path.startsWith(f.toString)))
+
+  def getModule(file: EnsimeFile): Option[EnsimeProject] = file match {
+    case RawFile(file) => getModule(file.toString)
+    case archive: ArchiveFile => getModule(archive.fullPath)
+  }
+  def getModule(file: File): Option[EnsimeProject] = getModule(file.toPath.toString)
+  def getModule(file: Either[File, SourceFileInfo]): Option[EnsimeProject] = file match {
+    case Left(f) => getModule(f)
+    case Right(sourceFileInfo) => getModule(sourceFileInfo.file)
+  }
+}
+
+sealed trait FileStatus {
+  def append(status: FileStatus): FileStatus
+}
+final case object NotLoaded extends FileStatus {
+  def append(status: FileStatus) = status match {
+    case Loaded => Loaded
+    case _ => NotLoaded
+  }
+}
+final case object Loaded extends FileStatus {
+  def append(status: FileStatus) = status match {
+    case Removed => Removed
+    case Unloaded => Unloaded
+    case _ => Loaded
+  }
+}
+final case object Removed extends FileStatus {
+  def append(status: FileStatus) = status match {
+    case Loaded => Loaded
+    case _ => Removed
+  }
+}
+final case object Unloaded extends FileStatus { // different from Removed
+  def append(status: FileStatus) = status match {
+    case Loaded => Loaded
+    case _ => Unloaded
+  }
+}
+
+final case class LoadedFilesData(statusOfFile: Map[SourceFileInfo, FileStatus], default: FileStatus)
+
+class AnalyzerManager(
+    broadcaster: ActorRef,
+    analyzerCreator: EnsimeProject => Props,
+    implicit val config: EnsimeConfig
+) extends Actor with ActorLogging with ModuleFinder with Stash {
+
+  // maps the active modules to their analyzers
+  private var analyzers: Map[EnsimeProject, ActorRef] = Map.empty
+  private var historyOfModule: Map[EnsimeProject, LoadedFilesData] = Map.empty
+
+  private val projectWideAnalyzer: Props = analyzerCreator(EnsimeProject.wholeProject)
+
+  override def preStart(): Unit = {
+    // initialize loadedFiles
+    config.projects foreach (p => historyOfModule += (p -> LoadedFilesData(Map.empty, NotLoaded)))
+    // legacy clients expect to see FullTypeCheckComlpeteEvent and AnalyzerReadyEvent on connection
+    broadcaster ! Broadcaster.Persist(AnalyzerReadyEvent)
+    broadcaster ! Broadcaster.Persist(FullTypeCheckCompleteEvent)
+  }
+
+  override def receive: Receive = ready
+
+  private def ready: Receive = withLabel("ready") {
+    case ReloadExistingFilesEvent =>
+      if (analyzers.isEmpty)
+        broadcaster ! AnalyzerReadyEvent
+      else
+        for {
+          (module, analyzer) <- analyzers
+        } analyzer forward ReloadExistingFilesEvent
+    case req: RpcAnalyserRequest =>
+      forwardToAnalyzer(req)
+  }
+
+  private def getOrSpawnNew(module: EnsimeProject): ActorRef =
+    analyzers.get(module) match {
+      case Some(analyzer) => analyzer
+      case None =>
+        // spawn a new analyzer and attach it to module
+        val newAnalyzer = context.actorOf(analyzerCreator(module))
+        analyzers = analyzers + (module -> newAnalyzer)
+        newAnalyzer
+    }
+
+  def toFile(f: SourceFileInfo) = f.file match {
+    case RawFile(path) => path.toFile
+    case file: ArchiveFile => File(file.fullPath) // not sure
+  }
+
+  def update(loadedFilesData: LoadedFilesData)(f: (Map[SourceFileInfo, FileStatus], FileStatus) => LoadedFilesData) =
+    f(loadedFilesData.statusOfFile, loadedFilesData.default)
+
+  def allSourceFiles(module: EnsimeProject): Set[SourceFileInfo] =
+    module.scalaSourceFiles.map(f => SourceFileInfo(RawFile(f.toPath), None, None))(breakOut)
+
+  def removeSymbolsOf(module: EnsimeProject): Set[SourceFileInfo] = {
+    val ld = historyOfModule(module)
+    allSourceFiles(module) filter (ld.statusOfFile.getOrElse(_, ld.default) == Removed)
+  }
+
+  private def withExistingModuleFor(fileInfo: SourceFileInfo, req: RpcAnalyserRequest)(f: (RpcAnalyserRequest, EnsimeProject) => Unit): Unit =
+    getModule(fileInfo.file) match {
+      case Some(module) =>
+        f(req, module)
+      case None =>
+        sender ! EnsimeServerError("Update .ensime file.")
+    }
+
+  private def withExistingModule(moduleId: EnsimeProjectId, req: RpcAnalyserRequest)(f: (RpcAnalyserRequest, EnsimeProject) => Unit) =
+    config.projects.find(_.id == moduleId) match {
+      case Some(module) =>
+        f(req, module)
+      case None =>
+        sender ! EnsimeServerError("Update .ensime file.")
+    }
+
+  private def forwardToAnalyzer: PartialFunction[RpcAnalyserRequest, Unit] = {
+    case req @ TypecheckAllReq =>
+      config.projects.foreach { module =>
+        getOrSpawnNew(module) forward req
+        historyOfModule += module -> LoadedFilesData(Map.empty, Loaded)
+      }
+    case req @ UnloadAllReq =>
+      analyzers.foreach {
+        case (_, analyzer) => analyzer forward req
+      }
+    case req @ TypecheckModule(moduleId) =>
+      withExistingModule(moduleId, req)((req, module) => {
+        getOrSpawnNew(module) forward req
+        historyOfModule += module -> LoadedFilesData(Map.empty, Loaded)
+      })
+    case req @ UnloadModuleReq(moduleId) =>
+      withExistingModule(moduleId, req)((req, module) => {
+        getOrSpawnNew(module) forward req
+        val previousData = historyOfModule(module)
+        historyOfModule += module -> update(previousData) { (statusOfFile, default) =>
+          default match {
+            case NotLoaded =>
+              LoadedFilesData(statusOfFile.map(m => m._1 -> m._2.append(Removed)), default)
+            case _ =>
+              LoadedFilesData(Map.empty, Removed)
+          }
+        }
+      })
+    case req @ RemoveFileReq(file: File) =>
+      val f = SourceFileInfo(RawFile(file.toPath), None, None)
+      withExistingModuleFor(f, req)((req, module) => {
+        getOrSpawnNew(module) forward req
+        val previousData = historyOfModule(module)
+        historyOfModule += module -> update(previousData) { (statusOfFile, default) =>
+          LoadedFilesData(statusOfFile + (f -> statusOfFile.getOrElse(f, default).append(Removed)), default)
+        }
+      })
+    case req @ TypecheckFileReq(fileInfo) =>
+      withExistingModuleFor(fileInfo, req)((req, module) => {
+        getOrSpawnNew(module) forward req
+        val previousData = historyOfModule(module)
+        historyOfModule += module -> update(previousData) { (statusOfFile, default) =>
+          LoadedFilesData(statusOfFile + (fileInfo -> statusOfFile.getOrElse(fileInfo, default).append(Loaded)), default)
+        }
+      })
+    case req @ TypecheckFilesReq(files) =>
+      var missingSource: Boolean = files.exists(getModule(_).isEmpty)
+      if (missingSource)
+        sender ! EnsimeServerError("Update .ensime file.")
+      else {
+        val filesPerModule: Map[EnsimeProject, List[Either[File, SourceFileInfo]]] = files.groupBy(getModule).map(x => x._1.get -> x._2)
+        for ((module, list) <- filesPerModule) {
+          val analyzer = getOrSpawnNew(module)
+          analyzer ! TypecheckFilesReq(list)
+          if (!list.map(toSourceFileInfo).exists(!_.file.exists)) {
+            val previousData = historyOfModule(module)
+            historyOfModule += module -> update(previousData) { (statusOfFile, default) =>
+              val addToStatusOfFile = list.map(toSourceFileInfo).map(f => f -> statusOfFile.getOrElse(f, default).append(Loaded))
+              LoadedFilesData(statusOfFile ++ addToStatusOfFile, default)
+            }
+          }
+
+        }
+        context.become(collector[List[String]](filesPerModule.size, Nil, sender)((newResponse, aggregate) => {
+          newResponse match {
+            case EnsimeServerError(desc) =>
+              desc :: aggregate
+            case _ =>
+              aggregate
+          }
+        }, aggregate => {
+          if (aggregate.isEmpty) // had no errors; return a  VoidResponse
+            VoidResponse
+          else // return the cumulative error
+            EnsimeServerError(aggregate mkString ", ")
+        }))
+      }
+    case req @ (InspectTypeByNameReq(_) |
+      SymbolByNameReq(_, _, _) |
+      DocUriForSymbolReq(_, _, _) |
+      PackageMemberCompletionReq(_, _) |
+      TypeByNameReq(_) |
+      InspectPackageByPathReq(_)) =>
+      val filesToBeDeleted = config.projects.flatMap(removeSymbolsOf(_)).filter(_.file.exists())
+      val originalSender = sender
+      context.actorOf(Props(new Actor {
+        private var analyzer: ActorRef = _
+        override def preStart(): Unit = {
+          analyzer = context.actorOf(projectWideAnalyzer)
+          if (filesToBeDeleted.nonEmpty)
+            analyzer ! TypecheckFilesReq(filesToBeDeleted.map(Right(_)).toList)
+          else
+            self ! FullTypeCheckCompleteEvent
+        }
+        def receive: Receive = {
+          case FullTypeCheckCompleteEvent =>
+            analyzer ! RemoveFilesReq(filesToBeDeleted.map(toFile))
+            analyzer ! req
+          case VoidResponse => // filter out
+          case res =>
+            originalSender ! res
+            context.stop(analyzer)
+            context.stop(self)
+        }
+      }))
+    case req @ RefactorReq(_, _, _) =>
+      context.actorOf(projectWideAnalyzer) forward req
+    case req @ CompletionsReq(fileInfo, _, _, _, _) =>
+      withExistingModuleFor(fileInfo, req)((req, module) =>
+        getOrSpawnNew(module) forward req)
+    case req @ UsesOfSymbolAtPointReq(f, _) =>
+      withExistingModuleFor(f, req)((req, module) => {
+        getOrSpawnNew(module) forward req
+      })
+    case req @ InspectTypeAtPointReq(file, range: OffsetRange) =>
+      withExistingModuleFor(file, req)((req, module) => {
+        getOrSpawnNew(module) forward req
+      })
+    case req @ SymbolAtPointReq(file, point: Int) =>
+      withExistingModuleFor(file, req)((req, module) => {
+        getOrSpawnNew(module) forward req
+      })
+    case req @ DocUriAtPointReq(file, range: OffsetRange) =>
+      withExistingModuleFor(file, req)((req, module) => {
+        getOrSpawnNew(module) forward req
+      })
+    case req @ TypeAtPointReq(file, range: OffsetRange) =>
+      withExistingModuleFor(file, req)((req, module) => {
+        getOrSpawnNew(module) forward req
+      })
+    case req @ TypeByNameAtPointReq(name: String, file, range: OffsetRange) =>
+      withExistingModuleFor(file, req)((req, module) => {
+        getOrSpawnNew(module) forward req
+      })
+    case req @ SymbolDesignationsReq(f, start, end, _) =>
+      withExistingModuleFor(f, req)((req, module) => {
+        getOrSpawnNew(module) forward req
+      })
+    case req @ ImplicitInfoReq(file, range: OffsetRange) =>
+      withExistingModuleFor(file, req)((req, module) => {
+        getOrSpawnNew(module) forward req
+      })
+    case req @ ExpandSelectionReq(file, start: Int, stop: Int) =>
+      val f = SourceFileInfo(RawFile(file.toPath), None, None)
+      withExistingModuleFor(f, req)((req, module) => {
+        getOrSpawnNew(module) forward req
+      })
+    case req @ StructureViewReq(fileInfo: SourceFileInfo) =>
+      withExistingModuleFor(fileInfo, req)((req, module) => {
+        getOrSpawnNew(module) forward req
+      })
+    case req @ AstAtPointReq(file, offset) =>
+      withExistingModuleFor(file, req)((req, module) => {
+        getOrSpawnNew(module) forward req
+      })
+    case req @ UnloadFileReq(file) =>
+      withExistingModuleFor(file, req)((req, module) => {
+        getOrSpawnNew(module) forward req
+        val previousData = historyOfModule(module)
+        historyOfModule += module -> update(previousData) { (statusOfFile, default) =>
+          LoadedFilesData(statusOfFile + (file -> statusOfFile.getOrElse(file, default).append(Unloaded)), default)
+        }
+      })
+  }
+
+  /**
+   * T is the type of parameter we need to agregate, for e.g, List[String], TypeInfo, PackageInfo etc.
+   *
+   *  @param remaining      number of responses that still need to be collected
+   *  @param aggregate      the agg
+   *  @param sendResultsTo  the original sender
+   *  @param addResponse    the aggregating function; takes as input the last aggregate and new response and, returns the new aggregate
+   *  @param combine        the combining function; makes the response from the final aggregate
+   *
+   * for instance, for collecting results of a TypeCheckFilesReq we will define it as follows :
+   *
+   *  collector[List[String], RpcResponse](remaining, Nil, sender)(...)
+   *
+   */
+  private def collector[T](remaining: Int, aggregate: T, sendResultsTo: ActorRef)(addResponse: (RpcResponse, T) => T, combine: T => RpcResponse): Receive =
+    if (remaining > 1) {
+      case res: RpcResponse =>
+        context.become(collector(remaining - 1, addResponse(res, aggregate), sendResultsTo)(addResponse, combine))
+      case msg => stash()
+    } else {
+      case res: RpcResponse =>
+        sendResultsTo ! combine(addResponse(res, aggregate))
+        context.become(ready)
+        unstashAll()
+      case msg => stash()
+    }
+
+}
+
+object AnalyzerManager {
+  def apply(
+    broadcaster: ActorRef,
+    creator: EnsimeProject => Props
+  )(
+    implicit
+    config: EnsimeConfig
+  ) = Props(new AnalyzerManager(broadcaster, creator, config))
+}

--- a/core/src/main/scala/org/ensime/core/AnalyzerManager.scala
+++ b/core/src/main/scala/org/ensime/core/AnalyzerManager.scala
@@ -89,15 +89,6 @@ class AnalyzerManager(
           (_, analyzer) <- analyzers
         } analyzer forward AskReTypecheck
 
-    case req @ TypecheckAllReq =>
-      config.projects.foreach { module =>
-        getOrSpawnNew(module) forward req
-        historyOfModule += module -> LoadedFilesData(Map.empty, Loaded)
-      }
-    case req @ UnloadAllReq =>
-      analyzers.foreach {
-        case (_, analyzer) => analyzer forward req
-      }
     case req @ TypecheckModule(moduleId) =>
       withExistingModule(moduleId, req)((req, module) => {
         getOrSpawnNew(module) forward req

--- a/core/src/main/scala/org/ensime/core/AnalyzerManager.scala
+++ b/core/src/main/scala/org/ensime/core/AnalyzerManager.scala
@@ -89,6 +89,10 @@ class AnalyzerManager(
           (_, analyzer) <- analyzers
         } analyzer forward AskReTypecheck
 
+    case req @ UnloadAllReq =>
+      analyzers.foreach {
+        case (_, analyzer) => analyzer forward req
+      }
     case req @ TypecheckModule(moduleId) =>
       withExistingModule(moduleId, req)((req, module) => {
         getOrSpawnNew(module) forward req

--- a/core/src/main/scala/org/ensime/core/FqnToSymbol.scala
+++ b/core/src/main/scala/org/ensime/core/FqnToSymbol.scala
@@ -50,9 +50,12 @@ trait FqnToSymbol { self: Global with SymbolToFqn =>
       segToSym(nme.segments(scalaName, assumeTerm = assumeTerm), rootSymbol)
     }
   }.getOrElse {
-    val term = segToSym(nme.segments(scalaName, assumeTerm = true), rootSymbol)
+    val nameSegments = nme.segments(scalaName, assumeTerm = true)
+    val term = segToSym(nameSegments, rootSymbol)
     if (term != NoSymbol) term
-    else segToSym(nme.segments(scalaName, assumeTerm = false), rootSymbol)
+    else
+      segToSym(nme.segments(scalaName, assumeTerm = false), rootSymbol)
+
   }
 
   private def traverseSymbolTree(sym: Symbol, name: Seq[String], isTermName: Boolean): Symbol = {

--- a/core/src/main/scala/org/ensime/core/Project.scala
+++ b/core/src/main/scala/org/ensime/core/Project.scala
@@ -113,7 +113,7 @@ class Project(
         }
       }))
 
-      scalac = context.actorOf(Analyzer(merger, indexer, searchService), "scalac")
+      scalac = context.actorOf(AnalyzerManager(merger, Analyzer(merger, indexer, searchService, _)(config, vfs)), "scalac")
       javac = context.actorOf(JavaAnalyzer(merger, indexer, searchService), "javac")
     } else {
       log.warning("Detected a pure Java project. Scala queries are not available.")
@@ -157,6 +157,7 @@ class Project(
     case m: RpcSearchRequest => indexer forward m
     case m: DocSigPair => docs forward m
 
+    case AnalyzerReadyEvent => broadcaster ! AnalyzerReadyEvent
     // added here to prevent errors when client sends this repeatedly (e.g. as a keepalive
     case ConnectionInfoReq =>
       sender() ! ConnectionInfo()

--- a/core/src/main/scala/org/ensime/core/Project.scala
+++ b/core/src/main/scala/org/ensime/core/Project.scala
@@ -21,6 +21,8 @@ import org.ensime.util.ensimefile._
 
 final case class ShutdownRequest(reason: String, isError: Boolean = false)
 
+case object AskReTypecheck
+
 /**
  * The Project actor simply forwards messages coming from the user to
  * the respective subcomponent.
@@ -131,13 +133,12 @@ class Project(
     Try(vfs.close())
   }
 
-  // debounces ReloadExistingFilesEvent
+  // debounces AskReTypecheck
   private var rechecking: Cancellable = _
 
   def handleRequests: Receive = withLabel("handleRequests") {
     case ShutdownRequest => context.parent forward ShutdownRequest
-    case AskReTypecheck =>
-      scalac ! ReloadExistingFilesEvent
+    case AskReTypecheck => scalac ! AskReTypecheck
     // HACK: to expedite initial dev, Java requests use the Scala API
     case m @ TypecheckFileReq(sfi) if sfi.file.isJava => javac forward m
     case m @ CompletionsReq(sfi, _, _, _, _) if sfi.file.isJava => javac forward m

--- a/core/src/main/scala/org/ensime/core/RichPresentationCompiler.scala
+++ b/core/src/main/scala/org/ensime/core/RichPresentationCompiler.scala
@@ -180,20 +180,12 @@ trait RichCompilerControl extends CompilerControl with RefactoringControl with C
 
   def askRemoveDeleted(f: File) = askOption(removeDeleted(AbstractFile.getFile(f)))
 
-  def askReloadAllFiles() = {
+  def askReloadAllFiles(scopes: List[EnsimeProjectId]) = {
     val all = {
       for {
-        file <- config.scalaSourceFiles
-        source = createSourceFile(file)
-      } yield source
-    } ++ activeUnits().map(_.source)
-    askReloadFiles(all)
-  }
-
-  def askReloadAllFiles(module: EnsimeProject) = {
-    val all = {
-      for {
-        file <- module.scalaSourceFiles
+        scope <- scopes
+        proj = config.modules(scope)
+        file <- proj.scalaSourceFiles
         source = createSourceFile(file)
       } yield source
     } ++ activeUnits().map(_.source)

--- a/core/src/main/scala/org/ensime/core/RichPresentationCompiler.scala
+++ b/core/src/main/scala/org/ensime/core/RichPresentationCompiler.scala
@@ -190,6 +190,16 @@ trait RichCompilerControl extends CompilerControl with RefactoringControl with C
     askReloadFiles(all)
   }
 
+  def askReloadAllFiles(module: EnsimeProject) = {
+    val all = {
+      for {
+        file <- module.scalaSourceFiles
+        source = createSourceFile(file)
+      } yield source
+    } ++ activeUnits().map(_.source)
+    askReloadFiles(all)
+  }
+
   def loadedFiles: List[SourceFile] = activeUnits().map(_.source)
 
   def askReloadExistingFiles() =
@@ -585,8 +595,10 @@ class RichPresentationCompiler(
           // like Eclipse is doing we would need to return:
           // List(qualifier.symbol, ap.symbol)
           List(qualifier.symbol)
+
         case st if st.symbol ne null =>
           List(st.symbol)
+
         case lit: Literal =>
           List(lit.tpe.typeSymbol)
 

--- a/core/src/main/scala/org/ensime/core/javac/JavaCompiler.scala
+++ b/core/src/main/scala/org/ensime/core/javac/JavaCompiler.scala
@@ -39,7 +39,7 @@ class JavaCompiler(
 
   private val listener = new JavaDiagnosticListener()
   private val silencer = new SilencedDiagnosticListener()
-  private val cp = (config.allJars ++ config.targetClasspath).mkString(JFile.pathSeparator)
+  private val cp = config.classpath.mkString(JFile.pathSeparator)
   private val workingSet = new ConcurrentHashMap[String, JavaFileObject]()
 
   private implicit def charset = Charset.defaultCharset() // how can we infer this?

--- a/core/src/main/scala/org/ensime/indexer/FileWatchers.scala
+++ b/core/src/main/scala/org/ensime/indexer/FileWatchers.scala
@@ -48,7 +48,7 @@ class ClassfileWatcher(
     else {
       val jarJava7WatcherBuilder = new JarJava7WatcherBuilder()
       val classJava7WatcherBuilder = new ClassJava7WatcherBuilder()
-      config.targetClasspath.map { target =>
+      config.targets.map { target =>
         if (target.isJar) {
           if (log.isTraceEnabled())
             log.trace(s"creating a Java 7 jar watcher for ${target}")

--- a/core/src/main/scala/org/ensime/indexer/SearchService.scala
+++ b/core/src/main/scala/org/ensime/indexer/SearchService.scala
@@ -37,7 +37,7 @@ class SearchService(
   import SearchService._
   import ExecutionContext.Implicits.global // not used for heavy lifting (indexing, graph or lucene)
 
-  private[indexer] val allTargets = config.projects.flatMap(_.targets).map(vfs.vfile)
+  private[indexer] val allTargets = config.targets.map(vfs.vfile)
 
   private[indexer] def isUserFile(file: FileName): Boolean = allTargets.exists(file isAncestor _.getName)
 

--- a/core/src/main/scala/org/ensime/indexer/SearchService.scala
+++ b/core/src/main/scala/org/ensime/indexer/SearchService.scala
@@ -37,7 +37,7 @@ class SearchService(
   import SearchService._
   import ExecutionContext.Implicits.global // not used for heavy lifting (indexing, graph or lucene)
 
-  private[indexer] val allTargets = config.allTargets.map(vfs.vfile)
+  private[indexer] val allTargets = config.projects.flatMap(_.targets).map(vfs.vfile)
 
   private[indexer] def isUserFile(file: FileName): Boolean = allTargets.exists(file isAncestor _.getName)
 

--- a/core/src/main/scala/org/ensime/util/Reporter.scala
+++ b/core/src/main/scala/org/ensime/util/Reporter.scala
@@ -2,13 +2,12 @@
 // License: http://www.gnu.org/licenses/gpl-3.0.en.html
 package org.ensime.util
 
+import org.ensime.api._
+import org.ensime.core.PositionBackCompat
 import org.slf4j.LoggerFactory
 
 import scala.reflect.internal.util.Position
 import scala.tools.nsc.reporters.Reporter
-
-import org.ensime.api._
-import org.ensime.core.PositionBackCompat
 
 trait ReportHandler {
   def messageUser(@deprecated("local", "") str: String): Unit = {}

--- a/core/src/test/scala/org/ensime/core/AnalyzerManagerSpec.scala
+++ b/core/src/test/scala/org/ensime/core/AnalyzerManagerSpec.scala
@@ -1,0 +1,69 @@
+package org.ensime.core
+
+import akka.actor.{ Actor, Props }
+import akka.testkit.TestActorRef
+import org.ensime.api.{ EnsimeConfig, EnsimeProject, EnsimeProjectId, EnsimeServerError, TypecheckFilesReq, VoidResponse }
+import org.ensime.fixture.SharedTestKitFixture
+import org.ensime.util.EnsimeSpec
+import org.ensime.util.FileUtils.toSourceFileInfo
+import org.ensime.util.ensimefile.EnsimeFile
+import org.ensime.util.file.{ RichFile, withTempDir }
+
+class AnalyzerManagerSpec extends EnsimeSpec with SharedTestKitFixture {
+
+  "Analyzer Manager" should "aggregate multiple EnsimeServerErrors into one" in withTestKit { testKist =>
+    import testKist._
+
+    class DummyFileMissingAnalyzer extends Actor {
+      override def receive: Receive = {
+        case TypecheckFilesReq(files) =>
+          val missingFilePaths = files.map { f => "\"" + toSourceFileInfo(f).file + "\"" }.mkString(",")
+          sender ! EnsimeServerError(s"file(s): ${missingFilePaths} do not exist")
+      }
+    }
+    withTempDir(dir => {
+      val module1 = dir / "module1"
+      val module2 = dir / "module2"
+      if (module1.mkdir() && module2.mkdir()) {
+        implicit val dummyConfig: EnsimeConfig = EnsimeConfig(dir, dir, dir, null, null, Nil, Nil, List(
+          EnsimeProject(EnsimeProjectId("module1", "compile"), Seq.empty, Set(module1), Set.empty, Nil, Nil, Set.empty, Set.empty, Set.empty),
+          EnsimeProject(EnsimeProjectId("module2", "compile"), Seq.empty, Set(module2), Set.empty, Nil, Nil, Set.empty, Set.empty, Set.empty)
+        ), Nil)
+        val analyzerManager = TestActorRef(AnalyzerManager(TestActorRef[Broadcaster], (module) => Props(new DummyFileMissingAnalyzer())))
+        val file1 = module1 / "missing1.scala"
+        val file1Path = file1.getAbsolutePath
+        val file2 = module2 / "missing2.scala"
+        val file2Path = file2.getAbsolutePath
+
+        analyzerManager ! TypecheckFilesReq(List(Left(file1), Left(file2)))
+        val error = expectMsgType[EnsimeServerError].description
+        error should include(s"""file(s): "${EnsimeFile(file1Path)}" do not exist""")
+        error should include(s"""file(s): "${EnsimeFile(file2Path)}" do not exist""")
+      }
+    })
+
+  }
+
+  it should "ask to update .ensime if module for a file is not found" in withTestKit { testKit =>
+    import testKit._
+
+    class DummyAnalyzer extends Actor {
+      override def receive: Receive = {
+        case TypecheckFilesReq(files) =>
+          sender ! VoidResponse
+      }
+    }
+
+    withTempDir(dir => {
+
+      implicit val dummyConfig: EnsimeConfig = EnsimeConfig(dir, dir, dir, null, null, Nil, Nil, Nil, Nil)
+      val analyzerManager = TestActorRef(AnalyzerManager(TestActorRef[Broadcaster], (module) => Props(new DummyAnalyzer)))
+      val testFile = dir / "inNoModule.scala"
+
+      analyzerManager ! TypecheckFilesReq(List(Left(testFile)))
+      expectMsg(EnsimeServerError("Update .ensime file."))
+
+    })
+  }
+
+}

--- a/util/src/main/scala/org/ensime/util/ensimefile.scala
+++ b/util/src/main/scala/org/ensime/util/ensimefile.scala
@@ -26,7 +26,6 @@ package ensimefile {
 
     /** Direct access contents: not efficient for streaming. */
     def readStringDirect()(implicit cs: Charset): String
-
     def uri(): URI
     def uriString(): String = uri.toASCIIString
   }


### PR DESCRIPTION
The main introduction is the `AnalyzerManager.scala` class. Except the `AnalyzerManager` class itself it has `ModuleFinder` trait and `LoadedFilesData` class.
I extracted `ModuleFinder` as a trait as it might be used elsewhere. (though I am not sure that is the best idea).
The history of an analyzer necessary to initialize the project-wide analyzer when required is stored with the help of `LoadedFilesData`.

I added a test to check if requests that would go to different analyzers were handled correctly. Hence introduced `AnalyzerManagerSpec` and `AnalyzerManagerFixture`. `BasicWorkflow` checked that the basic working remained intact.

Currently the project-wide analyser that handles the refactor request isn't closed and I need to come up with a way to do that. Any suggestions would really help. 
Also I used the `collector` method for collecting results of various requests(`TypeByName`, `InspectPackageByPath`) and initially made it generic. Now it's only used for `TypeCheckFilesReq`, so should I change it?

Please allow me to make whatever changes you think are needed. I'll try my best to solve any issues and improve the code. 

