### PR TITLE
WIP: Replace lsp implementation with lsp4s

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -83,6 +83,7 @@ lazy val core = project
       "org.apache.lucene" % "lucene-analyzers-common" % luceneVersion,
       "org.ow2.asm"       % "asm-commons"             % "5.2",
       "org.ow2.asm"       % "asm-util"                % "5.2",
+      // TODO remove the locally built snapshot in favour of a release
       "org.scalameta" %% "lsp4s" % "0.1.0+5-de927af3-SNAPSHOT",
       "org.scala-lang"    % "scalap"                  % scalaVersion.value,
       "com.typesafe.akka" %% "akka-actor"             % akkaVersion,
@@ -221,6 +222,7 @@ addCommandAlias("fix", "all compile:scalafixCli test:scalafixCli")
 addCommandAlias("tests", "all test it:test")
 // not really what is used in CI, but close enough...
 addCommandAlias("ci", ";check ;prep ;cpl ;doc ;tests")
+// TODO The logging between lsp4s (scribe) conflicts with this
 // private val slf4jVersion = "1.7.25"
 //   val logback = Seq(
 //     "ch.qos.logback" % "logback-classic"  % "1.2.3",

--- a/build.sbt
+++ b/build.sbt
@@ -83,6 +83,7 @@ lazy val core = project
       "org.apache.lucene" % "lucene-analyzers-common" % luceneVersion,
       "org.ow2.asm"       % "asm-commons"             % "5.2",
       "org.ow2.asm"       % "asm-util"                % "5.2",
+      "org.scalameta" %% "lsp4s" % "0.1.0+5-de927af3-SNAPSHOT",
       "org.scala-lang"    % "scalap"                  % scalaVersion.value,
       "com.typesafe.akka" %% "akka-actor"             % akkaVersion,
       "com.typesafe.akka" %% "akka-slf4j"             % akkaVersion, {
@@ -220,3 +221,11 @@ addCommandAlias("fix", "all compile:scalafixCli test:scalafixCli")
 addCommandAlias("tests", "all test it:test")
 // not really what is used in CI, but close enough...
 addCommandAlias("ci", ";check ;prep ;cpl ;doc ;tests")
+// private val slf4jVersion = "1.7.25"
+//   val logback = Seq(
+//     "ch.qos.logback" % "logback-classic"  % "1.2.3",
+//     "org.slf4j"      % "slf4j-api"        % slf4jVersion,
+//     "org.slf4j"      % "jul-to-slf4j"     % slf4jVersion,
+//     "org.slf4j"      % "jcl-over-slf4j"   % slf4jVersion,
+//     "org.slf4j"      % "log4j-over-slf4j" % slf4jVersion
+//   )

--- a/core/src/main/resources/logback.xml
+++ b/core/src/main/resources/logback.xml
@@ -10,9 +10,26 @@
       <pattern>%d{HH:mm:ss.SSS} %-5level %X{akkaSource:-None} %logger{10} - %.-250msg%n</pattern>
     </encoder>
   </appender>
-  <root level="INFO">
-    <appender-ref ref="STDOUT" />
+
+  
+  <!-- log to a file for testing -->
+  <appender name="FILE" class="ch.qos.logback.core.FileAppender">
+    <file>/home/zainab/ensime-server-log.log</file>
+    <append>true</append>
+    <!-- set immediateFlush to false for much higher logging throughput -->
+    <immediateFlush>true</immediateFlush>
+    <!-- encoders are assigned the type
+         ch.qos.logback.classic.encoder.PatternLayoutEncoder by default -->
+    <encoder>
+      <pattern>%-4relative [%thread] %-5level %logger{35} - %msg%n</pattern>
+    </encoder>
+  </appender>
+        
+  <root level="DEBUG">
+    <appender-ref ref="FILE" />
+    <!-- <appender-ref ref="STDOUT" /> -->
   </root>
+
   <logger name="org.ensime" level="DEBUG" />
   <logger name="akka" level="DEBUG" />
   <logger name="scala.tools" level="WARN" />


### PR DESCRIPTION
This is a WIP and shouldn't be reviewed yet, but I wanted to give it some visibility so others didn't repeat the work.

Since last month's [tooling hackday](https://twitter.com/syntaxSugarLdn) I, with the help of @peterneyens, have been working on integrating [lsp4s](https://github.com/scalameta/lsp4s/).  It's a much simpler task than I anticipated, partly due to lsp4s's clean structure (logging seems to be the most complicated aspect).  I expect to have a working implementation over the next few weeks.

There are some changes that may be worth discussing, even in these early stages, notably the dependency on monix.  According to some discussion in #1935, this might be problematic.