### PR TITLE
Add dealiasing fixes when formatting tuples and function types

### DIFF
--- a/core/src/it/scala/org/ensime/core/TypeToScalaNameSpec.scala
+++ b/core/src/it/scala/org/ensime/core/TypeToScalaNameSpec.scala
@@ -264,6 +264,24 @@ class TypeToScalaNameSpec extends EnsimeSpec
       "  val int@intlist@List: IntList = ???",
       "  type IntMap[A] = Map[Int, A]",
       "  val int@intmap@map: IntMap[Int] = ???",
+      "  type Env[E, A] = (E, A)",
+      "  val en@env@v: Env[String, Int] = ???",
+      "  type StringEnv[A] = Env[String, A]",
+      "  val string@stringenv@env: StringEnv[Int] = ???",
+      "  type EnvT[E, F[_], A] = (E, F[A])",
+      "  val maybe@maybeenv@env: EnvT[String, Option, String] = ???",
+      "  type MaybeStringEnv[A] = EnvT[String, Option, A]",
+      "  val maybe@maybestringenv@stringenv: MaybeStringEnv[Int] = ???",
+      "  type Arrow[A, B] = A => B",
+      "  val intString@intstringarrow@Arrow: Arrow[Int, String] = ???",
+      "  type Kleisli[F[_], A, B] = A => F[B]",
+      "  val intOption@intoptionstring@String: Kleisli[Option, Int, String] = ???",
+      "  type IntReader[A] = Int => A",
+      "  val int@intreader@reader: IntReader[String] = ???",
+      "  type IntArrow[A] = Arrow[Int, A]",
+      "  val int@intarrow@arrow: IntArrow[String] = ???",
+      "  type IntKleisli[F[_], A] = Kleisli[F, Int, A]",
+      "  val int@intkleisli@kleisli: IntKleisli[Option, String] = ???",
       "}"
     ) { (p, label, cc) =>
         withClue(label) {
@@ -276,6 +294,26 @@ class TypeToScalaNameSpec extends EnsimeSpec
                 BasicTypeInfo("IntList", DeclaredAs.Nil, "com.example.TypeAliases.IntList")
               case "intmap" =>
                 BasicTypeInfo("IntMap[Int]", DeclaredAs.Nil, "com.example.TypeAliases.IntMap[scala.Int]")
+              case "env" =>
+                BasicTypeInfo("Env[String, Int]", DeclaredAs.Nil, "com.example.TypeAliases.Env[java.lang.String, scala.Int]")
+              case "stringenv" =>
+                BasicTypeInfo("StringEnv[Int]", DeclaredAs.Nil, "com.example.TypeAliases.StringEnv[scala.Int]")
+              case "maybeenv" =>
+                BasicTypeInfo("EnvT[String, Option, String]", DeclaredAs.Nil,
+                  "com.example.TypeAliases.EnvT[java.lang.String, scala.Option, java.lang.String]")
+              case "maybestringenv" =>
+                BasicTypeInfo("MaybeStringEnv[Int]", DeclaredAs.Nil,
+                  "com.example.TypeAliases.MaybeStringEnv[scala.Int]")
+              case "intstringarrow" =>
+                BasicTypeInfo("Arrow[Int, String]", DeclaredAs.Nil, "com.example.TypeAliases.Arrow[scala.Int, java.lang.String]")
+              case "intoptionstring" =>
+                BasicTypeInfo("Kleisli[Option, Int, String]", DeclaredAs.Nil, "com.example.TypeAliases.Kleisli[scala.Option, scala.Int, java.lang.String]")
+              case "intreader" =>
+                BasicTypeInfo("IntReader[String]", DeclaredAs.Nil, "com.example.TypeAliases.IntReader[java.lang.String]")
+              case "intarrow" =>
+                BasicTypeInfo("IntArrow[String]", DeclaredAs.Nil, "com.example.TypeAliases.IntArrow[java.lang.String]")
+              case "intkleisli" =>
+                BasicTypeInfo("IntKleisli[Option, String]", DeclaredAs.Nil, "com.example.TypeAliases.IntKleisli[scala.Option, java.lang.String]")
             }
           }
         }

--- a/core/src/main/scala/org/ensime/core/Helpers.scala
+++ b/core/src/main/scala/org/ensime/core/Helpers.scala
@@ -30,9 +30,11 @@ trait Helpers { self: Global =>
     members.toList.filter { _.isConstructor }
   }
 
-  def isArrowType(tpe: Type): Boolean = {
+  def isArrowType(tpe: Type, shouldDealias: Boolean = true): Boolean = {
+    val typeSym = if (shouldDealias) tpe.typeSymbol else tpe.typeSymbolDirect
+
     tpe match {
-      case args: ArgsTypeRef if args.typeSymbol.fullName.startsWith("scala.Function") => true
+      case args: ArgsTypeRef if typeSym.fullName.startsWith("scala.Function") => true
       case TypeRef(_, definitions.ByNameParamClass, _) => true
       case _: MethodType => true
       case _: PolyType => true

--- a/core/src/main/scala/org/ensime/core/TypeToScalaName.scala
+++ b/core/src/main/scala/org/ensime/core/TypeToScalaName.scala
@@ -16,60 +16,64 @@ final class ScalaName(val underlying: String) extends AnyVal {
 trait TypeToScalaName { self: Global with Helpers =>
   import definitions._
 
-  def scalaName(tpe: Type, full: Boolean, shouldDealias: Boolean = true): ScalaName = tpe match {
-    case _: MethodType | _: PolyType =>
-      val tparams = tpe.paramss.map { sect =>
-        sect.map { p => scalaName(p.tpe, full).underlying }.mkString("(", ", ", ")")
-      }.mkString(" => ")
-      new ScalaName(tparams) + " => " + scalaName(tpe.finalResultType, full).underlying
+  def scalaName(tpe: Type, full: Boolean, shouldDealias: Boolean = true): ScalaName = {
+    val typeSymbol = if (shouldDealias) tpe.typeSymbol else tpe.typeSymbolDirect
 
-    case args: ArgsTypeRef if args.typeSymbol.fullName.startsWith("scala.Function") =>
-      val parts = tpe.typeArgs.map(scalaName(_, full).underlying)
-      new ScalaName(parts.init.mkString("(", ", ", ")")) + " => " + parts.last
+    tpe match {
+      case _: MethodType | _: PolyType =>
+        val tparams = tpe.paramss.map { sect =>
+          sect.map { p => scalaName(p.tpe, full).underlying }.mkString("(", ", ", ")")
+        }.mkString(" => ")
+        new ScalaName(tparams) + " => " + scalaName(tpe.finalResultType, full).underlying
 
-    case args: ArgsTypeRef if args.typeSymbol.fullName.startsWith("scala.Tuple") =>
-      val parts = tpe.typeArgs.map(scalaName(_, full).underlying)
-      new ScalaName(parts.mkString("(", ", ", ")"))
+      case args: ArgsTypeRef if typeSymbol.fullName.startsWith("scala.Function") =>
+        val parts = tpe.typeArgs.map(scalaName(_, full).underlying)
+        new ScalaName(parts.init.mkString("(", ", ", ")")) + " => " + parts.last
 
-    case args: ArgsTypeRef if args.typeSymbol.decodedName.forall(!_.isLetterOrDigit) =>
-      val parts = tpe.typeArgs.map(scalaName(_, full).underlying)
-      val name =
-        if (full) tpe.typeSymbol.fullNameString
-        else tpe.typeSymbol.nameString
+      case args: ArgsTypeRef if typeSymbol.fullName.startsWith("scala.Tuple") =>
+        val parts = tpe.typeArgs.map(scalaName(_, full).underlying)
+        new ScalaName(parts.mkString("(", ", ", ")"))
 
-      new ScalaName(parts.init.mkString(" ")) + s" $name ${parts.last}"
-
-    case TypeRef(_, RepeatedParamClass | JavaRepeatedParamClass, typeArgs) =>
-      // Safe to assume that args is of length 1 as repeated params means Seq[args]
-      val parts = typeArgs.map(scalaName(_, full).underlying)
-      new ScalaName(parts.mkString + "*")
-
-    case TypeRef(_, ByNameParamClass, typeArgs) =>
-      val parts = typeArgs.map(scalaName(_, full).underlying)
-      new ScalaName(s"=> ${parts.mkString}")
-
-    case _ =>
-      val name = tpe match {
-        case c: ConstantType =>
-          scalaName(c.underlying, full).underlying + "(" + c.value.escapedStringValue + ")"
-        case r: RefinedType =>
-          r.parents.map(scalaName(_, full).underlying).mkString(" with ")
-
-        case a: AliasTypeRef if !shouldDealias =>
-          if (full) tpe.typeSymbolDirect.fullNameString
-          else tpe.typeSymbolDirect.nameString
-
-        case _ =>
+      case args: ArgsTypeRef if typeSymbol.decodedName.forall(!_.isLetterOrDigit) =>
+        val parts = tpe.typeArgs.map(scalaName(_, full).underlying)
+        val name =
           if (full) tpe.typeSymbol.fullNameString
           else tpe.typeSymbol.nameString
-      }
 
-      new ScalaName(name) + {
-        val typeArgs = if (shouldDealias) tpe.dealias.typeArgs else tpe.typeArgs
+        new ScalaName(parts.init.mkString(" ")) + s" $name ${parts.last}"
 
-        if (typeArgs.isEmpty) ""
-        else typeArgs.map(scalaName(_, full).underlying).mkString("[", ", ", "]")
-      }
+      case TypeRef(_, RepeatedParamClass | JavaRepeatedParamClass, typeArgs) =>
+        // Safe to assume that args is of length 1 as repeated params means Seq[args]
+        val parts = typeArgs.map(scalaName(_, full).underlying)
+        new ScalaName(parts.mkString + "*")
+
+      case TypeRef(_, ByNameParamClass, typeArgs) =>
+        val parts = typeArgs.map(scalaName(_, full).underlying)
+        new ScalaName(s"=> ${parts.mkString}")
+
+      case _ =>
+        val name = tpe match {
+          case c: ConstantType =>
+            scalaName(c.underlying, full).underlying + "(" + c.value.escapedStringValue + ")"
+          case r: RefinedType =>
+            r.parents.map(scalaName(_, full).underlying).mkString(" with ")
+
+          case a: AliasTypeRef if !shouldDealias =>
+            if (full) tpe.typeSymbolDirect.fullNameString
+            else tpe.typeSymbolDirect.nameString
+
+          case _ =>
+            if (full) tpe.typeSymbol.fullNameString
+            else tpe.typeSymbol.nameString
+        }
+
+        new ScalaName(name) + {
+          val typeArgs = if (shouldDealias) tpe.dealias.typeArgs else tpe.typeArgs
+
+          if (typeArgs.isEmpty) ""
+          else typeArgs.map(scalaName(_, full).underlying).mkString("[", ", ", "]")
+        }
+    }
   }
 
   def fullName(tpe: Type, shouldDealias: Boolean = true): ScalaName = scalaName(tpe, full = true, shouldDealias = shouldDealias)

--- a/core/src/main/scala/org/ensime/model/ModelBuilders.scala
+++ b/core/src/main/scala/org/ensime/model/ModelBuilders.scala
@@ -143,9 +143,9 @@ trait ModelBuilders {
         case t => t
       }
 
-      def basicTypeInfo(tpe: Type): BasicTypeInfo = {
-        val shouldDealias = shouldDealiasType(tpe)
+      val shouldDealias = shouldDealiasType(tpe)
 
+      def basicTypeInfo(tpe: Type): BasicTypeInfo = {
         val typeSym = if (shouldDealias) tpe.typeSymbol else tpe.typeSymbolDirect
         val symbolToLocate = if (typeSym.isModuleClass) typeSym.sourceModule else typeSym
         val symPos = locateSymbolPos(symbolToLocate, needPos)
@@ -162,7 +162,7 @@ trait ModelBuilders {
         )
       }
       tpe match {
-        case arrow if isArrowType(arrow) => ArrowTypeInfoBuilder(tpe)
+        case arrow if isArrowType(arrow, shouldDealias) => ArrowTypeInfoBuilder(tpe)
         case tpe: NullaryMethodType => basicTypeInfo(tpe.resultType)
         case tpe: Type => basicTypeInfo(tpe)
         case _ => nullInfo


### PR DESCRIPTION
This commit fixes two issues:
- when formatting type aliases pointing to tuples, dealiasing is
  avoided by using typeSymbolDirect when testing if the type's full
  name starts with `Tuple`.
- when formatting type aliases pointing to function types, dealiasing
  is similarly avoided in isArrowType.

Resolves #1866.