### PR TITLE
FileWatchService using sensitive watch event modifier, and a bit of refactoring.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,6 @@ script:
   - export JAVA_HOME=$(/usr/libexec/java_home)
   - curl https://raw.githubusercontent.com/paulp/sbt-extras/master/sbt -o sbt ; chmod 755 sbt
   - ./sbt ++$SCALA_VERSION! ";prep ;cpl"
-  - if [ -n "$TRAVIS_PULL_REQUEST" ] ; then cd testing/cache && ../../sbt ++$SCALA_VERSION ensimeConfig ensimeServerIndex && cd ../.. ; fi
   - if [ -n "$TRAVIS_PULL_REQUEST" ] ; then ./sbt ++$SCALA_VERSION! "testOnly -- -l tags.IgnoreOnTravis" ; fi
   - if [ -n "$TRAVIS_PULL_REQUEST" ] ; then SBT_TASK_LIMIT=2 ./sbt ++$SCALA_VERSION! "it:testOnly -- -l tags.IgnoreOnTravis" ; fi
   - rm -rf $HOME/.coursier/cache/v1/https/oss.sonatype.org

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ script:
   - export JAVA_HOME=$(/usr/libexec/java_home)
   - curl https://raw.githubusercontent.com/paulp/sbt-extras/master/sbt -o sbt ; chmod 755 sbt
   - ./sbt ++$SCALA_VERSION! ";prep ;cpl"
+  - if [ -n "$TRAVIS_PULL_REQUEST" ] ; then cd testing/cache && ../../sbt ++$SCALA_VERSION ensimeConfig ensimeServerIndex && cd ../.. ; fi
   - if [ -n "$TRAVIS_PULL_REQUEST" ] ; then ./sbt ++$SCALA_VERSION! "testOnly -- -l tags.IgnoreOnTravis" ; fi
   - if [ -n "$TRAVIS_PULL_REQUEST" ] ; then SBT_TASK_LIMIT=2 ./sbt ++$SCALA_VERSION! "it:testOnly -- -l tags.IgnoreOnTravis" ; fi
   - rm -rf $HOME/.coursier/cache/v1/https/oss.sonatype.org

--- a/build.sbt
+++ b/build.sbt
@@ -208,7 +208,7 @@ TaskKey[Unit](
   // would be good to be able to do this without exiting the JVM...
   val sv = scalaVersion.value
   val cmd =
-    if (sys.env.contains("APPVEYOR")) """C:\sbt\bin\sbt.bat""" else "sbt"
+    if (sys.env.contains("APPVEYOR")) """C:\sbt\bin\sbt.bat""" else "../../sbt"
   sys.process
     .Process(
       Seq(cmd, s"++$sv!", "ensimeConfig", "ensimeServerIndex"),

--- a/core/src/main/scala/org/ensime/filewatcher/FileWatchService.scala
+++ b/core/src/main/scala/org/ensime/filewatcher/FileWatchService.scala
@@ -10,7 +10,6 @@ import com.sun.nio.file.SensitivityWatchEventModifier
 import java.util.UUID
 import org.slf4j.LoggerFactory
 
-import scala.annotation.tailrec
 import scala.collection.JavaConverters._
 import scala.collection.immutable.Set
 import scala.language.implicitConversions

--- a/core/src/main/scala/org/ensime/filewatcher/FileWatchService.scala
+++ b/core/src/main/scala/org/ensime/filewatcher/FileWatchService.scala
@@ -3,21 +3,17 @@
 package org.ensime.filewatcher
 
 import java.io._
-import java.nio.file.{ FileSystems, Path, WatchKey }
 import java.nio.file.StandardWatchEventKinds._
-import java.nio.file.WatchService
+import java.nio.file.{FileSystems, Path, WatchKey, WatchService}
 import java.util.UUID
-import java.util.concurrent.ConcurrentHashMap
 
-import scala.annotation.tailrec
+import org.slf4j.LoggerFactory
+
 import scala.collection.JavaConverters._
-import scala.collection.concurrent.Map
 import scala.collection.immutable.Set
 import scala.language.implicitConversions
 import scala.util.control.NonFatal
-import scala.util.{ Failure, Properties, Success, Try }
-
-import org.slf4j.LoggerFactory
+import scala.util.{Failure, Properties, Success, Try}
 
 abstract class Watcher(val watcherId: UUID,
                        val file: File,
@@ -27,40 +23,13 @@ abstract class Watcher(val watcherId: UUID,
     fileWatchService.watch(file, listeners, false)
 
   def shutdown(): Unit = {
-    fileWatchService.WatchKeyManager.removeObservers(watcherId)
+    WatchKeyManager.removeObservers(watcherId)
     fileWatchService.monitorThread.foreach { thread =>
       thread.interrupt()
     }
   }
 }
 
-trait WatcherListener {
-  val base: File
-  val recursive: Boolean
-  val extensions: scala.collection.Set[String]
-  val watcherId: UUID
-
-  def fileCreated(@deprecated("local", "") f: File): Unit  = {}
-  def fileDeleted(@deprecated("local", "") f: File): Unit  = {}
-  def fileModified(@deprecated("local", "") f: File): Unit = {}
-
-  def baseRegistered(): Unit                                       = {}
-  def baseRemoved(): Unit                                          = {}
-  def baseSubdirRemoved(@deprecated("local", "") f: File): Unit    = {}
-  def missingBaseRegistered(): Unit                                = {}
-  def baseSubdirRegistered(@deprecated("local", "") f: File): Unit = {}
-  def proxyRegistered(@deprecated("local", "") f: File): Unit      = {}
-
-  def existingFile(@deprecated("local", "") f: File): Unit = {}
-
-  def isWatched(f: File) =
-    (extensions.exists(e => {
-      f.getName.endsWith(e)
-    })) && f.getPath.startsWith(base.getPath)
-
-  def isBaseAncestor(f: File) =
-    base.getAbsolutePath.startsWith(f.getAbsolutePath)
-}
 
 // tested in FileWatcherSpec
 class FileWatchService { self =>
@@ -227,7 +196,7 @@ class FileWatchService { self =>
       if (WatchKeyManager.hasProxy(key))
         dir.listFiles
           .filter(f => (f.isDirectory || f.isFile))
-          .foreach(WatchKeyManager.maybeAdvanceProxy(key, _))
+          .foreach(WatchKeyManager.maybeAdvanceProxy(key, _)(this))
 
     } else
       log.warn("No listeners for {}. Skip registration.")
@@ -277,7 +246,7 @@ class FileWatchService { self =>
           watch(file, WatchKeyManager.recListeners(key), false)
 
         if (kind == ENTRY_CREATE)
-          WatchKeyManager.maybeAdvanceProxy(key, file)
+          WatchKeyManager.maybeAdvanceProxy(key, file)(this)
 
         val ls = WatchKeyManager.nonProxyListeners(key)
 
@@ -399,212 +368,4 @@ class FileWatchService { self =>
 
   init()
 
-  case class BaseObserver(val watcherListener: WatcherListener)
-      extends WatchKeyObserver {
-    override lazy val recursive = watcherListener.recursive
-    override val observerType   = "BaseObserver"
-  }
-  case class BaseFileObserver(val watcherListener: WatcherListener)
-      extends WatchKeyObserver {
-    val treatExistingAsNew    = true
-    val recursive             = false
-    override val observerType = "BaseFileObserver"
-  }
-  case class ProxyObserver(val watcherListener: WatcherListener)
-      extends WatchKeyObserver {
-    val recursive             = false
-    override val observerType = "ProxyObserver"
-  }
-  case class BaseSubdirObserver(val watcherListener: WatcherListener)
-      extends WatchKeyObserver {
-    override lazy val recursive = watcherListener.recursive
-    override val observerType   = "BaseSubdirObserver"
-  }
-
-  trait WatchKeyObserver {
-    val watcherListener: WatcherListener
-    val recursive: Boolean
-    val observerType: String
-  }
-
-  object WatchKeyManager {
-    val keymap: Map[WatchKey, Set[WatchKeyObserver]] =
-      new ConcurrentHashMap().asScala
-
-    def contains(key: WatchKey) =
-      keymap.contains(key)
-
-    @tailrec
-    def addObserver(key: WatchKey, o: WatchKeyObserver): Unit = {
-      val l            = Set[WatchKeyObserver]()
-      val oldListeners = keymap.putIfAbsent(key, l).getOrElse(l)
-      val newListeners = oldListeners + o
-      val status       = keymap.replace(key, oldListeners, newListeners)
-      if (!status) {
-        log.warn(s"retry adding ${o.observerType} to ${keyToFile(key)}")
-        addObserver(key, o)
-      }
-    }
-
-    @tailrec
-    def removeObserver(key: WatchKey,
-                       o: WatchKeyObserver,
-                       retry: Int = 2): Unit =
-      keymap.get(key) match {
-        case Some(oldObservers) => {
-          val newObservers = oldObservers - o
-          if (newObservers.isEmpty) {
-            keymap.remove(key)
-            key.cancel()
-          } else if (!keymap.replace(key, oldObservers, newObservers))
-            if (retry > 0)
-              removeObserver(key, o)
-            else
-              log.warn("unable to remove an observer from {}", keyToFile(key))
-        }
-        case None => log.warn(s"watcher doesn't monitor ${keyToFile(key)}")
-      }
-
-    def maybeAdvanceProxy(key: WatchKey, createdFile: File) =
-      proxies(key) foreach (
-        o =>
-          if (o.watcherListener.isBaseAncestor(createdFile))
-            if (createdFile.isDirectory || createdFile.isFile) {
-              removeObserver(key, o)
-              watch(createdFile, Set(o.watcherListener), true)
-            } else
-              log.warn("unable to advance a proxy {}", o)
-      )
-
-    def removeObservers(id: UUID) =
-      keymap.keys foreach (
-        key => {
-          val observers = keymap.get(key).getOrElse { Set() }
-          val unneeded  = observers filter { _.watcherListener.watcherId == id }
-          val retained  = observers filter { _.watcherListener.watcherId != id }
-
-          if (observers.size == 0 || unneeded.size == observers.size) {
-            key.cancel() // can hang, https://bugs.openjdk.java.net/browse/JDK-8029516
-            keymap.remove(key)
-          } else if (observers.size != retained.size)
-            if (!keymap.replace(key, observers, retained))
-              log.error(
-                s"failed to remove ${unneeded.size} listeners from  ${keyToFile(key)}"
-              )
-        }
-      )
-
-    def baseFileObservers(key: WatchKey) =
-      keymap getOrElse (key, Set()) filter {
-        case _: BaseFileObserver => true
-        case _                   => false
-      }
-
-    def recListeners(key: WatchKey) =
-      listeners(key) filter { _.recursive }
-
-    def baseListeners(key: WatchKey) =
-      keymap getOrElse (key, Set()) filter {
-        case _: BaseObserver => true
-        case _               => false
-      } map { _.watcherListener }
-
-    def baseFileListeners(key: WatchKey) =
-      keymap getOrElse (key, Set()) filter {
-        case _: BaseFileObserver => true
-        case _                   => false
-      } map { _.watcherListener }
-
-    def proxyListeners(key: WatchKey) =
-      keymap getOrElse (key, Set()) filter {
-        case _: ProxyObserver => true
-        case _                => false
-      } map { _.watcherListener }
-
-    def nonProxyListeners(key: WatchKey) =
-      keymap getOrElse (key, Set()) filter {
-        case _: ProxyObserver => false
-        case _                => true
-      } map { _.watcherListener }
-
-    def proxies(key: WatchKey) =
-      keymap getOrElse (key, Set()) filter {
-        case _: ProxyObserver => true
-        case _                => false
-      }
-
-    def listeners(key: WatchKey) =
-      keymap getOrElse (key, Set()) map { _.watcherListener }
-
-    def removeKey(key: WatchKey): Unit = {
-      key.cancel()
-      keymap.remove(key)
-    }
-
-    def hasRecursive(key: WatchKey) =
-      keymap.get(key) match {
-        case Some(os) => os.exists { _.recursive }
-        case None     => false
-      }
-
-    def hasBase(key: WatchKey) =
-      keymap.get(key) match {
-        case Some(os) =>
-          os.exists {
-            case _: BaseObserver => true
-            case _               => false
-          }
-        case None => false
-      }
-
-    def hasSubDir(key: WatchKey) =
-      keymap.get(key) match {
-        case Some(os) =>
-          os.exists {
-            case _: BaseSubdirObserver => true
-            case _                     => false
-          }
-        case None => false
-      }
-
-    def hasBaseFile(key: WatchKey) =
-      keymap.get(key) match {
-        case Some(os) =>
-          os.exists {
-            case _: BaseFileObserver => true
-            case _                   => false
-          }
-        case None => false
-      }
-
-    def hasProxy(key: WatchKey) =
-      keymap.get(key) match {
-        case Some(os) =>
-          os.exists {
-            case _: ProxyObserver => true
-            case _                => false
-          }
-        case None => false
-      }
-
-    def hasBaseSubdir(key: WatchKey) =
-      keymap.get(key) match {
-        case Some(os) =>
-          os.exists {
-            case _: BaseSubdirObserver => true
-            case _                     => false
-          }
-        case None => false
-      }
-
-    def totalKeyNum() =
-      keymap.keys.foldLeft(0) { (a, _) =>
-        a + 1
-      }
-
-    def keyFromFile(f: File): Option[WatchKey] =
-      keymap.keys.find { k =>
-        keyToFile(k).getAbsolutePath == f.getAbsolutePath
-      }
-  }
 }

--- a/core/src/main/scala/org/ensime/filewatcher/FileWatchService.scala
+++ b/core/src/main/scala/org/ensime/filewatcher/FileWatchService.scala
@@ -143,11 +143,15 @@ class FileWatchService { self =>
         log.trace(s"delay ${dir} base registration")
       Thread.sleep(100)
     }
-    val observers =
-      (listeners map { maybeBuildWatchKeyObserver(dir, _) }).flatten
+
+    val observers = listeners flatMap {
+        maybeBuildWatchKeyObserver(dir, _)
+      }
+
     if (log.isTraceEnabled)
       log.trace(s"register ${dir} with WatchService")
-    if (!observers.isEmpty) {
+
+    if (observers.nonEmpty) {
       val key: WatchKey = try {
         dir.toPath.register(
           watchService,

--- a/core/src/main/scala/org/ensime/filewatcher/WatchKeyManager.scala
+++ b/core/src/main/scala/org/ensime/filewatcher/WatchKeyManager.scala
@@ -121,41 +121,42 @@ object WatchKeyManager {
       case _                   => false
     }
 
+  private def observerOf(key: WatchKey)(observerCriteria: WatchKeyObserver => Boolean) = {
+    keymap getOrElse(key, Set()) filter observerCriteria
+  }
+
+  def listenerOf(key: WatchKey)(observerCriteria : WatchKeyObserver => Boolean) =
+    observerOf(key)(observerCriteria) map { _.watcherListener }
+
   def recListeners(key: WatchKey) =
     listeners(key) filter { _.recursive }
 
-  def baseListeners(key: WatchKey) =
-    keymap getOrElse (key, Set()) filter {
+  def baseListeners(key: WatchKey) = listenerOf(key){
       case _: BaseObserver => true
       case _               => false
-    } map { _.watcherListener }
+  }
 
-  def baseFileListeners(key: WatchKey) =
-    keymap getOrElse (key, Set()) filter {
+  def baseFileListeners(key: WatchKey) = listenerOf(key){
       case _: BaseFileObserver => true
       case _                   => false
-    } map { _.watcherListener }
+  }
 
-  def proxyListeners(key: WatchKey) =
-    keymap getOrElse (key, Set()) filter {
+  def proxyListeners(key: WatchKey) = listenerOf(key){
       case _: ProxyObserver => true
       case _                => false
-    } map { _.watcherListener }
+  }
 
-  def nonProxyListeners(key: WatchKey) =
-    keymap getOrElse (key, Set()) filter {
+  def nonProxyListeners(key: WatchKey) = listenerOf(key){
       case _: ProxyObserver => false
       case _                => true
-    } map { _.watcherListener }
+  }
 
-  def proxies(key: WatchKey) =
-    keymap getOrElse (key, Set()) filter {
+  def proxies(key: WatchKey) = observerOf(key){
       case _: ProxyObserver => true
       case _                => false
-    }
+  }
 
-  def listeners(key: WatchKey) =
-    keymap getOrElse (key, Set()) map { _.watcherListener }
+  def listeners(key: WatchKey) = listenerOf(key)(_=>true)
 
   def removeKey(key: WatchKey): Unit = {
     key.cancel()

--- a/core/src/main/scala/org/ensime/filewatcher/WatchKeyManager.scala
+++ b/core/src/main/scala/org/ensime/filewatcher/WatchKeyManager.scala
@@ -1,0 +1,230 @@
+package org.ensime.filewatcher
+
+import java.io.File
+import java.nio.file.{Path, WatchKey}
+import java.util.UUID
+import java.util.concurrent.ConcurrentHashMap
+
+import org.slf4j.LoggerFactory
+
+import scala.annotation.tailrec
+import scala.collection.concurrent.Map
+import scala.collection.immutable.Set
+import scala.collection.JavaConverters._
+import scala.language.implicitConversions
+
+case class BaseObserver(val watcherListener: WatcherListener)
+  extends WatchKeyObserver {
+  override lazy val recursive = watcherListener.recursive
+  override val observerType   = "BaseObserver"
+}
+case class BaseFileObserver(val watcherListener: WatcherListener)
+  extends WatchKeyObserver {
+  val treatExistingAsNew    = true
+  val recursive             = false
+  override val observerType = "BaseFileObserver"
+}
+case class ProxyObserver(val watcherListener: WatcherListener)
+  extends WatchKeyObserver {
+  val recursive             = false
+  override val observerType = "ProxyObserver"
+}
+case class BaseSubdirObserver(val watcherListener: WatcherListener)
+  extends WatchKeyObserver {
+  override lazy val recursive = watcherListener.recursive
+  override val observerType   = "BaseSubdirObserver"
+}
+
+trait WatchKeyObserver {
+  val watcherListener: WatcherListener
+  val recursive: Boolean
+  val observerType: String
+}
+
+object WatchKeyManager {
+  private val log = LoggerFactory.getLogger(getClass)
+
+  val keymap: Map[WatchKey, Set[WatchKeyObserver]] =
+    new ConcurrentHashMap[WatchKey, Set[WatchKeyObserver]]().asScala
+
+  def contains(key: WatchKey) =
+    keymap.contains(key)
+
+  implicit def keyToFile(k: WatchKey): File =
+    k.watchable().asInstanceOf[Path].toFile
+  implicit def keyToCanonicalPath(k: WatchKey): String =
+    k.watchable().asInstanceOf[Path].toFile.getCanonicalPath()
+
+  @tailrec
+  def addObserver(key: WatchKey, o: WatchKeyObserver): Unit = {
+    val l            = Set[WatchKeyObserver]()
+    val oldListeners = keymap.putIfAbsent(key, l).getOrElse(l)
+    val newListeners = oldListeners + o
+    val status       = keymap.replace(key, oldListeners, newListeners)
+    if (!status) {
+      log.warn(s"retry adding ${o.observerType} to ${keyToFile(key)}")
+      addObserver(key, o)
+    }
+  }
+
+  @tailrec
+  def removeObserver(key: WatchKey,
+                     o: WatchKeyObserver,
+                     retry: Int = 2): Unit =
+    keymap.get(key) match {
+      case Some(oldObservers) => {
+        val newObservers = oldObservers - o
+        if (newObservers.isEmpty) {
+          keymap.remove(key)
+          key.cancel()
+        } else if (!keymap.replace(key, oldObservers, newObservers))
+          if (retry > 0)
+            removeObserver(key, o)
+          else
+            log.warn("unable to remove an observer from {}", keyToFile(key))
+      }
+      case None => log.warn(s"watcher doesn't monitor ${keyToFile(key)}")
+    }
+
+  def maybeAdvanceProxy(key: WatchKey, createdFile: File)(fws : FileWatchService) =
+    proxies(key) foreach (
+      o =>
+        if (o.watcherListener.isBaseAncestor(createdFile))
+          if (createdFile.isDirectory || createdFile.isFile) {
+            removeObserver(key, o)
+            fws.watch(createdFile, Set(o.watcherListener), true)
+          } else
+            log.warn("unable to advance a proxy {}", o)
+      )
+
+  def removeObservers(id: UUID) =
+    keymap.keys foreach (
+      key => {
+        val observers = keymap.get(key).getOrElse { Set() }
+        val unneeded  = observers filter { _.watcherListener.watcherId == id }
+        val retained  = observers filter { _.watcherListener.watcherId != id }
+
+        if (observers.size == 0 || unneeded.size == observers.size) {
+          key.cancel() // can hang, https://bugs.openjdk.java.net/browse/JDK-8029516
+          keymap.remove(key)
+        } else if (observers.size != retained.size)
+          if (!keymap.replace(key, observers, retained))
+            log.error(
+              s"failed to remove ${unneeded.size} listeners from  ${keyToFile(key)}"
+            )
+      }
+      )
+
+  def baseFileObservers(key: WatchKey) =
+    keymap getOrElse (key, Set()) filter {
+      case _: BaseFileObserver => true
+      case _                   => false
+    }
+
+  def recListeners(key: WatchKey) =
+    listeners(key) filter { _.recursive }
+
+  def baseListeners(key: WatchKey) =
+    keymap getOrElse (key, Set()) filter {
+      case _: BaseObserver => true
+      case _               => false
+    } map { _.watcherListener }
+
+  def baseFileListeners(key: WatchKey) =
+    keymap getOrElse (key, Set()) filter {
+      case _: BaseFileObserver => true
+      case _                   => false
+    } map { _.watcherListener }
+
+  def proxyListeners(key: WatchKey) =
+    keymap getOrElse (key, Set()) filter {
+      case _: ProxyObserver => true
+      case _                => false
+    } map { _.watcherListener }
+
+  def nonProxyListeners(key: WatchKey) =
+    keymap getOrElse (key, Set()) filter {
+      case _: ProxyObserver => false
+      case _                => true
+    } map { _.watcherListener }
+
+  def proxies(key: WatchKey) =
+    keymap getOrElse (key, Set()) filter {
+      case _: ProxyObserver => true
+      case _                => false
+    }
+
+  def listeners(key: WatchKey) =
+    keymap getOrElse (key, Set()) map { _.watcherListener }
+
+  def removeKey(key: WatchKey): Unit = {
+    key.cancel()
+    keymap.remove(key)
+  }
+
+  def hasRecursive(key: WatchKey) =
+    keymap.get(key) match {
+      case Some(os) => os.exists { _.recursive }
+      case None     => false
+    }
+
+  def hasBase(key: WatchKey) =
+    keymap.get(key) match {
+      case Some(os) =>
+        os.exists {
+          case _: BaseObserver => true
+          case _               => false
+        }
+      case None => false
+    }
+
+  def hasSubDir(key: WatchKey) =
+    keymap.get(key) match {
+      case Some(os) =>
+        os.exists {
+          case _: BaseSubdirObserver => true
+          case _                     => false
+        }
+      case None => false
+    }
+
+  def hasBaseFile(key: WatchKey) =
+    keymap.get(key) match {
+      case Some(os) =>
+        os.exists {
+          case _: BaseFileObserver => true
+          case _                   => false
+        }
+      case None => false
+    }
+
+  def hasProxy(key: WatchKey) =
+    keymap.get(key) match {
+      case Some(os) =>
+        os.exists {
+          case _: ProxyObserver => true
+          case _                => false
+        }
+      case None => false
+    }
+
+  def hasBaseSubdir(key: WatchKey) =
+    keymap.get(key) match {
+      case Some(os) =>
+        os.exists {
+          case _: BaseSubdirObserver => true
+          case _                     => false
+        }
+      case None => false
+    }
+
+  def totalKeyNum() =
+    keymap.keys.foldLeft(0) { (a, _) =>
+      a + 1
+    }
+
+  def keyFromFile(f: File): Option[WatchKey] =
+    keymap.keys.find { k =>
+      keyToFile(k).getAbsolutePath == f.getAbsolutePath
+    }
+}

--- a/core/src/main/scala/org/ensime/filewatcher/WatcherListener.scala
+++ b/core/src/main/scala/org/ensime/filewatcher/WatcherListener.scala
@@ -1,0 +1,32 @@
+package org.ensime.filewatcher
+
+import java.io.File
+import java.util.UUID
+
+trait WatcherListener {
+  val base: File
+  val recursive: Boolean
+  val extensions: scala.collection.Set[String]
+  val watcherId: UUID
+
+  def fileCreated(@deprecated("local", "") f: File): Unit  = {}
+  def fileDeleted(@deprecated("local", "") f: File): Unit  = {}
+  def fileModified(@deprecated("local", "") f: File): Unit = {}
+
+  def baseRegistered(): Unit                                       = {}
+  def baseRemoved(): Unit                                          = {}
+  def baseSubdirRemoved(@deprecated("local", "") f: File): Unit    = {}
+  def missingBaseRegistered(): Unit                                = {}
+  def baseSubdirRegistered(@deprecated("local", "") f: File): Unit = {}
+  def proxyRegistered(@deprecated("local", "") f: File): Unit      = {}
+
+  def existingFile(@deprecated("local", "") f: File): Unit = {}
+
+  def isWatched(f: File) =
+    (extensions.exists(e => {
+      f.getName.endsWith(e)
+    })) && f.getPath.startsWith(base.getPath)
+
+  def isBaseAncestor(f: File) =
+    base.getAbsolutePath.startsWith(f.getAbsolutePath)
+}


### PR DESCRIPTION
The main change is using  SensitivityWatchEventModifier.HIGH when registering path in watchService. This will allow 2 secs polling in mac OS/X which then allow FileWatcherSpec to pass. The default value of MEDIUM sensitivity check every 10 seconds.

The other two changes are just to split FileWatchService into three files, separating WatchListener trait and WatchKeyManager object, so no longer 600 LOC of Scala. (I was originally thinking about incorporating https://github.com/lloydmeta/schwatcher to replace watch key manager, but then it seems a lot of work).

Small changes on build.sbt, (relative path to sbt)  to allow travis to pass when executing prewarm task.
