### PR TITLE
Prevent PR from triggering publish

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,8 +14,8 @@ before_install:
 stages:
   - name: test
   - name: integration
-#  - name: publish
-#    if: branch = 3.0
+  - name: publish
+    if: type != pull_request AND branch = 3.0
 matrix:
   include:
     - env: TASK=GIT
@@ -66,10 +66,10 @@ matrix:
         - SBT_TASK_LIMIT=2 sbt ++$SCALA_VERSION! "it:testOnly -- -l tags.IgnoreOnTravis"
         - rm -rf $HOME/.coursier/cache/v1/https/oss.sonatype.org
 
-#    - env: TASK=PUBLISH
-#      stage: publish
-#      script:
-#        - sbt ++$SCALA_VERSION! publish
+    - env: TASK=PUBLISH
+      stage: publish
+      script:
+        - sbt ++$SCALA_VERSION! publish
 cache:
   directories:
   - $HOME/.sbt


### PR DESCRIPTION
This fix the problem from #1937.
**BUT** how do we prevent someone to just remove this filter, open a PR and trigger the publish with his modification through the PR. GitLab solves this with protected variables which are visible only on protected branches but I'm not sure at all how travis does fix that.