### PR TITLE
UsesOfSymbolAtPointReq, do not try to solve symbols from classfiles (#1827)

### DIFF
--- a/core/src/it/scala/org/ensime/intg/BasicWorkflow.scala
+++ b/core/src/it/scala/org/ensime/intg/BasicWorkflow.scala
@@ -340,6 +340,14 @@ class BasicWorkflow extends EnsimeSpec
           expectMsg(VoidResponse)
 
           asyncHelper.expectMsg(FullTypeCheckCompleteEvent)
+
+          //-----------------------------------------------------------------------------------------------
+          // uses of symbol at point with a symbol defined in classfiles
+
+          project ! UsesOfSymbolAtPointReq(Left(fooFile), 162) // point on String.length
+          expectMsgType[ERangePositions].positions shouldBe empty
+
+          asyncHelper.expectMsg(FullTypeCheckCompleteEvent)
           asyncHelper.expectNoMsg(3 seconds)
         }
       }

--- a/core/src/main/scala/org/ensime/core/RichPresentationCompiler.scala
+++ b/core/src/main/scala/org/ensime/core/RichPresentationCompiler.scala
@@ -223,7 +223,11 @@ trait RichCompilerControl extends CompilerControl with RefactoringControl with C
             val source = u.source
             source.map(s => RawFile(Paths.get(new URI(s))))
           }(collection.breakOut)
-          uniqueFiles + RawFile(sym.sourceFile.file.toPath)
+          if (sym.sourceFile != null) {
+            uniqueFiles + RawFile(sym.sourceFile.file.toPath)
+          } else {
+            uniqueFiles
+          }
         }
       }
     }


### PR DESCRIPTION
I am not sure if there is a way to find usages of a symbol coming from classfiles, Intellij IDEA CE is also not able to do this.
This pr only prevents NPEs and returns a empty list as usages.

UsesOfSymbolAtPointReq, do not try to solve symbols from classfiles (#1827)