### PR TITLE
An Inspector Doesn't Call

### DIFF
--- a/api/src/main/scala/org/ensime/api/incoming.scala
+++ b/api/src/main/scala/org/ensime/api/incoming.scala
@@ -155,17 +155,6 @@ final case class DocUriAtPointReq(
 ) extends RpcAnalyserRequest
 
 /**
- * Responds with a `StringResponse` for the URL of the documentation if valid,
- * or `FalseResponse`.
- */
-@deprecating("https://github.com/ensime/ensime-server/issues/1787")
-final case class DocUriForSymbolReq(
-  typeFullName: String,
-  memberName: Option[String],
-  signatureString: Option[String]
-) extends RpcAnalyserRequest
-
-/**
  * Responds with a `CompletionInfoList`.
  */
 final case class CompletionsReq(
@@ -174,29 +163,6 @@ final case class CompletionsReq(
   maxResults: Int,
   caseSens: Boolean,
   reload: Boolean
-) extends RpcAnalyserRequest
-
-/**
- * Responds with a `List[CompletionInfo]`.
- */
-@deprecating("https://github.com/ensime/ensime-server/issues/1787")
-final case class PackageMemberCompletionReq(
-  path: String,
-  prefix: String
-) extends RpcAnalyserRequest
-
-/**
- * Responds with `TypeInfo` if valid, or `FalseResponse`.
- */
-@deprecating("https://github.com/ensime/ensime-server/issues/1787")
-final case class TypeByNameReq(name: String) extends RpcAnalyserRequest
-
-/**
- * Responds with `TypeInfo` if valid, or `FalseResponse`.
- */
-@deprecating("https://github.com/ensime/ensime-server/issues/1787")
-final case class TypeByNameAtPointReq(
-  name: String, file: Either[File, SourceFileInfo], range: OffsetRange
 ) extends RpcAnalyserRequest
 
 /**
@@ -219,42 +185,9 @@ final case class TypeAtPointReq(
 final case class InspectTypeAtPointReq(file: Either[File, SourceFileInfo], range: OffsetRange) extends RpcAnalyserRequest
 
 /**
- * Request detailed type description by fully qualified class name.
- *
- * Responds with a `TypeInspectInfo` if the FQN is valid, or
- * `FalseResponse`.
- *
- * @param name fully qualified type name to inspect
- */
-@deprecating("https://github.com/ensime/ensime-server/issues/1787")
-final case class InspectTypeByNameReq(name: String) extends RpcAnalyserRequest
-
-/**
  * Responds with a `SymbolInfo` if valid, or `FalseResponse`.
  */
 final case class SymbolAtPointReq(file: Either[File, SourceFileInfo], point: Int) extends RpcAnalyserRequest
-
-/**
- * Request detailed symbol description by fully qualified symbol name.
- *
- * Responds with a `SymbolInfo` if valid, or `FalseResponse`.
- *
- * @param typeFullName fully qualified name of a type, object or package.
- * @param memberName short name of a member symbol of the qualified symbol.
- * @param signatureString to disambiguate overloaded methods.
- */
-@deprecating("https://github.com/ensime/ensime-server/issues/1787")
-final case class SymbolByNameReq(
-  typeFullName: String,
-  memberName: Option[String],
-  signatureString: Option[String]
-) extends RpcAnalyserRequest
-
-/**
- * Responds with `PackageInfo`.
- */
-@deprecating("https://github.com/ensime/ensime-server/issues/1787")
-final case class InspectPackageByPathReq(path: String) extends RpcAnalyserRequest
 
 /**
  * Responds with a `RefactorFailure` or a `RefactorDiffEffect`.

--- a/core/src/main/scala/org/ensime/core/Analyzer.scala
+++ b/core/src/main/scala/org/ensime/core/Analyzer.scala
@@ -214,46 +214,27 @@ class Analyzer(
         uses.map(positions => ERangePositions(positions.map(ERangePositionHelper.fromRangePosition)))
       } else Future.successful(EnsimeServerError(s"File does not exist: ${file.file}"))
       pipe(response) to sender
-    case PackageMemberCompletionReq(path: String, prefix: String) =>
-      val members = scalaCompiler.askCompletePackageMember(path, prefix)
-      sender ! members
     case InspectTypeAtPointReq(file, range: OffsetRange) =>
       sender ! withExisting(file) {
         val p = pos(file, range)
         scalaCompiler.askLoadedTyped(p.source)
         scalaCompiler.askInspectTypeAt(p).getOrElse(FalseResponse)
       }
-    case InspectTypeByNameReq(name: String) =>
-      sender ! scalaCompiler.askInspectTypeByName(name).getOrElse(FalseResponse)
     case SymbolAtPointReq(file, point: Int) =>
       sender ! withExisting(file) {
         val p = pos(file, point)
         scalaCompiler.askLoadedTyped(p.source)
         scalaCompiler.askSymbolInfoAt(p).getOrElse(FalseResponse)
       }
-    case SymbolByNameReq(typeFullName: String, memberName: Option[String], signatureString: Option[String]) =>
-      sender ! scalaCompiler.askSymbolByName(typeFullName, memberName, signatureString).getOrElse(FalseResponse)
     case DocUriAtPointReq(file, range: OffsetRange) =>
       val p = pos(file, range)
       scalaCompiler.askLoadedTyped(p.source)
       sender() ! scalaCompiler.askDocSignatureAtPoint(p)
-    case DocUriForSymbolReq(typeFullName: String, memberName: Option[String], signatureString: Option[String]) =>
-      sender() ! scalaCompiler.askDocSignatureForSymbol(typeFullName, memberName, signatureString)
-    case InspectPackageByPathReq(path: String) =>
-      sender ! scalaCompiler.askPackageByPath(path).getOrElse(FalseResponse)
     case TypeAtPointReq(file, range: OffsetRange) =>
       sender ! withExisting(file) {
         val p = pos(file, range)
         scalaCompiler.askLoadedTyped(p.source)
         scalaCompiler.askTypeInfoAt(p).getOrElse(FalseResponse)
-      }
-    case TypeByNameReq(name: String) =>
-      sender ! scalaCompiler.askTypeInfoByName(name).getOrElse(FalseResponse)
-    case TypeByNameAtPointReq(name: String, file, range: OffsetRange) =>
-      sender ! withExisting(file) {
-        val p = pos(file, range)
-        scalaCompiler.askLoadedTyped(p.source)
-        scalaCompiler.askTypeInfoByNameAt(name, p).getOrElse(FalseResponse)
       }
     case SymbolDesignationsReq(f, start, end, Nil) =>
       sender ! SymbolDesignations(f.file, List.empty)

--- a/core/src/main/scala/org/ensime/core/RichPresentationCompiler.scala
+++ b/core/src/main/scala/org/ensime/core/RichPresentationCompiler.scala
@@ -131,6 +131,7 @@ trait RichCompilerControl extends CompilerControl with RefactoringControl with C
   def askTypeInfoByName(name: String): Option[TypeInfo] =
     askOption(TypeInfo(toSymbol(name).tpe, PosNeededYes))
 
+  // FIXME delete unused PC methods
   def askTypeInfoByNameAt(name: String, p: Position): Option[TypeInfo] = {
     val nameSegs = name.split("\\.")
     val firstName: String = nameSegs.head

--- a/protocol-swanky/src/main/scala/org/ensime/server/protocol/swank/SwankFormats.scala
+++ b/protocol-swanky/src/main/scala/org/ensime/server/protocol/swank/SwankFormats.scala
@@ -632,18 +632,11 @@ object SwankProtocolRequest {
   implicit val PublicSymbolSearchReqHint: TypeHint[PublicSymbolSearchReq] = TypeHint[PublicSymbolSearchReq](SexpSymbol("swank:public-symbol-search"))
   implicit val ImportSuggestionsReqHint: TypeHint[ImportSuggestionsReq] = TypeHint[ImportSuggestionsReq](SexpSymbol("swank:import-suggestions"))
   implicit val DocUriAtPointReqHint: TypeHint[DocUriAtPointReq] = TypeHint[DocUriAtPointReq](SexpSymbol("swank:doc-uri-at-point"))
-  implicit val DocUriForSymbolReqHint: TypeHint[DocUriForSymbolReq] = TypeHint[DocUriForSymbolReq](SexpSymbol("swank:doc-uri-for-symbol"))
   implicit val CompletionsReqHint: TypeHint[CompletionsReq] = TypeHint[CompletionsReq](SexpSymbol("swank:completions"))
-  implicit val PackageMemberCompletionReqHint: TypeHint[PackageMemberCompletionReq] = TypeHint[PackageMemberCompletionReq](SexpSymbol("swank:package-member-completion"))
   implicit val UsesOfSymbolAtPointReqHint: TypeHint[UsesOfSymbolAtPointReq] = TypeHint[UsesOfSymbolAtPointReq](SexpSymbol("swank:uses-of-symbol-at-point"))
-  implicit val TypeByNameReqHint: TypeHint[TypeByNameReq] = TypeHint[TypeByNameReq](SexpSymbol("swank:type-by-name"))
-  implicit val TypeByNameAtPointReqHint: TypeHint[TypeByNameAtPointReq] = TypeHint[TypeByNameAtPointReq](SexpSymbol("swank:type-by-name-at-point"))
   implicit val TypeAtPointReqHint: TypeHint[TypeAtPointReq] = TypeHint[TypeAtPointReq](SexpSymbol("swank:type-at-point"))
   implicit val InspectTypeAtPointReqHint: TypeHint[InspectTypeAtPointReq] = TypeHint[InspectTypeAtPointReq](SexpSymbol("swank:inspect-type-at-point"))
-  implicit val InspectTypeByNameReqHint: TypeHint[InspectTypeByNameReq] = TypeHint[InspectTypeByNameReq](SexpSymbol("swank:inspect-type-by-name"))
   implicit val SymbolAtPointReqHint: TypeHint[SymbolAtPointReq] = TypeHint[SymbolAtPointReq](SexpSymbol("swank:symbol-at-point"))
-  implicit val SymbolByNameReqHint: TypeHint[SymbolByNameReq] = TypeHint[SymbolByNameReq](SexpSymbol("swank:symbol-by-name"))
-  implicit val InspectPackageByPathReqHint: TypeHint[InspectPackageByPathReq] = TypeHint[InspectPackageByPathReq](SexpSymbol("swank:inspect-package-by-path"))
   implicit val RefactorReqHint: TypeHint[RefactorReq] = TypeHint[RefactorReq](SexpSymbol("swank:diff-refactor"))
   implicit val SymbolDesignationsReqHint: TypeHint[SymbolDesignationsReq] = TypeHint[SymbolDesignationsReq](SexpSymbol("swank:symbol-designations"))
   implicit val ImplicitInfoReqHint: TypeHint[ImplicitInfoReq] = TypeHint[ImplicitInfoReq](SexpSymbol("swank:implicit-info"))
@@ -787,18 +780,11 @@ object SwankProtocolRequest {
   implicit def PublicSymbolSearchHint: SexpFormat[PublicSymbolSearchReq] = { def PublicSymbolSearchHint = ???; implicitly[SexpFormat[PublicSymbolSearchReq]] }
   implicit def ImportSuggestionsReqFormat: SexpFormat[ImportSuggestionsReq] = { def ImportSuggestionsReqFormat = ???; implicitly[SexpFormat[ImportSuggestionsReq]] }
   implicit def DocUriAtPointReqFormat: SexpFormat[DocUriAtPointReq] = { def DocUriAtPointReqFormat = ???; implicitly[SexpFormat[DocUriAtPointReq]] }
-  implicit def DocUriForSymbolReqFormat: SexpFormat[DocUriForSymbolReq] = { def DocUriForSymbolReqFormat = ???; implicitly[SexpFormat[DocUriForSymbolReq]] }
   implicit def CompletionsReqFormat: SexpFormat[CompletionsReq] = { def CompletionsReqFormat = ???; implicitly[SexpFormat[CompletionsReq]] }
-  implicit def PackageMemberCompletionReqFormat: SexpFormat[PackageMemberCompletionReq] = { def PackageMemberCompletionReqFormat = ???; implicitly[SexpFormat[PackageMemberCompletionReq]] }
   implicit def UsesOfSymbolAtPointReqFormat: SexpFormat[UsesOfSymbolAtPointReq] = { def UsesOfSymbolAtPointReqFormat = ???; implicitly[SexpFormat[UsesOfSymbolAtPointReq]] }
-  implicit def TypeByNameReqFormat: SexpFormat[TypeByNameReq] = { def TypeByNameReqFormat = ???; implicitly[SexpFormat[TypeByNameReq]] }
-  implicit def TypeByNameAtPointReqFormat: SexpFormat[TypeByNameAtPointReq] = { def TypeByNameAtPointReqFormat = ???; implicitly[SexpFormat[TypeByNameAtPointReq]] }
   implicit def TypeAtPointReqFormat: SexpFormat[TypeAtPointReq] = { def TypeAtPointReqFormat = ???; implicitly[SexpFormat[TypeAtPointReq]] }
   implicit def InspectTypeAtPointReqFormat: SexpFormat[InspectTypeAtPointReq] = { def InspectTypeAtPointReqFormat = ???; implicitly[SexpFormat[InspectTypeAtPointReq]] }
-  implicit def InspectTypeByNameReqFormat: SexpFormat[InspectTypeByNameReq] = { def InspectTypeByNameReqFormat = ???; implicitly[SexpFormat[InspectTypeByNameReq]] }
   implicit def SymbolAtPointReqFormat: SexpFormat[SymbolAtPointReq] = { def SymbolAtPointReqFormat = ???; implicitly[SexpFormat[SymbolAtPointReq]] }
-  implicit def SymbolByNameReqFormat: SexpFormat[SymbolByNameReq] = { def SymbolByNameReqFormat = ???; implicitly[SexpFormat[SymbolByNameReq]] }
-  implicit def InspectPackageByPathReqFormat: SexpFormat[InspectPackageByPathReq] = { def InspectPackageByPathReqFormat = ???; implicitly[SexpFormat[InspectPackageByPathReq]] }
   implicit def RefactorReqFormat: SexpFormat[RefactorReq] = { def RefactorReqFormat = ???; implicitly[SexpFormat[RefactorReq]] }
   implicit def SymbolDesignationsReqFormat: SexpFormat[SymbolDesignationsReq] = { def SymbolDesignationsReqFormat = ???; implicitly[SexpFormat[SymbolDesignationsReq]] }
   implicit def ImplicitInfoReqFormat: SexpFormat[ImplicitInfoReq] = { def ImplicitInfoReqFormat = ???; implicitly[SexpFormat[ImplicitInfoReq]] }
@@ -833,18 +819,11 @@ object SwankProtocolRequest {
           case s if s == PublicSymbolSearchReqHint.hint => value.convertTo[PublicSymbolSearchReq]
           case s if s == ImportSuggestionsReqHint.hint => value.convertTo[ImportSuggestionsReq]
           case s if s == DocUriAtPointReqHint.hint => value.convertTo[DocUriAtPointReq]
-          case s if s == DocUriForSymbolReqHint.hint => value.convertTo[DocUriForSymbolReq]
           case s if s == CompletionsReqHint.hint => value.convertTo[CompletionsReq]
-          case s if s == PackageMemberCompletionReqHint.hint => value.convertTo[PackageMemberCompletionReq]
           case s if s == UsesOfSymbolAtPointReqHint.hint => value.convertTo[UsesOfSymbolAtPointReq]
-          case s if s == TypeByNameReqHint.hint => value.convertTo[TypeByNameReq]
-          case s if s == TypeByNameAtPointReqHint.hint => value.convertTo[TypeByNameAtPointReq]
           case s if s == TypeAtPointReqHint.hint => value.convertTo[TypeAtPointReq]
           case s if s == InspectTypeAtPointReqHint.hint => value.convertTo[InspectTypeAtPointReq]
-          case s if s == InspectTypeByNameReqHint.hint => value.convertTo[InspectTypeByNameReq]
           case s if s == SymbolAtPointReqHint.hint => value.convertTo[SymbolAtPointReq]
-          case s if s == SymbolByNameReqHint.hint => value.convertTo[SymbolByNameReq]
-          case s if s == InspectPackageByPathReqHint.hint => value.convertTo[InspectPackageByPathReq]
           case s if s == RefactorReqHint.hint => value.convertTo[RefactorReq]
           case s if s == SymbolDesignationsReqHint.hint => value.convertTo[SymbolDesignationsReq]
           case s if s == ImplicitInfoReqHint.hint => value.convertTo[ImplicitInfoReq]

--- a/server/src/main/scala/org/ensime/server/RequestHandler.scala
+++ b/server/src/main/scala/org/ensime/server/RequestHandler.scala
@@ -21,7 +21,7 @@ class RequestHandler(
       log.debug(envelope.req.toString)
     envelope.req match {
       // multi-phase queries
-      case DocUriAtPointReq(_, _) | DocUriForSymbolReq(_, _, _) =>
+      case DocUriAtPointReq(_, _) =>
         project ! envelope.req
         context.become(resolveDocSig, discardOld = false)
 


### PR DESCRIPTION
Contentious PR because this removes the support for the Emacs' Inspector feature, which would be better served with a rewrite as per #1787 

The reasons to remove these calls are numerous:

- it relies on using an "all seeing" presentation compiler, which doesn't have a well defined set of compiler parameters
- it is pretty buggy
- it is very very slow on larger projects
- if you navigate to the wrong place, it can just take down the server (I've done this many times, especially the tab complete) and quite often cause Emacs to crash. On Windows, the fix is a reboot, nothing else will do.
- it's existence dramatically complicates #1152 and could mean that it is all our sponsored dev gets to do. That feature is highly sought after by many users and will allow ensime to "just work" on projects that use macros and compiler plugins. Right now, it's the biggest turn-off for people who've tried ensime and got lots of red squigglies, so left.

I am veering towards finishing off this PR and merging, but I am open to being convinced by fans of the Inspector, e.g. @mpollmeier @timcharper (although I really think it's less effort to just implement the same functionality with the graph and / or documentation browser)