### PR TITLE
Fix shutdown routine

### DIFF
--- a/lsp/src/main/scala/org/ensime/lsp/api/commands.scala
+++ b/lsp/src/main/scala/org/ensime/lsp/api/commands.scala
@@ -133,7 +133,8 @@ final case class InitializeResult(capabilities: ServerCapabilities)
 @deriving(JsReader, JsWriter)
 final case class Shutdown() extends ServerCommand
 
-final case class ShutdownResult(dummy: Int) extends ResultResponse
+@deriving(JsWriter)
+final case class ShutdownResult() extends ResultResponse
 
 @deriving(JsReader, JsWriter)
 final case class ShowMessageRequestParams(
@@ -209,7 +210,9 @@ final case class PublishDiagnostics(uri: String, diagnostics: Seq[Diagnostic])
 
 // from client to server
 
-final case class ExitNotification() extends Notification
+@deriving(JsReader, JsWriter)
+final case class Exit() extends Notification
+
 @deriving(JsReader, JsWriter)
 final case class DidOpenTextDocumentParams(textDocument: TextDocumentItem)
     extends Notification

--- a/lsp/src/main/scala/org/ensime/lsp/api/companions.scala
+++ b/lsp/src/main/scala/org/ensime/lsp/api/companions.scala
@@ -70,6 +70,8 @@ object Notifications {
     RpcNotification[Initialized]("initialized")
   implicit val cancelRequestNotification: RpcNotification[CancelRequest] =
     RpcNotification[CancelRequest]("$/cancelRequest")
+  implicit val exitNotification: RpcNotification[Exit] =
+    RpcNotification[Exit]("exit")
 }
 
 object Notification extends NotificationCompanion[Notification] {
@@ -86,6 +88,7 @@ object Notification extends NotificationCompanion[Notification] {
     didSaveNotification,
     didChangeWatchedFilesNotification,
     initializedNotification,
-    cancelRequestNotification
+    cancelRequestNotification,
+    exitNotification
   )
 }

--- a/lsp/src/main/scala/org/ensime/lsp/api/methods.scala
+++ b/lsp/src/main/scala/org/ensime/lsp/api/methods.scala
@@ -70,6 +70,8 @@ object Notifications {
     RpcNotification[Initialized]("initialized")
   implicit val cancelRequestNotification: RpcNotification[CancelRequest] =
     RpcNotification[CancelRequest]("$/cancelRequest")
+  implicit val exitNotification: RpcNotification[Exit] =
+    RpcNotification[Exit]("exit")
 }
 
 object Notification extends NotificationCompanion[Notification] {
@@ -86,6 +88,7 @@ object Notification extends NotificationCompanion[Notification] {
     didSaveNotification,
     didChangeWatchedFilesNotification,
     initializedNotification,
-    cancelRequestNotification
+    cancelRequestNotification,
+    exitNotification
   )
 }

--- a/lsp/src/main/scala/org/ensime/lsp/rpc/companions.scala
+++ b/lsp/src/main/scala/org/ensime/lsp/rpc/companions.scala
@@ -121,6 +121,8 @@ trait NotificationCompanion[A] {
       case None => Left(UnknownMethod)
       case Some(command) =>
         jsonRpcNotificationMessage.params match {
+          case None if command.method == "exit" =>
+            readObj(command, JsObject.empty)
           case None                    => Left(NoParams)
           case Some(ArrayParams(_))    => Left(NoNamedParams)
           case Some(ObjectParams(obj)) => readObj(command, obj)


### PR DESCRIPTION
Adapted some pieces from https://github.com/scalameta/metals/pull/53. 

Server should respond to the shutdown request and exit on the exit notification. This procedure is required for the correct communication with the client.

This seems to fix problems with the server shutdown: _if_ server starts well, then it will also stops well when the client asks. It still doesn't always start well, but that's another problem.