### PR TITLE
Fix assembly errors that were introduced with the asm / orient bump

### DIFF
--- a/project/EnsimeBuild.scala
+++ b/project/EnsimeBuild.scala
@@ -196,7 +196,8 @@ object EnsimeBuild {
         "com.orientechnologies" % "orientdb-graphdb" % orientVersion
           exclude ("commons-collections", "commons-collections")
           exclude ("commons-beanutils", "commons-beanutils")
-          exclude ("commons-logging", "commons-logging"),
+          exclude ("commons-logging", "commons-logging")
+          exclude ("stax", "stax-api"),
         "org.apache.lucene" % "lucene-core" % luceneVersion,
         "org.apache.lucene" % "lucene-analyzers-common" % luceneVersion,
         "org.ow2.asm" % "asm-commons" % "6.1.1",
@@ -259,6 +260,7 @@ object EnsimeBuild {
       resources in Compile := Nil,
       aggregate in assembly := false,
       assemblyMergeStrategy in assembly := {
+        case PathList(xs @ _*) if xs.last == "module-info.class" => MergeStrategy.discard
         case PathList("org", "apache", "commons", "vfs2", xs @ _*) => MergeStrategy.first // assumes our classpath is setup correctly
         case PathList("META-INF", "io.netty.versions.properties") => MergeStrategy.concat // assumes our classpath is setup correctly
         case PathList("LICENSE") => MergeStrategy.concat // WORKAROUND https://github.com/sbt/sbt-assembly/issues/224


### PR DESCRIPTION
63b3ba2b fixes the errors produced when parsing java9 byte
code. sbt-assembly began to fail, for the following reasons:

Orient brought in two different artifacts that provided the same library in
the same package paths:

- javax.xml.stream:stax-api:1.0-2 (published 2008)
- stax:stax-api:1.0.1 (published 2006)

Since javax.xml.stream:stax-api:1.0-2 looked more modern, we ignore the
stax:stax-api:1.0.1 dependency. Things seem to work fine with this and this
resolves a good chunk of the merge conflict errors produced by sbt-assembly

Further, asm 6 dependencies provide various `module-info.class` in the root
of the JAR. It is not possible to merge these so we just discard them.