### PR TITLE
add GNU/Linux tests to travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,20 +1,75 @@
-language: java
-os:
-  - osx
+os: linux
+language: scala
 env:
   global:
     - AKKA_TEST_TIMEFACTOR=10
     - SBT_TASK_LIMIT=4
     - SCALA_VERSION=2.12.4
-script:
-  - echo "ensimeServerJars := Nil" > ensime.sbt ;
-    echo "ensimeServerProjectJars := Nil" >> ensime.sbt ;
-  - export JAVA_HOME=$(/usr/libexec/java_home)
-  - curl https://raw.githubusercontent.com/paulp/sbt-extras/master/sbt -o sbt ; chmod 755 sbt
-  - ./sbt ++$SCALA_VERSION! ";prep ;cpl"
-  - if [ -n "$TRAVIS_PULL_REQUEST" ] ; then ./sbt ++$SCALA_VERSION! "testOnly -- -l tags.IgnoreOnTravis" ; fi
-  - if [ -n "$TRAVIS_PULL_REQUEST" ] ; then SBT_TASK_LIMIT=2 ./sbt ++$SCALA_VERSION! "it:testOnly -- -l tags.IgnoreOnTravis" ; fi
-  - rm -rf $HOME/.coursier/cache/v1/https/oss.sonatype.org
+before_install:
+  - if [[ "$TRAVIS_OS_NAME" = "osx" ]]; then
+      brew update;
+      brew install sbt;
+      export JAVA_HOME=$(/usr/libexec/java_home);
+    fi
+stages:
+  - name: test
+  - name: integration
+  - name: publish
+    if: branch = master
+matrix:
+  include:
+    - env: TASK=GIT
+      script:
+      - if $(git grep -qE "TODO|FIXME" *) ; then
+          echo "Please remove TODO or FIXME." ;
+          exit 1 ;
+        fi
+
+    - env: TASK=FORMAT
+      script:
+      - sbt scalafmtSbtCheck compile:scalafmtCheck test:scalafmtCheck it:scalafmtCheck
+
+    - env: TASK=LINT
+      script:
+      - sbt "compile:scalafixCli --test" "test:scalafixCli --test"
+
+    - env: TASK=TEST
+      script:
+      - sbt ++$SCALA_VERSION! "testOnly -- -l tags.IgnoreOnTravis"
+
+    - env: TASK=TEST
+      os: osx
+      osx_image: xcode8.3
+      language: java
+      script:
+      - sbt ++$SCALA_VERSION! "testOnly -- -l tags.IgnoreOnTravis"
+
+    - env: TASK=INTEGRATION
+      sudo: true
+      stage: integration
+      script:
+      - echo "ensimeServerJars := Nil" > ensime.sbt ;
+      - echo "ensimeServerProjectJars := Nil" >> ensime.sbt ;
+      - sbt ++$SCALA_VERSION! ";prep ;cpl"
+      - SBT_TASK_LIMIT=2 sbt ++$SCALA_VERSION! "it:testOnly -- -l tags.IgnoreOnTravis"
+      - rm -rf $HOME/.coursier/cache/v1/https/oss.sonatype.org
+
+    - env: TASK=INTEGRATION
+      os: osx
+      osx_image: xcode8.3
+      language: java
+      stage: integration
+      script:
+        - echo "ensimeServerJars := Nil" > ensime.sbt ;
+        - echo "ensimeServerProjectJars := Nil" >> ensime.sbt ;
+        - sbt ++$SCALA_VERSION! ";prep ;cpl"
+        - SBT_TASK_LIMIT=2 sbt ++$SCALA_VERSION! "it:testOnly -- -l tags.IgnoreOnTravis"
+        - rm -rf $HOME/.coursier/cache/v1/https/oss.sonatype.org
+
+    - env: TASK=PUBLISH
+      stage: publish
+      script:
+        - sbt publish
 cache:
   directories:
   - $HOME/.sbt

--- a/build.sbt
+++ b/build.sbt
@@ -191,7 +191,6 @@ TaskKey[Unit](
   val sv = scalaVersion.value
   val cmd =
     if (sys.env.contains("APPVEYOR")) """C:\sbt\bin\sbt.bat"""
-    else if (sys.env.contains("TRAVIS")) "../../sbt"
     else "sbt"
   sys.process
     .Process(


### PR DESCRIPTION
A few notes about this:
- Using the vm based infrastucture (sudo: true) helps mitigate https://github.com/travis-ci/travis-ci/issues/3775.
- The approach using stage and several smaller tasks is not by itself incompatible with having a build matrix. Currently language: scala + os: osx is not supported which makes it a pain to use in build matrix. (but there are probably workarounds)

It should complete #1922.