### PR TITLE
Convert the SearchService to use FS2

### DIFF
--- a/core/src/it/scala/org/ensime/core/JavaCompilerSpec.scala
+++ b/core/src/it/scala/org/ensime/core/JavaCompilerSpec.scala
@@ -2,6 +2,7 @@
 // License: http://www.gnu.org/licenses/gpl-3.0.en.html
 package org.ensime.core
 
+import fs2.Strategy
 import org.ensime.api, api.{ BasicTypeInfo => _, _ }
 import org.ensime.fixture._
 import org.ensime.indexer.SearchServiceTestUtils._
@@ -19,6 +20,9 @@ class JavaCompilerSpec
 
   val original                   = EnsimeConfigFixture.SimpleTestProject.copy(javaSources = Nil)
   override def usePreWarmedIndex = false
+  implicit val strategy: Strategy = Strategy.fromExecutionContext(
+    scala.concurrent.ExecutionContext.Implicits.global
+  )
 
   // NOTE: we're intentionally removing the pre-indexing support so
   // that we don't have javaSources here, because they break
@@ -103,7 +107,7 @@ class JavaCompilerSpec
 
   it should "find symbol at point" in withJavaCompiler {
     (_, config, cc, store, search) =>
-      refresh()(search)
+      refresh()(search, strategy)
 
       runForPositionInCompiledSource(
         config,

--- a/core/src/main/scala/org/ensime/core/debug/SourceMap.scala
+++ b/core/src/main/scala/org/ensime/core/debug/SourceMap.scala
@@ -2,12 +2,16 @@
 // License: http://www.gnu.org/licenses/gpl-3.0.en.html
 package org.ensime.core.debug
 
+import fs2.Strategy
 import java.io.File
 import org.ensime.api._
 import org.ensime.indexer.SearchService
 import org.ensime.util.ensimefile._
 
 object SourceMap {
+  implicit val strategy: Strategy = Strategy.fromExecutionContext(
+    scala.concurrent.ExecutionContext.Implicits.global
+  )
 
   // WORKAROUND: https://github.com/ensime/scala-debugger/issues/344
   //             aka Windows uses \, not /
@@ -16,6 +20,7 @@ object SourceMap {
   // the class package name and the source file from the debug)
   def fromJdi(jdi: String)(implicit s: SearchService): Option[EnsimeFile] =
     s.findClasses(jdi.replace('\\', '/'))
+      .unsafeRun()
       .flatMap(_.source)
       .map(EnsimeFile)
       .headOption
@@ -24,6 +29,7 @@ object SourceMap {
   // scala-debugger's representation (the/package/File.scala)
   def toJdi(file: EnsimeFile)(implicit s: SearchService): Option[String] =
     s.findClasses(file)
+      .unsafeRun()
       .flatMap(_.jdi)
       .headOption
       .map(_.replace('/', File.separatorChar))

--- a/core/src/main/scala/org/ensime/core/javac/JavaCompiler.scala
+++ b/core/src/main/scala/org/ensime/core/javac/JavaCompiler.scala
@@ -14,6 +14,7 @@ import akka.event.slf4j.SLF4JLogging
 import com.sun.source.tree.Scope
 import com.sun.source.util.{ JavacTask, TreePath }
 import com.sun.tools.javac.util.Abort
+import fs2.Strategy
 import javax.tools._
 import org.ensime.api._
 import org.ensime.core.DocSigPair
@@ -38,6 +39,9 @@ class JavaCompiler(
     with Helpers
     with SLF4JLogging {
 
+  implicit val strategy = Strategy.fromExecutionContext(
+    scala.concurrent.ExecutionContext.Implicits.global
+  )
   private val listener   = new JavaDiagnosticListener()
   private val silencer   = new SilencedDiagnosticListener()
   private val cp         = config.classpath.mkString(JFile.pathSeparator)

--- a/core/src/main/scala/org/ensime/core/javac/JavaSourceFinding.scala
+++ b/core/src/main/scala/org/ensime/core/javac/JavaSourceFinding.scala
@@ -4,6 +4,7 @@ package org.ensime.core.javac
 
 import akka.event.slf4j.SLF4JLogging
 import com.sun.source.util.TreePath
+import fs2.Strategy
 import javax.lang.model.element.Element
 
 import org.ensime.api._
@@ -14,6 +15,7 @@ import org.ensime.indexer.SearchService
 import org.ensime.indexer.FullyQualifiedName
 
 trait JavaSourceFinding extends Helpers with SLF4JLogging {
+  implicit def strategy: Strategy
 
   def askLinkPos(fqn: FullyQualifiedName,
                  file: SourceFileInfo): Option[SourcePosition]
@@ -51,7 +53,7 @@ trait JavaSourceFinding extends Helpers with SLF4JLogging {
                             path: TreePath): Option[SourcePosition] = {
     val javaFqn = fqn(c, path)
     val query   = javaFqn.map(_.fqnString).getOrElse("")
-    val hit     = search.findUnique(query)
+    val hit     = search.findUnique(query).unsafeRun()
     if (log.isTraceEnabled())
       log.trace(s"search: '$query' = $hit")
     hit.flatMap(LineSourcePositionHelper.fromFqnSymbol(_)(vfs)).flatMap {

--- a/core/src/main/scala/org/ensime/indexer/SearchService.scala
+++ b/core/src/main/scala/org/ensime/indexer/SearchService.scala
@@ -504,6 +504,8 @@ class SearchService(
     val dwork = Task.fromFuture(db.removeFiles(files))
 
     for {
+      iwork    <- Task.start(iwork)
+      dwork    <- Task.start(dwork)
       _        <- iwork
       removals <- dwork
     } yield removals

--- a/core/src/main/scala/org/ensime/indexer/SearchService.scala
+++ b/core/src/main/scala/org/ensime/indexer/SearchService.scala
@@ -281,7 +281,7 @@ class SearchService(
     file match {
       case classfile if classfile.getName.getExtension == "class" =>
         Stream
-          .bracket(Task.now((grouped(classfile.getName), classfile)))(
+          .bracket(Task.delay((grouped(classfile.getName), classfile)))(
             {
               case (files, classfile) =>
                 Stream.eval(extractSymbols(classfile, files, classfile))

--- a/core/src/main/scala/org/ensime/model/ModelBuilders.scala
+++ b/core/src/main/scala/org/ensime/model/ModelBuilders.scala
@@ -2,6 +2,8 @@
 // License: http://www.gnu.org/licenses/gpl-3.0.en.html
 package org.ensime.model
 
+import fs2.Strategy
+
 import org.ensime.api
 import org.ensime.api._
 import org.ensime.core.{ FqnToSymbol, RichPresentationCompiler }
@@ -16,6 +18,7 @@ import scala.reflect.internal.util.{ NoPosition, Position }
 
 trait ModelBuilders {
   self: RichPresentationCompiler with FqnToSymbol =>
+  implicit def strategy: Strategy
 
   def locateSymbolPos(sym: Symbol, needPos: PosNeeded): Option[SourcePosition] =
     _locateSymbolPos(sym, needPos).orElse({
@@ -40,7 +43,7 @@ trait ModelBuilders {
         val fqn = toFqn(sym).fqnString
         logger.debug(s"$sym ==> $fqn")
 
-        val hit = search.findUnique(fqn)
+        val hit = search.findUnique(fqn).unsafeRun()
         logger.debug(s"search: $fqn = $hit")
         hit.flatMap(LineSourcePositionHelper.fromFqnSymbol(_)(vfs)).flatMap {
           sourcePos =>

--- a/project/EnsimeBuild.scala
+++ b/project/EnsimeBuild.scala
@@ -32,6 +32,8 @@ object ProjectPlugin extends AutoPlugin {
     scalafmtConfig in ThisBuild := file("project/scalafmt.conf"),
     scalafmtVersion in ThisBuild := "1.3.0",
 
+    logBuffered in Test := true,
+
     sonatypeGithub := ("ensime", "ensime-server"),
     licenses := Seq(GPL3),
     startYear := Some(2010)

--- a/project/EnsimeBuild.scala
+++ b/project/EnsimeBuild.scala
@@ -195,6 +195,7 @@ object EnsimeBuild {
         "org.scala-lang" % "scalap" % scalaVersion.value,
         "com.typesafe.akka" %% "akka-actor" % akkaVersion,
         "com.typesafe.akka" %% "akka-slf4j" % akkaVersion,
+        "co.fs2" %% "fs2-core" % "0.9.7",
         {
           // see notes in https://github.com/ensime/ensime-server/pull/1446
           val suffix = CrossVersion.partialVersion(scalaVersion.value) match {


### PR DESCRIPTION
Resolves #1756.

Summary of the changes:
- Added a dependency on fs2 0.9.7 (would love to use 0.10 but that means using cats - we need to decide separately)
- SearchService has been split up into three parts:
   - The plain request/response methods stay in `SearchService` - `search*`, `persist`, `delete`, etc.
    - The actor that managed the indexing is now gone and replaced with `IndexStream` - an FS2 stream that is fed via an `fs2.async.mutable.Queue` and manages the indexing in the same manner
    - The file change listener is replaced by a method on `IndexStream` that returns a listener that is hooked up to the stream's input queue

Other changes:
- The SearchService API has been converted to use `Task`. I'd love to do something more parametric in the effect type, but we need to discuss use of an FP library for that.
- The above change led to a lot of `.unsafe*` calls across the code. I think this is a good path that we can follow to continue converting more parts of the code to be safer.
- We need to pass around an fs2.Scheduler (this is gone in 0.10 of fs2), an fs2.Strategy (for various FS2 stuff) and an ExecutionContext (for suspending Futures into Tasks). We'll get rid of the execution contexts eventually.