### PR TITLE
Fix RequestMessage parsing

### DIFF
--- a/lsp/src/main/scala/org/ensime/lsp/core/Connection.scala
+++ b/lsp/src/main/scala/org/ensime/lsp/core/Connection.scala
@@ -86,6 +86,7 @@ class Connection(inStream: InputStream,
       case Some(jsonString) =>
         readJsonRpcMessage(jsonString) match {
           case Left(e) =>
+            log.error(s"Invalid message: ${e} - ${jsonString}")
             msgWriter.write(e)
 
           case Right(message) =>
@@ -105,6 +106,7 @@ class Connection(inStream: InputStream,
               case request: JsonRpcRequestMessage =>
                 unpackRequest(request) match {
                   case Left(e) =>
+                    log.error(s"Invalid request: ${e} - ${request}")
                     msgWriter.write(e)
                   case Right(command) =>
                     msgWriter.write(

--- a/lsp/src/main/scala/org/ensime/lsp/core/LanguageServer.scala
+++ b/lsp/src/main/scala/org/ensime/lsp/core/LanguageServer.scala
@@ -63,6 +63,7 @@ abstract class LanguageServer(inStream: InputStream, outStream: OutputStream)
   protected val documentManager = new TextDocumentManager
 
   private val notificationHandler: Notification => Unit = {
+    case Initialized() => ()
     case DidOpenTextDocumentParams(td) =>
       onOpenTextDocument(td)
     case DidChangeTextDocumentParams(td, changes) =>

--- a/lsp/src/main/scala/org/ensime/lsp/rpc/messages.scala
+++ b/lsp/src/main/scala/org/ensime/lsp/rpc/messages.scala
@@ -117,6 +117,7 @@ final case class JsonRpcRequestMessage(jsonrpc: String,
     extends JsonRpcMessage
     with JsonRpcRequestOrNotificationMessage {
   require(jsonrpc == JsonRpcMessages.Version)
+  require(id != NullId)
 }
 object JsonRpcRequestMessage {
   def apply(method: String,


### PR DESCRIPTION
Fixes #1911. @zainab-ali was right from the beginning: https://github.com/ensime/ensime-server/issues/1911#issuecomment-362096344

> A quick glance at the LSP spec indicates that requests should always have a non-null id parameter. This isn't enforced within the `JsonRpcRequestMessage` decoder, although an attempt is made to do this in the `JsonRpcRequestOrNotificationMessage` decoder.

After that comment there is some confusing discussion about null ids which I don't really understand (in particular, how it is related to the problem). But anyway LSP spec is unambiguous about [`RequestMessage`](https://github.com/Microsoft/language-server-protocol/blob/gh-pages/specification.md#request-message) id type:

```
id: number | string;
```

It's **not optional** and **cannot be `null`**. 


I've tested it locally and now server recognizes notifications and basic features like type on hover, symbols outline and go to definition work well 👌 