### PR TITLE
Support file names with '%' characters

### DIFF
--- a/util/src/main/scala/org/ensime/util/ensimefile.scala
+++ b/util/src/main/scala/org/ensime/util/ensimefile.scala
@@ -41,11 +41,11 @@ package object ensimefile {
     implicit val DefaultCharset: Charset = Charset.defaultCharset()
   }
 
-  private val ArchiveRegex = "(?:(?:jar:)?file:)?([^!]++)!(.++)".r
-  private val FileRegex = "(?:(?:jar:)?file:)?(.++)".r
+  private val ArchiveRegex = "((?:jar:)?file:)?([^!]++)!(.++)".r
+  private val FileRegex = "((?:jar:)?file:)?(.++)".r
   def EnsimeFile(path: String): EnsimeFile = path match {
-    case ArchiveRegex(file, entry) => ArchiveFile(Paths.get(cleanBadWindows(file)), entry)
-    case FileRegex(file) => RawFile(Paths.get(cleanBadWindows(file)))
+    case ArchiveRegex(urlPart, file, entry) => ArchiveFile(stringToPath(file, Option(urlPart).isDefined), entry)
+    case FileRegex(urlPart, file) => RawFile(stringToPath(file, Option(urlPart).isDefined))
   }
   def EnsimeFile(path: File): EnsimeFile = RawFile(path.toPath)
   def EnsimeFile(url: URL): EnsimeFile = EnsimeFile(URLDecoder.decode(url.toExternalForm(), "UTF-8"))
@@ -55,6 +55,11 @@ package object ensimefile {
   private def cleanBadWindows(file: String): String = file match {
     case BadWindowsRegex(clean) => clean
     case other => other
+  }
+
+  private def stringToPath(file: String, isUrl: Boolean): Path = {
+    val decodedFile = if (isUrl) URLDecoder.decode(file, "UTF-8") else file
+    Paths.get(cleanBadWindows(decodedFile))
   }
 
   implicit class RichRawFile(val raw: RawFile) extends RichEnsimeFile {

--- a/util/src/main/scala/org/ensime/util/ensimefile.scala
+++ b/util/src/main/scala/org/ensime/util/ensimefile.scala
@@ -57,9 +57,18 @@ package object ensimefile {
     case other => other
   }
 
-  private def stringToPath(file: String, isUrl: Boolean): Path = {
-    val decodedFile = if (isUrl) URLDecoder.decode(file, "UTF-8") else file
-    Paths.get(cleanBadWindows(decodedFile))
+  private def getUriPath(uri: String): String = {
+    try {
+      new URI(cleanBadWindows(uri)).getPath
+    } catch {
+      case e: URISyntaxException => cleanBadWindows(uri)
+    }
+  }
+
+  private def stringToPath(file: String, isUri: Boolean): Path = {
+    val decodedFile = if (isUri) getUriPath(file) else cleanBadWindows(file)
+    val result = Paths.get(decodedFile)
+    result
   }
 
   implicit class RichRawFile(val raw: RawFile) extends RichEnsimeFile {

--- a/util/src/main/scala/org/ensime/util/ensimefile.scala
+++ b/util/src/main/scala/org/ensime/util/ensimefile.scala
@@ -59,7 +59,7 @@ package object ensimefile {
 
   private def getUriPath(uri: String): String = {
     try {
-      new URI(cleanBadWindows(uri)).getPath
+      new URI(uri).getPath
     } catch {
       case e: URISyntaxException => cleanBadWindows(uri)
     }

--- a/util/src/test/scala/org/ensime/util/EnsimeFileSpec.scala
+++ b/util/src/test/scala/org/ensime/util/EnsimeFileSpec.scala
@@ -54,6 +54,12 @@ class EnsimeFileSpec extends FlatSpec with Matchers {
     EnsimeFile(url) shouldBe RawFile(Paths.get(file))
   }
 
+  it should "support urls containing '%' character" in {
+    val fileName = "/my/coursier/path/user%40repository/mylib.jar"
+    val fileUri = new File(fileName).toURI
+    EnsimeFile(fileUri.toString).uri shouldBe fileUri
+  }
+
   "RichRawFile" should "support isJava / isScala" in {
     RawFile(Paths.get("/foo/bar/baz.scala")).isScala shouldBe true
     RawFile(Paths.get("/foo/bar/baz.java")).isJava shouldBe true


### PR DESCRIPTION
Current EnsimeFile implementation handles url as file path, just removing the 'file://' part.
But urls can be encoded, '%' characters are converted to '%25', and this is ignored by the EnsimeFile constructor.
If your file contains a '%' in it's name, ensime will search for a file path with '%25' that does not exists.

This add a test case that shows the problem. I'm trying to get a proper fix for the 2.0 branch (ie without switching everything to java.nio)