### PR TITLE
Widen single types when formatting them for display

### DIFF
--- a/core/src/it/scala/org/ensime/core/TypeToScalaNameSpec.scala
+++ b/core/src/it/scala/org/ensime/core/TypeToScalaNameSpec.scala
@@ -205,4 +205,50 @@ class TypeToScalaNameSpec extends EnsimeSpec
       }
   }
 
+  it should "return the full type when asking for the type of the qualifier in a method selection" in withPresCompiler { (config, cc) =>
+    runForPositionInCompiledSource(
+      config, cc,
+      "package com.example",
+      "object Test {",
+      "  val set: Set[(String, String)] = ???",
+      "  s@set@et.toMap",
+      "  def t(set2: Set[(String, String)]) = { se@set2@t2.toMap }",
+      "}"
+    ) { (p, label, cc) =>
+        withClue(label) {
+          val typeResult = cc.askTypeInfoAt(p).getOrElse(fail)
+          typeResult shouldEqual {
+            label match {
+              case "set" =>
+                BasicTypeInfo("Set[(String, String)]", DeclaredAs.Trait, "scala.collection.immutable.Set[(java.lang.String, java.lang.String)]")
+              case "set2" =>
+                BasicTypeInfo("Set[(String, String)]", DeclaredAs.Trait, "scala.collection.immutable.Set[(java.lang.String, java.lang.String)]")
+            }
+          }
+        }
+      }
+  }
+
+  it should "format constant types properly" in withPresCompiler { (config, cc) =>
+    runForPositionInCompiledSource(
+      config, cc,
+      "package com.example",
+      "object Test {",
+      "  1@twelve@2",
+      "  \"he@string@llo\"",
+      "}"
+    ) { (p, label, cc) =>
+        withClue(label) {
+          val typeResult = cc.askTypeInfoAt(p).getOrElse(fail)
+          typeResult shouldEqual {
+            label match {
+              case "twelve" =>
+                BasicTypeInfo("Int(12)", DeclaredAs.Class, "scala.Int(12)")
+              case "string" =>
+                BasicTypeInfo("String(\"hello\")", DeclaredAs.Class, "java.lang.String(\"hello\")")
+            }
+          }
+        }
+      }
+  }
 }

--- a/core/src/main/scala/org/ensime/model/ModelBuilders.scala
+++ b/core/src/main/scala/org/ensime/model/ModelBuilders.scala
@@ -127,8 +127,10 @@ trait ModelBuilders {
     def apply(typ: Type, needPos: PosNeeded = PosNeededNo, members: Iterable[EntityInfo] = List.empty): TypeInfo = {
       val tpe = typ match {
         case et: ExistentialType => et.underlying
+        case s: SingleType => s.widen
         case t => t
       }
+
       def basicTypeInfo(tpe: Type): BasicTypeInfo = {
         val typeSym = tpe.typeSymbol
         val symbolToLocate = if (typeSym.isModuleClass) typeSym.sourceModule else typeSym


### PR DESCRIPTION
Next up in the "scratch your itch" series...

Given the expression `set.toMap`, the tree for the qualifier is of type
`set.type`. This causes the name formatting to drop the type parameters.

This commit widens single types before formatting them for display.

Also added is coverage for formatting of constant types.

Resolves #1860.