### PR TITLE
Recover when indexing a single class fails (#1912)

### DIFF
--- a/testing/simple/.gitignore
+++ b/testing/simple/.gitignore
@@ -1,0 +1,1 @@
+!/target/scala*/classes/bad/Bad.class

--- a/testing/simple/target/scala-2.12/classes/bad/Bad.class
+++ b/testing/simple/target/scala-2.12/classes/bad/Bad.class
@@ -1,0 +1,1 @@
+This is so totally not a real class file.


### PR DESCRIPTION
... I realize the way I'm just shoving `Bad.class` under `target` is very awkward and brittle, and also isn't really "a test", _per se_. I'm very open to ideas.

Main diff is mostly whitespace, I'm afraid. In a nutshell the real change is

```
<big chunk of code>
```

to
```
Try {
  <big chunk of code>
} fold ( <deal with exception>, <no op> )
```
