### PR TITLE
Bump coursier on the build to 1.0.1

### DIFF
--- a/project/project/plugins.sbt
+++ b/project/project/plugins.sbt
@@ -1,1 +1,1 @@
-addSbtPlugin("io.get-coursier" % "sbt-coursier" % "1.0.0-RC3")
+addSbtPlugin("io.get-coursier" % "sbt-coursier" % "1.0.0")


### PR DESCRIPTION
SBT fails to start on missing artifacts otherwise.